### PR TITLE
앱 푸시 오픈 이벤트 남기기

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
 /**
  * @format
  */
-import {getMessaging} from '@react-native-firebase/messaging';
 import React from 'react';
-import {AppRegistry, Linking} from 'react-native';
+import {AppRegistry} from 'react-native';
 // https://github.com/facebook/react-native/issues/23922#issuecomment-648096619
 // a polyfill is code that implements a feature on web browsers that do not natively support the feature.
 import 'react-native-url-polyfill/auto';
 
 import App from './App';
 import {name as appName} from './app.json';
-import {logDebug} from '@/utils/DebugUtils';
 import Logger from '@/logging/Logger';
 import {getStorageValue} from '@/atoms/atomForLocal';
 
@@ -19,7 +17,7 @@ import {getStorageValue} from '@/atoms/atomForLocal';
 // 따라서 명시적으로 셋업해주도록 한다.
 const userId = getStorageValue('userInfo')?.id;
 if (userId) {
-  Logger.setUserId(userId)
+  Logger.setUserId(userId);
 }
 
 // getInitialNotification은 RootScreen.tsx의 getInitialURL에서 처리됨

--- a/index.js
+++ b/index.js
@@ -10,12 +10,22 @@ import 'react-native-url-polyfill/auto';
 
 import App from './App';
 import {name as appName} from './app.json';
+import {logDebug} from '@/utils/DebugUtils';
+import Logger from '@/logging/Logger';
+import {getStorageValue} from '@/atoms/atomForLocal';
 
-getMessaging().onNotificationOpenedApp(async remoteMessage => {
-  if (remoteMessage?.data?._d) {
-    Linking.openURL(remoteMessage?.data?._d);
-  }
-});
+// 앱 오픈 ~ useMe hook 사이에 날라가는 GA event도 있다.
+// 이 이벤트에 정상적으로 userId가 담길 수 있도록, 앱 오픈 시 명시적으로 userId를 한 번 셋업해주도록 한다.
+// 따라서 명시적으로 셋업해주도록 한다.
+const userId = getStorageValue('userInfo')?.id;
+if (userId) {
+  Logger.setUserId(userId)
+}
+
+// getInitialNotification은 RootScreen.tsx의 getInitialURL에서 처리됨
+// 여기서 호출하면 중복 호출로 인해 null을 반환함
+
+// 푸시 알림 처리는 RootScreen.tsx에서 통합 관리됨
 
 // Check if app was launched in the background and conditionally render null if so
 function HeadlessCheck({isHeadless}) {

--- a/ios/sccReactNative.xcodeproj/xcshareddata/xcschemes/StairCrusherClubSandbox.xcscheme
+++ b/ios/sccReactNative.xcodeproj/xcshareddata/xcschemes/StairCrusherClubSandbox.xcscheme
@@ -78,6 +78,12 @@
             ReferencedContainer = "container:sccReactNative.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "DebugSandbox"

--- a/src/atoms/atomForLocal.ts
+++ b/src/atoms/atomForLocal.ts
@@ -5,12 +5,15 @@ import {MMKV} from 'react-native-mmkv';
 import {parseOrNull} from '@/utils/JSON';
 
 export const storage = new MMKV();
+
+export function getStorageValue<T>(key: string): T | null {
+  const value = storage.getString(key);
+  return value ? parseOrNull(value) : null;
+}
+
 export function atomForLocal<T>(atomKey: string) {
   const valueStore: SyncStorage<T | null> = {
-    getItem: key => {
-      const value = storage.getString(key);
-      return value ? parseOrNull(value) : null;
-    },
+    getItem: key => getStorageValue<T>(key),
     setItem: (key, value) => {
       storage.set(key, JSON.stringify(value));
     },

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -3,6 +3,7 @@ import crashlytics from '@react-native-firebase/crashlytics';
 
 import {logDebug} from '@/utils/DebugUtils';
 
+
 interface ElementEventParams {
   name: string;
   currScreenName: string;
@@ -12,6 +13,14 @@ interface ElementEventParams {
 interface ScreenViewParams {
   prevScreenName?: string;
   currScreenName?: string;
+  extraParams?: Record<string, any>;
+}
+
+interface AppPushOpenParams {
+  title: string;
+  body: string;
+  campaignId?: string;
+  campaignType?: string;
   extraParams?: Record<string, any>;
 }
 
@@ -72,6 +81,18 @@ const Logger = {
     logDebug('logError', error, currUserPropertiesForDebugging);
     crashlytics().recordError(error);
   },
+
+  async logAppPushOpen(params: AppPushOpenParams) {
+    logDebug('logAppPushOpen', params, currUserPropertiesForDebugging);
+    getAnalytics().logEvent('app_push_open', {
+      ...(params.extraParams || {}),
+      push_title: params.title,
+      push_body: params.body,
+      push_campaign_id: params.campaignId,
+      push_campaign_type: params.campaignType,
+      user_id: currUserPropertiesForDebugging.userId,
+    });
+  }
 };
 
 export default Logger;

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -3,7 +3,6 @@ import crashlytics from '@react-native-firebase/crashlytics';
 
 import {logDebug} from '@/utils/DebugUtils';
 
-
 interface ElementEventParams {
   name: string;
   currScreenName: string;
@@ -92,7 +91,7 @@ const Logger = {
       push_campaign_type: params.campaignType,
       user_id: currUserPropertiesForDebugging.userId,
     });
-  }
+  },
 };
 
 export default Logger;

--- a/src/screens/RootScreen.tsx
+++ b/src/screens/RootScreen.tsx
@@ -74,16 +74,16 @@ const RootScreen = () => {
             logDebug('Normal deeplink click during app quit state', url);
             return url;
           }
-          
+
           // 푸시 알림 처리
           const message = await getMessaging().getInitialNotification();
           if (message) {
-            logDebug('getInitialNotification', message)
+            logDebug('getInitialNotification', message);
             Logger.logAppPushOpen({
               title: message.notification?.title || '',
               body: message.notification?.body || '',
-              campaignId: message.data?.campaign_id as (string | undefined),
-              campaignType: message.data?.campaign_type as (string | undefined),
+              campaignId: message.data?.campaign_id as string | undefined,
+              campaignType: message.data?.campaign_type as string | undefined,
             });
             const data = message.data as {_d: string};
             return data?._d;
@@ -93,35 +93,47 @@ const RootScreen = () => {
         // 앱 background 상태에서 deeplink 클릭이나 앱 푸시 클릭을 했을 때의 처리
         subscribe(listener) {
           // 일반 딥링크 처리
-          const linkingSubscription = Linking.addEventListener('url', ({url}) => {
-            logDebug('Normal deeplink click during app background state', url);
-            listener(url);
-          });
-          
-          // 푸시 알림 처리
-          const pushSubscription = getMessaging().onNotificationOpenedApp(async (remoteMessage) => {
-            // https://github.com/invertase/react-native-firebase/issues/7749#issuecomment-2075084174
-            // 1. background 상태 -> 2. 앱 푸시 A 클릭해서 오픈 -> 3. quit 상태 -> 4. 앱 푸시 B 클릭해서 오픈
-            // 위와 같은 시나리오를 겪을 때, 4번의 getInitialNotification()에서 앱 푸시 A의 remoteMessage를 수신하는 문제가 있다.
-            // 링크된 github issue를 보면 2번 타이밍 때 getInitialNotification() 쪽에 앱 푸시 A에 대한 데이터가 로컬에 저장되는데,
-            // onNotificationOpenedApp() 호출로는 이 데이터가 초기화되지 않아서 4번 타이밍에 앱 푸시 A의 remoteMessage가 쓰이는 것으로 보인다.
-            // 임시 방편으로 2번 타이밍 때 getInitialNotification()를 호출해줘서 강제로 로컬에 저장된 remoteMessage를 초기화해준다.
-            getMessaging().getInitialNotification()
+          const linkingSubscription = Linking.addEventListener(
+            'url',
+            ({url}) => {
+              logDebug(
+                'Normal deeplink click during app background state',
+                url,
+              );
+              listener(url);
+            },
+          );
 
-            logDebug('onNotificationOpenedApp', remoteMessage)
-            Logger.logAppPushOpen({
-              title: remoteMessage.notification?.title || '',
-              body: remoteMessage.notification?.body || '',
-              campaignId: remoteMessage.data?.campaign_id as (string | undefined),
-              campaignType: remoteMessage.data?.campaign_type as (string | undefined),
-            });
-            
-            const data = remoteMessage.data as {_d?: string};
-            if (data?._d) {
-              listener(data._d);
-            }
-          });
-          
+          // 푸시 알림 처리
+          const pushSubscription = getMessaging().onNotificationOpenedApp(
+            async remoteMessage => {
+              // https://github.com/invertase/react-native-firebase/issues/7749#issuecomment-2075084174
+              // 1. background 상태 -> 2. 앱 푸시 A 클릭해서 오픈 -> 3. quit 상태 -> 4. 앱 푸시 B 클릭해서 오픈
+              // 위와 같은 시나리오를 겪을 때, 4번의 getInitialNotification()에서 앱 푸시 A의 remoteMessage를 수신하는 문제가 있다.
+              // 링크된 github issue를 보면 2번 타이밍 때 getInitialNotification() 쪽에 앱 푸시 A에 대한 데이터가 로컬에 저장되는데,
+              // onNotificationOpenedApp() 호출로는 이 데이터가 초기화되지 않아서 4번 타이밍에 앱 푸시 A의 remoteMessage가 쓰이는 것으로 보인다.
+              // 임시 방편으로 2번 타이밍 때 getInitialNotification()를 호출해줘서 강제로 로컬에 저장된 remoteMessage를 초기화해준다.
+              getMessaging().getInitialNotification();
+
+              logDebug('onNotificationOpenedApp', remoteMessage);
+              Logger.logAppPushOpen({
+                title: remoteMessage.notification?.title || '',
+                body: remoteMessage.notification?.body || '',
+                campaignId: remoteMessage.data?.campaign_id as
+                  | string
+                  | undefined,
+                campaignType: remoteMessage.data?.campaign_type as
+                  | string
+                  | undefined,
+              });
+
+              const data = remoteMessage.data as {_d?: string};
+              if (data?._d) {
+                listener(data._d);
+              }
+            },
+          );
+
           return () => {
             linkingSubscription.remove();
             pushSubscription();

--- a/src/screens/RootScreen.tsx
+++ b/src/screens/RootScreen.tsx
@@ -100,6 +100,14 @@ const RootScreen = () => {
           
           // 푸시 알림 처리
           const pushSubscription = getMessaging().onNotificationOpenedApp(async (remoteMessage) => {
+            // https://github.com/invertase/react-native-firebase/issues/7749#issuecomment-2075084174
+            // 1. background 상태 -> 2. 앱 푸시 A 클릭해서 오픈 -> 3. quit 상태 -> 4. 앱 푸시 B 클릭해서 오픈
+            // 위와 같은 시나리오를 겪을 때, 4번의 getInitialNotification()에서 앱 푸시 A의 remoteMessage를 수신하는 문제가 있다.
+            // 링크된 github issue를 보면 2번 타이밍 때 getInitialNotification() 쪽에 앱 푸시 A에 대한 데이터가 로컬에 저장되는데,
+            // onNotificationOpenedApp() 호출로는 이 데이터가 초기화되지 않아서 4번 타이밍에 앱 푸시 A의 remoteMessage가 쓰이는 것으로 보인다.
+            // 임시 방편으로 2번 타이밍 때 getInitialNotification()를 호출해줘서 강제로 로컬에 저장된 remoteMessage를 초기화해준다.
+            getMessaging().getInitialNotification()
+
             logDebug('onNotificationOpenedApp', remoteMessage)
             Logger.logAppPushOpen({
               title: remoteMessage.notification?.title || '',

--- a/src/screens/SearchScreen/index.tsx
+++ b/src/screens/SearchScreen/index.tsx
@@ -118,7 +118,10 @@ const SearchScreen = ({route}: ScreenProps<'Search'>) => {
   useEffect(() => {
     if (deepLinkSearchQuery) {
       setViewState({type: 'map', inputMode: false});
-      onQueryUpdate({text: deepLinkSearchQuery}, {shouldAnimate: true, shouldRecordHistory: true});
+      onQueryUpdate(
+        {text: deepLinkSearchQuery},
+        {shouldAnimate: true, shouldRecordHistory: true},
+      );
     }
   }, [deepLinkSearchQuery]);
 


### PR DESCRIPTION
- 앱 푸시 오픈율을 추적하기 위해 app_push_open 이벤트를 새롭게 로깅합니다.
  - 발송 모수는 서버에서 쌓는 푸시 발송 이력 테이블이 있어서 그걸 쓸 예정입니다.
- 원래 https://support.google.com/analytics/answer/9234069?hl=ko <- `notification_open` 이라는 기본 이벤트가 있어서 이걸 쓰려고 했는데, 어떻게 해도 campaign id 같은 걸 담는 게 안 돼서 그냥 커스텀 이벤트를 쏘게 만들었습니다.
- 몇 가지 notable한 수정사항이 있습니다.
  - 이벤트 발송 라이브러리의 userId 셋업을 원래 useMe()에서만 해주고 있었는데, useMe()가 호출되기 전에도 이벤트를 쏘는 상황이 생길 수 있을 것 같아서 index.js에서 userId를 셋업해주도록 수정합니다.
  - 이벤트 로깅 QA를 보다 수월하게 할 수 있도록, `-FIRDebugEnabled` 옵션을 sandbox 앱에서는 기본으로 켜도록 수정합니다. 이러면 클라가 쏘는 이벤트를 [firebase debugView](https://console.firebase.google.com/u/0/project/staircrusherclub/analytics/app/android:club.staircrusher.sandbox/debugview/realtime~2Fdebugview%3Ffpn%3D633681505724?hl=ko)에서 실시간으로 확인할 수 있게 됩니다. android는 adb 설정을 별도로 해야 해서 패스...
  - 앱 푸시를 핸들링하는 로직이 index.js와 RootScreen.tsx에 흩어져 있었는데, RootScreen.tsx로 모았습니다.
  - https://github.com/invertase/react-native-firebase/issues/7749#issuecomment-2075084174 <- QA하다가 이런 이슈를 맞아서 해결해뒀습니다.