### PR TITLE
fix: 즐겨찾기 시, 검색 결과 optimistic update 처리

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/lodash": "^4.14.186",
     "axios": "^1.8.2",
     "dayjs": "^1.11.11",
+    "fast-json-stable-stringify": "^2.1.0",
     "jotai": "^2.12.3",
     "lodash": "^4.17.21",
     "lottie-react-native": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/lodash": "^4.14.186",
     "axios": "^1.8.2",
     "dayjs": "^1.11.11",
-    "fast-json-stable-stringify": "^2.1.0",
     "jotai": "^2.12.3",
     "lodash": "^4.17.21",
     "lottie-react-native": "^5.1.4",

--- a/src/hooks/useToggleFavoritePlace.ts
+++ b/src/hooks/useToggleFavoritePlace.ts
@@ -1,6 +1,7 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {useAtomValue} from 'jotai';
 
+import {PlaceListItem} from '@/generated-sources/openapi';
 import {filterAtom, searchQueryAtom} from '@/screens/SearchScreen/atoms';
 import ToastUtils from '@/utils/ToastUtils';
 
@@ -28,6 +29,47 @@ export function useToggleFavoritePlace() {
         return await api.createPlaceFavoritePost({placeId});
       }
     },
+    onMutate: async variables => {
+      await queryClient.cancelQueries({
+        queryKey: [
+          'search',
+          {text, location, sortOption, scoreUnder, hasSlope, isRegistered},
+        ],
+      });
+
+      const previousSearchData = queryClient.getQueryData<PlaceListItem[]>([
+        'search',
+        {text, location, sortOption, scoreUnder, hasSlope, isRegistered},
+      ]);
+
+      console.log(previousSearchData);
+
+      queryClient.setQueryData<PlaceListItem[]>(
+        [
+          'search',
+          {text, location, sortOption, scoreUnder, hasSlope, isRegistered},
+        ],
+        oldData => {
+          if (!oldData) return oldData;
+
+          return oldData.map(data =>
+            data.place.id === variables.placeId
+              ? {
+                  ...data,
+                  place: {
+                    ...data.place,
+                    isFavorite: !variables.currentIsFavorite,
+                  },
+                }
+              : data,
+          );
+        },
+      );
+
+      return {
+        previousSearchData,
+      };
+    },
     onSuccess: (_data, variables) => {
       if (!variables.currentIsFavorite) {
         ToastUtils.show('[메뉴 → 저장한 장소]에서 확인 가능해요');
@@ -38,16 +80,19 @@ export function useToggleFavoritePlace() {
       queryClient.invalidateQueries({
         queryKey: ['PlaceDetail', variables.placeId],
       });
-
-      queryClient.invalidateQueries({
-        queryKey: [
-          'search',
-          {text, location, sortOption, scoreUnder, hasSlope, isRegistered},
-        ],
-      });
     },
-    onError: error => {
+    onError: (error, _variables, context) => {
       ToastUtils.showOnApiError(error);
+
+      if (context?.previousSearchData) {
+        queryClient.setQueryData(
+          [
+            'search',
+            {text, location, sortOption, scoreUnder, hasSlope, isRegistered},
+          ],
+          context.previousSearchData,
+        );
+      }
     },
   });
 

--- a/src/hooks/useToggleFavoritePlace.ts
+++ b/src/hooks/useToggleFavoritePlace.ts
@@ -42,8 +42,6 @@ export function useToggleFavoritePlace() {
         {text, location, sortOption, scoreUnder, hasSlope, isRegistered},
       ]);
 
-      console.log(previousSearchData);
-
       queryClient.setQueryData<PlaceListItem[]>(
         [
           'search',

--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -1,6 +1,5 @@
 import {useRoute} from '@react-navigation/native';
 import {useQuery} from '@tanstack/react-query';
-import stringify from 'fast-json-stable-stringify';
 import {useAtomValue} from 'jotai';
 import {useRef} from 'react';
 
@@ -72,7 +71,6 @@ export default function useSearchRequest() {
       onFetchCompleted.current = undefined;
       return result;
     },
-    queryKeyHashFn: stringify,
   });
   const onFetchCompleted = useRef<(result: PlaceListItem[]) => void>();
   const {updateQuery} = useUpdateSearchQuery();

--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -1,5 +1,6 @@
 import {useRoute} from '@react-navigation/native';
 import {useQuery} from '@tanstack/react-query';
+import stringify from 'fast-json-stable-stringify';
 import {useAtomValue} from 'jotai';
 import {useRef} from 'react';
 
@@ -71,7 +72,7 @@ export default function useSearchRequest() {
       onFetchCompleted.current = undefined;
       return result;
     },
-    queryKeyHashFn: queryKey => JSON.stringify(queryKey),
+    queryKeyHashFn: stringify,
   });
   const onFetchCompleted = useRef<(result: PlaceListItem[]) => void>();
   const {updateQuery} = useUpdateSearchQuery();


### PR DESCRIPTION
- 검색 결과 캐시 날리면 데이터가 바뀌면서 카드만 사라지는게 아니라, 마커도 같이 튀어서 optimistic update로 처리했습니다.
- ~~검색 query key를 정렬 + 직렬화 해서 항상 동일한 키값을 보장할 수 있게 `fast-json-stable-stringify` 라이브러리 적용했습니다. (적용하기 전에는 `getQueryData` 할 때 쿼리 키를 동일한 순서로 넣었음에도 캐시 데이터를 못찾고 항상 undefined 반환)~~
- ~~라이브러리가 추가되었으니 머지 후 서버 실행전에 yarn install 실행해주세요. (js기반 라이브러리니까 코드푸시로 배포 가능하겠죠?)~~