### PR TITLE
안드로이드에서 KeyboardAvoidingView bottom이 잘못 잡히는 문제 해결

### DIFF
--- a/scripts/sync-env-local.js
+++ b/scripts/sync-env-local.js
@@ -21,4 +21,4 @@ content = content.replace(/^FLAVOR=.*$/m, 'FLAVOR=local');
 fs.writeFileSync(LOCAL_ENV_PATH, content);
 
 console.log(`✅ Successfully synced ${LOCAL_ENV_PATH} from ${SANDBOX_ENV_PATH}`);
-console.log('📝 BASE_URL will be set dynamically based on platform (iOS: localhost:3000, Android: 10.0.2.2:3000)');
+console.log('📝 BASE_URL will be set dynamically based on platform (iOS: localhost:8080, Android: 10.0.2.2:8080)');

--- a/src/components/ScreenLayout.tsx
+++ b/src/components/ScreenLayout.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import {KeyboardAvoidingView, Platform, ViewProps} from 'react-native';
+import React, {useEffect, useState} from 'react';
+import {Keyboard, KeyboardAvoidingView, Platform, ViewProps} from 'react-native';
 import {Edge, useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {SafeAreaWrapper} from '@/components/SafeAreaWrapper';
@@ -21,10 +21,27 @@ export const ScreenLayout = ({
   style = {},
 }: ScreenLayoutProps) => {
   const insets = useSafeAreaInsets();
+  const [isKeyboardShownInAndroid, setIsKeyboardShownInAndroid] = useState<boolean>(false);
   let verticalOffset = 0;
   if (isHeaderVisible) {
     verticalOffset = HEIGHT_OF_NAVIGATION_HEADER + insets.top;
   }
+
+  // https://github.com/facebook/react-native/pull/51132
+  // 현재 RN 0.80 버전의 KeyboardAvoidingView의 경우, 안드로이드에서 키보드가 show / hide 될 때
+  // bottom padding / height가 올바르게 계산되지 않는 문제가 있다.
+  // 이를 해결해주기 위해, android에서는 키보드가 가려질 때 강제로 enabled를 false로 설정하게끔 한다.
+  useEffect(() => {
+    if (Platform.OS === 'android') {
+      const subscriptions = [
+        Keyboard.addListener('keyboardDidHide', () => setIsKeyboardShownInAndroid(false)),
+        Keyboard.addListener('keyboardDidShow', () => setIsKeyboardShownInAndroid(true)),
+      ]
+      return () => {
+        subscriptions.forEach(it => it.remove())
+      }
+    }
+  }, []);
 
   return (
     <SafeAreaWrapper
@@ -32,7 +49,7 @@ export const ScreenLayout = ({
       style={[{flex: 1, backgroundColor: color.white}, style]}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        enabled={isKeyboardAvoidingView ?? true}
+        enabled={(isKeyboardAvoidingView && (Platform.OS !=='android' || isKeyboardShownInAndroid)) ?? true}
         keyboardVerticalOffset={verticalOffset}
         style={[{flex: 1}, style]}>
         {children}


### PR DESCRIPTION
- https://github.com/facebook/react-native/pull/51132 <- RN 0.80.0 버전으로 올린 이후에, KeyboardAvoidingView를 android에서 사용할 때 키보드가 닫히는 시점에 bottom padding/height가 잘못 계산되는 문제가 있어 보입니다.
- 첫 번째로 시도한 해결책은 [react-native-keyboard-controller 라이브러리](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-avoiding-view)를 사용하는 것이었습니다. 근데 써보니까 약간 디자인 이슈가 있는데, 다 잡기 좀 어려워보여서 기각했습니다.
  - 기본적으로 bottom safe area가 무조건 잡혀 있음
  - 애니메이션 드드득거림
  - 등등
- 삽질을 좀 하다가, 결국 https://github.com/facebook/react-native/pull/51132 <- 이 패치도 안드로이드에서 키보드가 꺼질 때 특수 로직을 넣는 것이 목적이라는 점에서 착안해서 keyboardDidShow / keyboardDidHide 이벤트를 구독해서 강제로 KeyboardAvoidingView.enabled를 조절해줘서 해결했습니다.
  - keyboardDidShow / keyboardDidHide 구독하는 구현은 KeyboardAvoidingView 내부 구현을 참고했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android keyboard handling so the layout only adjusts when the keyboard is actually shown, reducing overlap and visual flicker; iOS behavior remains unchanged.

* **Chores**
  * Standardized local environment sync messaging to reference port 8080 for both iOS and Android.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->