### PR TITLE
fix: 코치 마크 배너 깨짐 개선

### DIFF
--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -278,7 +278,9 @@ const HomeScreen = ({navigation}: any) => {
         </S.Container>
       </ScreenLayout>
 
-      <CoachMarkOverlay visible={!hasShownCoachMarkForFirstVisit} />
+      <CoachMarkOverlay
+        visible={!hasShownCoachMarkForFirstVisit && hasShownGuideForFirstVisit}
+      />
     </>
   );
 };

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -17,11 +17,7 @@ import DeviceInfo from 'react-native-device-info';
 import CrusherClubLogo from '@/assets/icon/logo.svg';
 import {accessTokenAtom} from '@/atoms/Auth';
 import {currentLocationAtom} from '@/atoms/Location';
-import {
-  hasShownCoachMarkForFirstVisitAtom,
-  hasShownGuideForFirstVisitAtom,
-  isGuestUserAtom,
-} from '@/atoms/User';
+import {hasShownGuideForFirstVisitAtom, isGuestUserAtom} from '@/atoms/User';
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {color} from '@/constant/color';
 import {
@@ -78,10 +74,6 @@ const HomeScreen = ({navigation}: any) => {
       return result;
     },
   });
-
-  const hasShownCoachMarkForFirstVisit = useAtomValue(
-    hasShownCoachMarkForFirstVisitAtom,
-  );
 
   const versionStatusMessage = data?.message;
   const versionStatus = data?.status;
@@ -278,9 +270,7 @@ const HomeScreen = ({navigation}: any) => {
         </S.Container>
       </ScreenLayout>
 
-      <CoachMarkOverlay
-        visible={!hasShownCoachMarkForFirstVisit && hasShownGuideForFirstVisit}
-      />
+      <CoachMarkOverlay />
     </>
   );
 };

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -154,7 +154,7 @@ const HomeScreen = ({navigation}: any) => {
 
   const goToGuide = () => {
     navigation.navigate('Webview', {
-      fixedTitle: '정보 등록/조회 가이드',
+      fixedTitle: '계단뿌셔클럽 앱 사용설명서',
       url: 'https://admin.staircrusher.club/public/guide',
       headerVariant: 'navigation',
     });
@@ -232,7 +232,7 @@ const HomeScreen = ({navigation}: any) => {
                     }}
                     renderItem={CoachMarkGuideLink}>
                     <S.Description allowFontScaling={false} onPress={goToGuide}>
-                      {'계단뿌셔클럽 이용가이드'}
+                      {'계단뿌셔클럽 사용설명서'}
                     </S.Description>
                   </CoachMarkTarget>
                 </LogClick>

--- a/src/screens/HomeScreen/components/CoachMarkGuideLink.tsx
+++ b/src/screens/HomeScreen/components/CoachMarkGuideLink.tsx
@@ -26,7 +26,7 @@ export default function CoachMarkGuideLink({
           left: x + width + 50,
         }}>
         <S.Description>
-          <Text style={{color: color.yellow}}>이용 가이드</Text>
+          <Text style={{color: color.yellow}}>사용설명서</Text>
           {'를 확인해서\n계단뿌셔클럽을 알아보세요'}
         </S.Description>
       </View>

--- a/src/screens/HomeScreen/sections/SearchSection.tsx
+++ b/src/screens/HomeScreen/sections/SearchSection.tsx
@@ -58,7 +58,11 @@ export default function SearchSection() {
               maxWidth: 50,
             }}
             renderItem={CoachMarkMapButton}>
-            <Pressable onPress={() => goToSearch('', true)}>
+            <Pressable
+              onPress={() => {
+                goToSearch('', true);
+                setHasShownMapIconTooltipForFirstVisit(true);
+              }}>
               <MapIcon width={24} height={24} />
             </Pressable>
           </CoachMarkTarget>


### PR DESCRIPTION
- `가이드` → `사용설명서`로 표현 변경
- `GuideForFirstVisit` 화면을 본 사용자에게만 코치마크 노출되도록 조건 추가
- 홈의 `map` 아이콘을 눌렀을 때도 툴팁이 사라지도록 처리
- 코치마크 타겟 위치를 20ms 이후에 측정하도록 변경:  
  처음 가입한 사용자가 가이드 화면을 보고 홈으로 복귀했을 때 코치마크 타겟의 위치를 정확히 측정하지 못하는 이슈가 있어,  
  [16.66ms 안에 UI가 그려진다고 가정](https://reactnative.dev/docs/performance#what-you-need-to-know-about-frames)하고 한 프레임 이후인 약 20ms 지연을 두고 위치를 측정하도록 수정했습니다.
- 코치마크 노출을 300ms 지연:  
  안드로이드에서 코치마크 타겟들이 순차적으로 하나씩 나타나는 시각적 이슈가 있어, 전체 코치마크를 한 번에 자연스럽게 표시하기 위해 지연을 적용했습니다.
- 코치마크 노출 조건에 배너 여부 추가: 배너가 없으면 코치마크가 깨지기 때문