### PR TITLE
건물용 라벨 제대로 사용하기

### DIFF
--- a/src/screens/PlaceDetailScreen/sections/PlaceDetailBuildingSection.tsx
+++ b/src/screens/PlaceDetailScreen/sections/PlaceDetailBuildingSection.tsx
@@ -90,7 +90,7 @@ export default function PlaceDetailEntranceSection({
           </S.Comments>
           <PlaceDetailCrusher
             crusherGroupIcon={
-              accessibility.placeAccessibility?.challengeCrusherGroup?.icon
+              accessibility.buildingAccessibility?.challengeCrusherGroup?.icon
             }
             crusherName={registeredUserName}
           />


### PR DESCRIPTION
- placeAccessibility 와 buildingAccessibility 를 등록한 사람이 다를 수 있습니다
- 각각의 모델에 crusherGroup 이 정의되어 있으므로 적절한 것을 가져다가 사용합니다