### PR TITLE
fix: 화장실 리뷰

### DIFF
--- a/src/components/PressableChip/index.tsx
+++ b/src/components/PressableChip/index.tsx
@@ -11,26 +11,46 @@ interface ChipProps extends PressableProps {
 export default function PressableChip({
   label,
   active = false,
+  disabled = false,
   ...props
 }: ChipProps) {
   return (
     <Pressable
-      style={{
-        paddingVertical: 10,
-        paddingHorizontal: 16,
-        borderRadius: 48,
-        borderWidth: 1,
-        borderColor: active ? color.brand : '#DCDEE3',
-        backgroundColor: active ? '#EBF5FF' : color.white,
-      }}
+      style={[
+        {
+          paddingVertical: 10,
+          paddingHorizontal: 16,
+          borderRadius: 48,
+          borderWidth: 1,
+          borderColor: '#DCDEE3',
+          backgroundColor: color.white,
+        },
+        active && {
+          borderColor: color.brand,
+          backgroundColor: '#EBF5FF',
+        },
+        disabled && {
+          borderColor: color.gray20,
+          backgroundColor: color.gray10,
+        },
+      ]}
+      disabled={disabled}
       {...props}>
       <Text
-        style={{
-          fontSize: 14,
-          lineHeight: 20,
-          fontFamily: font.pretendardRegular,
-          color: active ? color.brand : color.black,
-        }}>
+        style={[
+          {
+            fontSize: 14,
+            lineHeight: 20,
+            fontFamily: font.pretendardRegular,
+            color: color.black,
+          },
+          active && {
+            color: color.brand,
+          },
+          disabled && {
+            color: color.gray40,
+          },
+        ]}>
         {label}
       </Text>
     </Pressable>

--- a/src/constant/review.ts
+++ b/src/constant/review.ts
@@ -36,8 +36,6 @@ export function getMobilityToolDefaultValue(
   const validOrder = Object.keys(
     MOBILITY_TOOL_LABELS,
   ) as UserMobilityToolMapDto[];
-  console.log(mobilityTools);
-
   return validOrder.find(tool => mobilityTools?.includes(tool));
 }
 

--- a/src/constant/review.ts
+++ b/src/constant/review.ts
@@ -37,20 +37,46 @@ export const RECOMMEND_MOBILITY_TOOL_OPTIONS = Object.entries(
   label,
 }));
 
+export const makeRecommendedMobilityOptions = (
+  currentOptions: RecommendedMobilityTypeDto[],
+) => {
+  const isNoneSelected = currentOptions.includes(
+    RecommendedMobilityTypeDto.None,
+  );
+  const isAnyOtherSelected =
+    currentOptions.length > 0 &&
+    currentOptions.some(opt => opt !== RecommendedMobilityTypeDto.None);
+
+  return Object.entries(RECOMMEND_MOBILITY_TOOL_LABELS).map(([key, label]) => {
+    const value = key as RecommendedMobilityTypeDto;
+    const isNone = value === RecommendedMobilityTypeDto.None;
+
+    return {
+      label,
+      value,
+      disabled: isNone ? isAnyOtherSelected : isNoneSelected,
+    };
+  });
+};
+
+type ToiletLocationTypeMap = typeof ToiletLocationTypeDto;
+
+export type ToiletLocationTypeDtoWithoutNotSure =
+  ToiletLocationTypeMap[keyof Omit<ToiletLocationTypeMap, 'NotSure'>];
+
 export const TOILET_LOCATION_TYPE_LABELS: Record<
-  ToiletLocationTypeDto,
+  ToiletLocationTypeDtoWithoutNotSure,
   string
 > = {
   [ToiletLocationTypeDto.Building]: '건물 내 있음',
   [ToiletLocationTypeDto.Place]: '매장 내부에 있음',
   [ToiletLocationTypeDto.None]: '없음',
-  [ToiletLocationTypeDto.NotSure]: '모름',
   [ToiletLocationTypeDto.Etc]: '기타',
 };
 
 export const TOILET_LOCATION_TYPE_OPTIONS = Object.entries(
   TOILET_LOCATION_TYPE_LABELS,
 ).map(([value, label]) => ({
-  value: value as ToiletLocationTypeDto,
+  value: value as ToiletLocationTypeDtoWithoutNotSure,
   label,
 }));

--- a/src/constant/review.ts
+++ b/src/constant/review.ts
@@ -3,7 +3,55 @@ import {
   RecommendedMobilityTypeDto,
   SpaciousTypeDto,
   ToiletLocationTypeDto,
+  UserMobilityToolDto,
 } from '@/generated-sources/openapi';
+
+type UserMobilityToolMap = typeof UserMobilityToolDto;
+
+export type UserMobilityToolMapDto = UserMobilityToolMap[keyof Omit<
+  UserMobilityToolMap,
+  'FriendOfToolUser' | 'Cluch'
+>];
+
+export const MOBILITY_TOOL_LABELS: Record<UserMobilityToolMapDto, string> = {
+  [UserMobilityToolDto.ManualWheelchair]: '수동휠체어',
+  [UserMobilityToolDto.ElectricWheelchair]: '전동휠체어',
+  [UserMobilityToolDto.ManualAndElectricWheelchair]: '수전동휠체어',
+  [UserMobilityToolDto.WalkingAssistanceDevice]: '보행보조도구',
+  [UserMobilityToolDto.ProstheticFoot]: '의족',
+  [UserMobilityToolDto.Stroller]: '유아차 동반',
+  [UserMobilityToolDto.None]: '해당없음',
+};
+
+export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS)
+  .filter(([value]) => value !== UserMobilityToolDto.FriendOfToolUser)
+  .map(([value, label]) => ({
+    value: value as UserMobilityToolDto,
+    label,
+  }));
+
+export function getMobilityToolDefaultValue(
+  mobilityTools?: UserMobilityToolDto[],
+) {
+  const validOrder = Object.keys(
+    MOBILITY_TOOL_LABELS,
+  ) as UserMobilityToolMapDto[];
+  console.log(mobilityTools);
+
+  return validOrder.find(tool => mobilityTools?.includes(tool));
+}
+
+export const RECOMMEND_MOBILITY_TOOL_LABELS: Record<
+  RecommendedMobilityTypeDto,
+  string
+> = {
+  [RecommendedMobilityTypeDto.ManualWheelchair]: '수동휠체어',
+  [RecommendedMobilityTypeDto.ElectricWheelchair]: '전동휠체어',
+  [RecommendedMobilityTypeDto.Elderly]: '고령자',
+  [RecommendedMobilityTypeDto.Stroller]: '유아차 동반',
+  [RecommendedMobilityTypeDto.NotSure]: '모름',
+  [RecommendedMobilityTypeDto.None]: '추천안함',
+};
 
 export const SPACIOUS_LABELS: Record<SpaciousTypeDto, string> = {
   [SpaciousTypeDto.Wide]: '매우 넓고, 이용하기 적합해요 🥰',
@@ -18,18 +66,6 @@ export const SPACIOUS_OPTIONS = Object.entries(SPACIOUS_LABELS).map(
     label,
   }),
 );
-
-export const RECOMMEND_MOBILITY_TOOL_LABELS: Record<
-  RecommendedMobilityTypeDto,
-  string
-> = {
-  [RecommendedMobilityTypeDto.ManualWheelchair]: '수동휠체어',
-  [RecommendedMobilityTypeDto.ElectricWheelchair]: '전동휠체어',
-  [RecommendedMobilityTypeDto.Elderly]: '고령자',
-  [RecommendedMobilityTypeDto.Stroller]: '유아차 동반',
-  [RecommendedMobilityTypeDto.NotSure]: '모름',
-  [RecommendedMobilityTypeDto.None]: '추천안함',
-};
 
 export const RECOMMEND_MOBILITY_TOOL_OPTIONS = Object.entries(
   RECOMMEND_MOBILITY_TOOL_LABELS,

--- a/src/constant/review.ts
+++ b/src/constant/review.ts
@@ -1,4 +1,5 @@
 import {
+  EntranceDoorType,
   RecommendedMobilityTypeDto,
   SpaciousTypeDto,
   ToiletLocationTypeDto,
@@ -80,3 +81,24 @@ export const TOILET_LOCATION_TYPE_OPTIONS = Object.entries(
   value: value as ToiletLocationTypeDtoWithoutNotSure,
   label,
 }));
+
+type DoorTypeMap = typeof EntranceDoorType;
+
+type DoorTypeMapDto = DoorTypeMap[keyof Omit<
+  DoorTypeMap,
+  'Revolving' | 'None'
+>];
+
+export const DOOR_TYPE_LABELS: Record<DoorTypeMapDto, string> = {
+  Hinged: '여닫이문',
+  Sliding: '미닫이문',
+  Automatic: '자동문',
+  ETC: '기타',
+};
+
+export const DOOR_TYPE_OPTIONS = Object.entries(DOOR_TYPE_LABELS).map(
+  ([value, label]) => ({
+    value: value as DoorTypeMapDto,
+    label,
+  }),
+);

--- a/src/navigation/Navigation.screens.ts
+++ b/src/navigation/Navigation.screens.ts
@@ -181,7 +181,11 @@ export const MainNavigationScreens: {
   {
     name: 'ReviewForm/Toilet',
     component: ToiletReviewFormScreen,
-    options: {headerShown: true, headerTitle: '화장실 후기 작성하기'},
+    options: {
+      headerShown: true,
+      headerTitle: '화장실 후기 작성하기',
+      variant: 'close',
+    },
   },
 ];
 

--- a/src/navigation/Navigation.screens.ts
+++ b/src/navigation/Navigation.screens.ts
@@ -176,6 +176,7 @@ export const MainNavigationScreens: {
       headerShown: true,
       headerTitle: '방문 후기 작성하기',
       variant: 'close',
+      gestureEnabled: false,
     },
   },
   {
@@ -185,6 +186,7 @@ export const MainNavigationScreens: {
       headerShown: true,
       headerTitle: '화장실 후기 작성하기',
       variant: 'close',
+      gestureEnabled: false,
     },
   },
 ];

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -74,6 +74,7 @@ export const Navigation = () => {
               title={title}
               navigation={navigation}
               variant={variant}
+              {...options}
             />
           );
         },

--- a/src/screens/PlaceReviewFormScreen/index.tsx
+++ b/src/screens/PlaceReviewFormScreen/index.tsx
@@ -34,6 +34,11 @@ export default function PlaceReviewFormScreen({
   }
 
   function gotoPlaceDetail() {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
     navigation.replace('PlaceDetail', {
       placeInfo: {
         placeId: data?.place?.id!,

--- a/src/screens/PlaceReviewFormScreen/index.tsx
+++ b/src/screens/PlaceReviewFormScreen/index.tsx
@@ -1,6 +1,5 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
-import {ScrollView} from 'react-native';
 
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {Building, Place} from '@/generated-sources/openapi';
@@ -68,11 +67,7 @@ export default function PlaceReviewFormScreen({
 
   return (
     <LogParamsProvider params={{placeId}}>
-      <ScreenLayout isHeaderVisible={true}>
-        <ScrollView contentContainerStyle={{flexGrow: 1}}>
-          {renderView()}
-        </ScrollView>
-      </ScreenLayout>
+      <ScreenLayout isHeaderVisible={true}>{renderView()}</ScreenLayout>
     </LogParamsProvider>
   );
 }

--- a/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
@@ -8,8 +8,10 @@ import Photos from '@/components/form/Photos';
 import TextInput from '@/components/form/TextArea';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
-import {makeDoorTypeOptions} from '@/constant/options';
-import {TOILET_LOCATION_TYPE_OPTIONS} from '@/constant/review';
+import {
+  DOOR_TYPE_OPTIONS,
+  TOILET_LOCATION_TYPE_OPTIONS,
+} from '@/constant/review';
 
 import FloorSelect from '../components/FloorSelect';
 import {FormValues} from '../views/ToiletReviewView';
@@ -20,7 +22,6 @@ const MAX_NUMBER_OF_TAKEN_PHOTOS = 3;
 export default function ToiletSection({onSave}: {onSave: () => void}) {
   const {watch, formState, resetField} = useFormContext<FormValues>();
   const toiletLocationType = watch('toiletLocationType');
-  const doorTypes = watch('doorTypes');
 
   const isExist =
     toiletLocationType === 'PLACE' || toiletLocationType === 'BUILDING';
@@ -112,27 +113,24 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
                   }}
                   render={({field}) => (
                     <>
-                      {makeDoorTypeOptions([...doorTypes]).map(
-                        ({label, value, disabled}) => {
-                          return (
-                            <PressableChip
-                              key={value}
-                              label={label}
-                              active={field.value?.has(value)}
-                              disabled={disabled}
-                              onPress={() => {
-                                const newSet = new Set(field.value);
-                                if (newSet.has(value)) {
-                                  newSet.delete(value);
-                                } else {
-                                  newSet.add(value);
-                                }
-                                field.onChange(newSet);
-                              }}
-                            />
-                          );
-                        },
-                      )}
+                      {DOOR_TYPE_OPTIONS.map(({label, value}) => {
+                        return (
+                          <PressableChip
+                            key={value}
+                            label={label}
+                            active={field.value?.has(value)}
+                            onPress={() => {
+                              const newSet = new Set(field.value);
+                              if (newSet.has(value)) {
+                                newSet.delete(value);
+                              } else {
+                                newSet.add(value);
+                              }
+                              field.onChange(newSet);
+                            }}
+                          />
+                        );
+                      })}
                     </>
                   )}
                 />

--- a/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {Controller, useFormContext} from 'react-hook-form';
 import {Text, View} from 'react-native';
 
@@ -17,13 +18,21 @@ import * as S from './common.style';
 const MAX_NUMBER_OF_TAKEN_PHOTOS = 3;
 
 export default function ToiletSection({onSave}: {onSave: () => void}) {
-  const {watch} = useFormContext<FormValues>();
+  const {watch, formState, resetField} = useFormContext<FormValues>();
   const toiletLocationType = watch('toiletLocationType');
   const doorTypes = watch('doorTypes');
 
   const isExist =
     toiletLocationType === 'PLACE' || toiletLocationType === 'BUILDING';
   const isVisibleTextarea = toiletLocationType === 'ETC' || isExist;
+
+  useEffect(() => {
+    if (!isExist) {
+      resetField('floor');
+      resetField('doorTypes');
+      resetField('toiletPhotos');
+    }
+  }, [toiletLocationType]);
 
   return (
     <S.Container style={{flex: 1, justifyContent: 'space-between'}}>
@@ -44,7 +53,7 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
             }}>
             <Controller
               name="toiletLocationType"
-              rules={{required: true, validate: value => value.size > 0}}
+              rules={{required: true}}
               render={({field}) => (
                 <>
                   {TOILET_LOCATION_TYPE_OPTIONS.map(({label, value}) => (
@@ -71,6 +80,7 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
               <Controller
                 name="floor"
                 rules={{
+                  required: isExist,
                   validate: v =>
                     v !== 0 && v !== 1
                       ? true
@@ -96,7 +106,10 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
                 }}>
                 <Controller
                   name="doorTypes"
-                  rules={{required: true, validate: value => value.size > 0}}
+                  rules={{
+                    required: isExist,
+                    validate: value => value.length > 0,
+                  }}
                   render={({field}) => (
                     <>
                       {makeDoorTypeOptions(doorTypes).map(
@@ -196,6 +209,7 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
             backgroundColor: color.brand,
           }}
           fontSize={18}
+          isDisabled={!formState.isValid}
           fontFamily={font.pretendardBold}
           onPress={onSave}
         />

--- a/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
@@ -136,61 +136,65 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
                 />
               </View>
             </View>
-            <View style={{gap: 12}}>
-              <S.Question>
-                화장실 이용 경험 및 참고할점을 알려주세요.
-              </S.Question>
+          </>
+        )}
+        <View style={{gap: 12}}>
+          {isExist && (
+            <S.Question>화장실 이용 경험 및 참고할점을 알려주세요.</S.Question>
+          )}
+          {(isExist || isVisibleTextarea) && (
+            <View style={{gap: 8}}>
               <Controller
-                name="toiletPhotos"
-                rules={{required: false}}
+                name="comment"
                 render={({field}) => (
-                  <Photos
-                    value={field.value ?? []}
-                    onChange={field.onChange}
-                    target="place"
-                    maxPhotos={MAX_NUMBER_OF_TAKEN_PHOTOS}
-                  />
+                  <>
+                    <TextInput
+                      multiline
+                      style={{
+                        color: color.black,
+                        fontSize: 16,
+                        fontFamily: font.pretendardRegular,
+                        paddingVertical: 0,
+                        textAlignVertical: 'top',
+                        minHeight: 160,
+                      }}
+                      value={field.value}
+                      maxLength={300}
+                      placeholder={
+                        toiletLocationType === 'ETC'
+                          ? '기타 사항을 작성해주세요.'
+                          : '장소의 전체적인 접근성, 방문 경험을 나눠주세요.'
+                      }
+                      placeholderTextColor={color.gray50}
+                      onChangeText={field.onChange}
+                    />
+                    <Text
+                      style={{
+                        alignSelf: 'flex-end',
+                        color: '#7A7A88',
+                      }}>
+                      {field.value?.length ?? 0}/300
+                    </Text>
+                  </>
                 )}
               />
             </View>
-          </>
-        )}
+          )}
+        </View>
 
-        {isVisibleTextarea && (
-          <View style={{gap: 8}}>
-            <Controller
-              name="comment"
-              render={({field}) => (
-                <>
-                  <TextInput
-                    multiline
-                    style={{
-                      color: color.black,
-                      fontSize: 16,
-                      fontFamily: font.pretendardRegular,
-                      paddingVertical: 0,
-                      textAlignVertical: 'top',
-                      minHeight: 160,
-                    }}
-                    value={field.value}
-                    maxLength={300}
-                    placeholder={
-                      '장소의 전체적인 접근성, 방문 경험을 나눠주세요.'
-                    }
-                    placeholderTextColor={color.gray50}
-                    onChangeText={field.onChange}
-                  />
-                  <Text
-                    style={{
-                      alignSelf: 'flex-end',
-                      color: '#7A7A88',
-                    }}>
-                    {field.value?.length ?? 0}/300
-                  </Text>
-                </>
-              )}
-            />
-          </View>
+        {isExist && (
+          <Controller
+            name="toiletPhotos"
+            rules={{required: false}}
+            render={({field}) => (
+              <Photos
+                value={field.value ?? []}
+                onChange={field.onChange}
+                target="place"
+                maxPhotos={MAX_NUMBER_OF_TAKEN_PHOTOS}
+              />
+            )}
+          />
         )}
       </View>
 

--- a/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
@@ -108,27 +108,26 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
                   name="doorTypes"
                   rules={{
                     required: isExist,
-                    validate: value => value.length > 0,
+                    validate: value => value.size > 0,
                   }}
                   render={({field}) => (
                     <>
-                      {makeDoorTypeOptions(doorTypes).map(
-                        ({label, value}, idx) => {
-                          const isActive = field.value?.includes(value);
-
+                      {makeDoorTypeOptions([...doorTypes]).map(
+                        ({label, value, disabled}) => {
                           return (
                             <PressableChip
-                              key={value + idx}
+                              key={value}
                               label={label}
-                              active={isActive}
+                              active={field.value?.has(value)}
+                              disabled={disabled}
                               onPress={() => {
-                                const nextValue = isActive
-                                  ? field.value.filter(
-                                      (v: string) => v !== value,
-                                    )
-                                  : [...(field.value || []), value];
-
-                                field.onChange(nextValue);
+                                const newSet = new Set(field.value);
+                                if (newSet.has(value)) {
+                                  newSet.delete(value);
+                                } else {
+                                  newSet.add(value);
+                                }
+                                field.onChange(newSet);
                               }}
                             />
                           );

--- a/src/screens/PlaceReviewFormScreen/sections/UserTypeSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/UserTypeSection.tsx
@@ -61,12 +61,18 @@ export default function UserTypeSection() {
       <View
         style={{
           padding: 12,
-          backgroundColor: '#F7F7F9',
+          backgroundColor: color.gray10,
           borderRadius: 4,
           alignItems: 'center',
           gap: 8,
         }}>
-        <Text>사용자 유형은 리뷰에서 이렇게 보여요!</Text>
+        <Text
+          style={{
+            color: color.gray60,
+            fontSize: 13,
+          }}>
+          사용자 유형은 리뷰에서 이렇게 보여요!
+        </Text>
         <View
           style={{
             flexDirection: 'row',
@@ -76,7 +82,7 @@ export default function UserTypeSection() {
             style={{
               fontSize: 13,
               lineHeight: 18,
-              fontFamily: font.pretendardBold,
+              fontFamily: font.pretendardMedium,
             }}>
             {userInfo?.nickname}
           </Text>
@@ -87,8 +93,9 @@ export default function UserTypeSection() {
               fontSize: 11,
               lineHeight: 14,
               fontFamily: font.pretendardMedium,
-              color: color.brand,
-              backgroundColor: color.brand5,
+              color: color.gray50,
+              backgroundColor: color.gray20,
+              borderRadius: 3,
             }}>
             {MOBILITY_TOOL_LABELS[mobilityTool]}
           </Text>

--- a/src/screens/PlaceReviewFormScreen/sections/UserTypeSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/UserTypeSection.tsx
@@ -19,6 +19,7 @@ export default function UserTypeSection() {
     mobilityTool: UserMobilityToolMapDto;
   }>();
   const mobilityTool = watch('mobilityTool');
+  const isVisibleLabel = mobilityTool !== 'NONE';
 
   return (
     <S.Container>
@@ -86,19 +87,21 @@ export default function UserTypeSection() {
             }}>
             {userInfo?.nickname}
           </Text>
-          <Text
-            style={{
-              paddingVertical: 2,
-              paddingHorizontal: 4,
-              fontSize: 11,
-              lineHeight: 14,
-              fontFamily: font.pretendardMedium,
-              color: color.gray50,
-              backgroundColor: color.gray20,
-              borderRadius: 3,
-            }}>
-            {MOBILITY_TOOL_LABELS[mobilityTool]}
-          </Text>
+          {isVisibleLabel && (
+            <Text
+              style={{
+                paddingVertical: 2,
+                paddingHorizontal: 4,
+                fontSize: 11,
+                lineHeight: 14,
+                fontFamily: font.pretendardMedium,
+                color: color.gray50,
+                backgroundColor: color.gray20,
+                borderRadius: 3,
+              }}>
+              {MOBILITY_TOOL_LABELS[mobilityTool]}
+            </Text>
+          )}
         </View>
       </View>
     </S.Container>

--- a/src/screens/PlaceReviewFormScreen/sections/UserTypeSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/UserTypeSection.tsx
@@ -7,8 +7,8 @@ import {font} from '@/constant/font';
 import {
   MOBILITY_TOOL_LABELS,
   MOBILITY_TOOL_OPTIONS,
-} from '@/constant/mobilityTool';
-import {UserMobilityToolDto} from '@/generated-sources/openapi';
+  UserMobilityToolMapDto,
+} from '@/constant/review';
 import useMe from '@/hooks/useMe';
 
 import * as S from './common.style';
@@ -16,7 +16,7 @@ import * as S from './common.style';
 export default function UserTypeSection() {
   const {userInfo} = useMe();
   const {watch} = useFormContext<{
-    mobilityTool: UserMobilityToolDto;
+    mobilityTool: UserMobilityToolMapDto;
   }>();
   const mobilityTool = watch('mobilityTool');
 

--- a/src/screens/PlaceReviewFormScreen/sections/VisitorReviewSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/VisitorReviewSection.tsx
@@ -121,14 +121,14 @@ export default function VisitorReviewSection() {
                       fontFamily: font.pretendardRegular,
                       paddingVertical: 0,
                       textAlignVertical: 'top',
-                      minHeight: 90,
+                      minHeight: 160,
                     }}
                     value={field.value}
                     maxLength={300}
                     placeholder={
                       '장소의 전체적인 접근성, 방문 경험을 나눠주세요.'
                     }
-                    placeholderTextColor={color.gray50}
+                    placeholderTextColor={color.gray40}
                     onChangeText={field.onChange}
                   />
                   <Text

--- a/src/screens/PlaceReviewFormScreen/sections/VisitorReviewSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/VisitorReviewSection.tsx
@@ -1,4 +1,4 @@
-import {Controller} from 'react-hook-form';
+import {Controller, useFormContext} from 'react-hook-form';
 import {Text, View} from 'react-native';
 
 import PressableChip from '@/components/PressableChip';
@@ -7,15 +7,18 @@ import TextInput from '@/components/form/TextArea';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 import {
-  RECOMMEND_MOBILITY_TOOL_OPTIONS,
+  makeRecommendedMobilityOptions,
   SPACIOUS_OPTIONS,
 } from '@/constant/review';
 
+import {FormValues} from '../views/IndoorReviewView';
 import * as S from './common.style';
 
 const MAX_NUMBER_OF_TAKEN_PHOTOS = 3;
 
 export default function VisitorReviewSection() {
+  const {watch} = useFormContext<FormValues>();
+  const recommendedMobilityTypes = watch('recommendedMobilityTypes');
   return (
     <S.Container>
       <S.Title>방문 리뷰</S.Title>
@@ -39,24 +42,25 @@ export default function VisitorReviewSection() {
               rules={{required: true, validate: value => value.size > 0}}
               render={({field}) => (
                 <>
-                  {RECOMMEND_MOBILITY_TOOL_OPTIONS.map(
-                    ({label, value}, idx) => (
-                      <PressableChip
-                        key={label + idx}
-                        label={label}
-                        active={field.value?.has(value)}
-                        onPress={() => {
-                          const newSet = new Set(field.value);
-                          if (newSet.has(value)) {
-                            newSet.delete(value);
-                          } else {
-                            newSet.add(value);
-                          }
-                          field.onChange(newSet);
-                        }}
-                      />
-                    ),
-                  )}
+                  {makeRecommendedMobilityOptions([
+                    ...recommendedMobilityTypes,
+                  ]).map(({label, value, disabled}) => (
+                    <PressableChip
+                      key={label}
+                      label={label}
+                      active={field.value?.has(value)}
+                      disabled={disabled}
+                      onPress={() => {
+                        const newSet = new Set(field.value);
+                        if (newSet.has(value)) {
+                          newSet.delete(value);
+                        } else {
+                          newSet.add(value);
+                        }
+                        field.onChange(newSet);
+                      }}
+                    />
+                  ))}
                 </>
               )}
             />

--- a/src/screens/PlaceReviewFormScreen/views/IndoorReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/IndoorReviewView.tsx
@@ -5,11 +5,14 @@ import {FormProvider, useForm} from 'react-hook-form';
 
 import {loadingState} from '@/components/LoadingView';
 import {
+  getMobilityToolDefaultValue,
+  UserMobilityToolMapDto,
+} from '@/constant/review';
+import {
   DefaultApi,
   Place,
   RecommendedMobilityTypeDto,
   SpaciousTypeDto,
-  UserMobilityToolDto,
 } from '@/generated-sources/openapi';
 import useAppComponents from '@/hooks/useAppComponents';
 import useMe from '@/hooks/useMe';
@@ -25,7 +28,7 @@ import VisitorReviewSection from '../sections/VisitorReviewSection';
 import {SectionSeparator} from '../sections/common.style';
 
 export interface FormValues {
-  mobilityTool: UserMobilityToolDto;
+  mobilityTool: UserMobilityToolMapDto;
   recommendedMobilityTypes: Set<RecommendedMobilityTypeDto>;
   spaciousType?: SpaciousTypeDto;
   indoorPhotos: ImageFile[];
@@ -51,7 +54,7 @@ export default function IndoorReviewView({
   const [loading, setLoading] = useAtom(loadingState);
   const form = useForm<FormValues>({
     defaultValues: {
-      mobilityTool: userInfo?.mobilityTools[0],
+      mobilityTool: getMobilityToolDefaultValue(userInfo?.mobilityTools),
       recommendedMobilityTypes: new Set(),
       spaciousType: undefined,
       comment: '',

--- a/src/screens/PlaceReviewFormScreen/views/IndoorReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/IndoorReviewView.tsx
@@ -2,6 +2,7 @@ import {useAtom} from 'jotai';
 import {throttle} from 'lodash';
 import {useMemo} from 'react';
 import {FormProvider, useForm} from 'react-hook-form';
+import {ScrollView} from 'react-native';
 
 import {loadingState} from '@/components/LoadingView';
 import {
@@ -91,19 +92,23 @@ export default function IndoorReviewView({
 
   return (
     <FormProvider {...form}>
-      <PlaceInfoSection name={place?.name} address={place?.address} />
-      <SectionSeparator />
+      <ScrollView
+        stickyHeaderIndices={[0]}
+        contentContainerStyle={{flexGrow: 1}}>
+        <PlaceInfoSection name={place?.name} address={place?.address} />
+        <SectionSeparator />
 
-      <UserTypeSection />
-      <SectionSeparator />
+        <UserTypeSection />
+        <SectionSeparator />
 
-      <VisitorReviewSection />
-      <SectionSeparator />
+        <VisitorReviewSection />
+        <SectionSeparator />
 
-      <IndoorInfoSection
-        onSave={form.handleSubmit(onValid)}
-        onSaveAndToiletReview={form.handleSubmit(onValidAfterToilet)}
-      />
+        <IndoorInfoSection
+          onSave={form.handleSubmit(onValid)}
+          onSaveAndToiletReview={form.handleSubmit(onValidAfterToilet)}
+        />
+      </ScrollView>
     </FormProvider>
   );
 }

--- a/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
@@ -42,7 +42,7 @@ export default function ToiletReviewView({
 
   const form = useForm<FormValues>({
     defaultValues: {
-      floor: 1,
+      floor: 2,
       doorTypes: [],
       toiletPhotos: [],
       comment: '',

--- a/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
@@ -2,6 +2,7 @@ import {useAtom} from 'jotai';
 import {throttle} from 'lodash';
 import {useMemo} from 'react';
 import {FormProvider, useForm} from 'react-hook-form';
+import {ScrollView} from 'react-native';
 
 import {loadingState} from '@/components/LoadingView';
 import {
@@ -72,9 +73,13 @@ export default function ToiletReviewView({
 
   return (
     <FormProvider {...form}>
-      <PlaceInfoSection name={place?.name} address={place?.address} />
-      <SectionSeparator />
-      <ToiletSection onSave={form.handleSubmit(onValid)} />
+      <ScrollView
+        stickyHeaderIndices={[0]}
+        contentContainerStyle={{flexGrow: 1}}>
+        <PlaceInfoSection name={place?.name} address={place?.address} />
+        <SectionSeparator />
+        <ToiletSection onSave={form.handleSubmit(onValid)} />
+      </ScrollView>
     </FormProvider>
   );
 }

--- a/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
@@ -28,7 +28,7 @@ interface ToiletReviewViewProps {
 export interface FormValues {
   toiletLocationType: ToiletLocationTypeDto;
   floor: number;
-  doorTypes: EntranceDoorType[];
+  doorTypes: Set<EntranceDoorType>;
   toiletPhotos: ImageFile[];
   comment: string;
 }
@@ -43,7 +43,7 @@ export default function ToiletReviewView({
   const form = useForm<FormValues>({
     defaultValues: {
       floor: 2,
-      doorTypes: [],
+      doorTypes: new Set(),
       toiletPhotos: [],
       comment: '',
     },
@@ -90,7 +90,7 @@ async function register(api: DefaultApi, placeId: string, values: FormValues) {
       await api.registerToiletReviewPost({
         placeId,
         toiletLocationType: values.toiletLocationType,
-        entranceDoorTypes: values.doorTypes,
+        entranceDoorTypes: [...values.doorTypes],
         comment: values.comment,
         imageUrls: images,
       });

--- a/src/screens/ToiletReviewFormScreen/index.tsx
+++ b/src/screens/ToiletReviewFormScreen/index.tsx
@@ -27,6 +27,12 @@ export default function ToiletReviewFormScreen({
   });
 
   function gotoPlaceDetail() {
+    if (navigation.canGoBack()) {
+      console.log('back?');
+      navigation.goBack();
+      return;
+    }
+
     navigation.replace('PlaceDetail', {
       placeInfo: {
         placeId: data?.place?.id!,

--- a/src/screens/ToiletReviewFormScreen/index.tsx
+++ b/src/screens/ToiletReviewFormScreen/index.tsx
@@ -27,7 +27,6 @@ export default function ToiletReviewFormScreen({
 
   function gotoPlaceDetail() {
     if (navigation.canGoBack()) {
-      console.log('back?');
       navigation.goBack();
       return;
     }

--- a/src/screens/ToiletReviewFormScreen/index.tsx
+++ b/src/screens/ToiletReviewFormScreen/index.tsx
@@ -1,5 +1,4 @@
 import {useQuery} from '@tanstack/react-query';
-import {ScrollView} from 'react-native';
 
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {Building, Place} from '@/generated-sources/openapi';
@@ -43,12 +42,10 @@ export default function ToiletReviewFormScreen({
   return (
     <LogParamsProvider params={{placeId}}>
       <ScreenLayout isHeaderVisible={true}>
-        <ScrollView contentContainerStyle={{flexGrow: 1}}>
-          <ToiletReviewView
-            place={data?.place}
-            gotoPlaceDetail={gotoPlaceDetail}
-          />
-        </ScrollView>
+        <ToiletReviewView
+          place={data?.place}
+          gotoPlaceDetail={gotoPlaceDetail}
+        />
       </ScreenLayout>
     </LogParamsProvider>
   );

--- a/src/screens/ToiletReviewFormScreen/index.tsx
+++ b/src/screens/ToiletReviewFormScreen/index.tsx
@@ -1,5 +1,5 @@
 import {useQuery} from '@tanstack/react-query';
-import {ScrollView} from 'react-native-gesture-handler';
+import {ScrollView} from 'react-native';
 
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {Building, Place} from '@/generated-sources/openapi';


### PR DESCRIPTION
- 화장실 유무에 따른 필드값 초기화
- 동시에 선택 불가능한 필드 대응
- 화장실 리뷰 ScrollVeiw 때문에 깨지는거 해결 + 헤더 변경
- 출입문 회전문, 없음 제거
- 리뷰 화면은 goBack 상세페이지로 이동
- 사용자 유형 우선순위 높은 순서대로 보여주기
- 장소명, 주소 영역 sticky 처리
- 리뷰 화면은 ios 스와이프 뒤로가기 막기