### PR TITLE
screen_view 이벤트에 globalLogParams가 포함 안 되는 문제 해결

### DIFF
--- a/src/screens/RootScreen.tsx
+++ b/src/screens/RootScreen.tsx
@@ -7,6 +7,7 @@ import React, {useEffect, useRef} from 'react';
 import {Linking} from 'react-native';
 import SplashScreen from 'react-native-splash-screen';
 
+import {useLogParams} from '@/logging/LogParamsProvider';
 import Logger from '@/logging/Logger';
 import {Navigation} from '@/navigation';
 import {logDebug} from '@/utils/DebugUtils';
@@ -18,6 +19,7 @@ const RootScreen = () => {
 
   const routeNameRef = useRef<string>();
   const navigationRef = useNavigationContainerRef();
+  const globalLogParams = useLogParams();
 
   return (
     <NavigationContainer
@@ -82,6 +84,7 @@ const RootScreen = () => {
             prevScreenName: previousScreenName,
             currScreenName: currentScreenName,
             extraParams: {
+              ...globalLogParams,
               routeParams: state?.routes.at(-1)?.params ?? {},
             },
           });


### PR DESCRIPTION
- 빅쿼리에 GA 이벤트 파이프라이닝하고 있는데, PlaceDetail 화면 screen_view 이벤트에 place_id 필드가 없어서 보니 LogParamsProvider로 주입한 param들이 screen_view 이벤트에 안 남고 있었습니다. 이 문제를 해결합니다.
- 