### PR TITLE
feat: 홈 팝업 모달 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,31 @@ After any code changes or implementation work, **ALWAYS** run these validation c
 - Optional `disableLogging` prop to completely disable event logging
 - Automatic duplicate element detection via global registry
 
+### SccRemoteImage (원격 이미지 필수)
+- **원격 URL 이미지를 표시할 때 `<Image source={{uri: ...}}>` 직접 사용 금지. 반드시 `SccRemoteImage` 사용.**
+- `SccRemoteImage`는 `Image.getSize` + 메모리 캐시 + 비율 자동 계산을 추상화한 컴포넌트
+- width를 지정하면 원본 비율에 맞춰 height를 자동 계산 (별도 `Image.getSize` useEffect 불필요)
+- `fixedHeight` prop으로 height 고정 + width 자동 계산 모드도 지원
+- `wrapperBackgroundColor`로 로딩 중 배경색 제어 (null이면 투명)
+
+```typescript
+import SccRemoteImage from '@/components/SccRemoteImage';
+
+// 기본: width 지정 → height 자동
+<SccRemoteImage
+  imageUrl={imageUrl}
+  style={{width: 300}}
+  resizeMode="cover"
+/>
+
+// height 고정 모드
+<SccRemoteImage
+  imageUrl={imageUrl}
+  fixedHeight={200}
+  resizeMode="cover"
+/>
+```
+
 ### Event Logging
 - `element_view` logged on component mount
 - `element_click` logged on press events

--- a/src/atoms/User.ts
+++ b/src/atoms/User.ts
@@ -83,6 +83,11 @@ export const placeFormV2GuideDismissedUntilAtom =
     },
   );
 
+// 홈 팝업 "다시 보지 않기" 상태 (팝업 ID → dismissed 여부)
+export const dismissedHomePopupIdsAtom = atomForLocalNonNull<
+  Record<string, boolean>
+>('dismissedHomePopupIds', {});
+
 export const recentlyUsedMobilityToolAtom = atomForLocal<{
   name: UserMobilityToolMapDto;
   timestamp: number;

--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -289,7 +289,8 @@ export const ApiErrorResponseCodeEnum = {
     CHALLENGE_CLOSED: '13',
     INVALID_BIRTH_YEAR: '14',
     B2B_INFO_REQUIRED: '15',
-    PHONE_NUMBER_VERIFICATION_FAILED: '20'
+    PHONE_NUMBER_VERIFICATION_FAILED: '16',
+    CHALLENGE_FULL: '20'
 } as const;
 
 export type ApiErrorResponseCodeEnum = typeof ApiErrorResponseCodeEnum[keyof typeof ApiErrorResponseCodeEnum];
@@ -2359,6 +2360,12 @@ export interface GetHomeScreenDataResponseDto {
      * @memberof GetHomeScreenDataResponseDto
      */
     'recommendedContents': Array<HomeRecommendedContentDto>;
+    /**
+     * 홈 화면 팝업 (활성 상태, displayOrder 오름차순)
+     * @type {Array<HomePopupDto>}
+     * @memberof GetHomeScreenDataResponseDto
+     */
+    'homePopups': Array<HomePopupDto>;
 }
 /**
  * 
@@ -2712,6 +2719,31 @@ export interface HomeBannerDto {
      * @memberof HomeBannerDto
      */
     'clickPageTitle': string;
+}
+/**
+ * 홈 화면 팝업
+ * @export
+ * @interface HomePopupDto
+ */
+export interface HomePopupDto {
+    /**
+     * 
+     * @type {string}
+     * @memberof HomePopupDto
+     */
+    'id': string;
+    /**
+     * 팝업 이미지 URL (제목 텍스트도 이미지에 포함)
+     * @type {string}
+     * @memberof HomePopupDto
+     */
+    'imageUrl': string;
+    /**
+     * 노출 순서 (작을수록 높은 우선순위)
+     * @type {number}
+     * @memberof HomePopupDto
+     */
+    'displayOrder': number;
 }
 /**
  * 홈 화면 추천 컨텐츠

--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -109,9 +109,13 @@ const HomeScreenV2 = ({navigation}: any) => {
     if (!showPopupThisSession) {
       return null;
     }
+    // 튜토리얼이 진행 중이면 팝업을 보여주지 않음
+    if (needsTutorial && !hasShownHomeTutorial) {
+      return null;
+    }
     const popups = homeData?.homePopups ?? [];
     return popups.find(p => !dismissedPopupIds[p.id]) ?? null;
-  }, [homeData?.homePopups, dismissedPopupIds, showPopupThisSession]);
+  }, [homeData?.homePopups, dismissedPopupIds, showPopupThisSession, needsTutorial, hasShownHomeTutorial]);
 
   // 튜토리얼: 마운트 시점부터 이미지 렌더(디코딩), 1.5초 후 zIndex 올려서 표시
   // Deferred deep link가 있으면 이번에는 tutorial 스킵 (hasShownHomeTutorial은 세팅하지 않아 다음에 정상 노출)

--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -125,7 +125,13 @@ const HomeScreenV2 = ({navigation}: any) => {
     }
     const popups = homeData?.homePopups ?? [];
     return popups.find(p => !dismissedPopupIds[p.id]) ?? null;
-  }, [homeData?.homePopups, dismissedPopupIds, showPopupThisSession, needsTutorial, hasShownHomeTutorial]);
+  }, [
+    homeData?.homePopups,
+    dismissedPopupIds,
+    showPopupThisSession,
+    needsTutorial,
+    hasShownHomeTutorial,
+  ]);
 
   useEffect(() => {
     if (!needsTutorial) {

--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -4,8 +4,8 @@ import {
 } from '@react-native-firebase/messaging';
 import {useFocusEffect} from '@react-navigation/native';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {useAtomValue, useSetAtom} from 'jotai';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {useAtom, useAtomValue, useSetAtom} from 'jotai';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
   BackHandler,
   Dimensions,
@@ -25,7 +25,10 @@ import styled from 'styled-components/native';
 import CrusherClubLogo from '@/assets/icon/logo.svg';
 import {accessTokenAtom, isAnonymousUserAtom, useMe} from '@/atoms/Auth';
 import {currentLocationAtom} from '@/atoms/Location';
-import {hasShownHomeTutorialAtom} from '@/atoms/User';
+import {
+  dismissedHomePopupIdsAtom,
+  hasShownHomeTutorialAtom,
+} from '@/atoms/User';
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {color} from '@/constant/color';
 import {GetClientVersionStatusResponseDtoStatusEnum} from '@/generated-sources/openapi';
@@ -48,6 +51,7 @@ import QuickMenuSection from './sections/QuickMenuSection';
 import RecommendedContentSection from './sections/RecommendedContentSection';
 import SearchButtonSection from './sections/SearchButtonSection';
 import StripBannerSection from './sections/StripBannerSection';
+import HomePopupModal from './components/HomePopupModal';
 import TutorialOverlay from './components/TutorialOverlay';
 
 export interface HomeScreenV2Params {}
@@ -95,6 +99,19 @@ const HomeScreenV2 = ({navigation}: any) => {
   const isAnonymousUser = useAtomValue(isAnonymousUserAtom);
   const hasShownHomeTutorial = useAtomValue(hasShownHomeTutorialAtom);
   const setHasShownHomeTutorial = useSetAtom(hasShownHomeTutorialAtom);
+
+  // 홈 팝업 상태
+  const [dismissedPopupIds, setDismissedPopupIds] = useAtom(
+    dismissedHomePopupIdsAtom,
+  );
+  const [showPopupThisSession, setShowPopupThisSession] = useState(true);
+  const activePopup = useMemo(() => {
+    if (!showPopupThisSession) {
+      return null;
+    }
+    const popups = homeData?.homePopups ?? [];
+    return popups.find(p => !dismissedPopupIds[p.id]) ?? null;
+  }, [homeData?.homePopups, dismissedPopupIds, showPopupThisSession]);
 
   // 튜토리얼: 마운트 시점부터 이미지 렌더(디코딩), 1.5초 후 zIndex 올려서 표시
   // Deferred deep link가 있으면 이번에는 tutorial 스킵 (hasShownHomeTutorial은 세팅하지 않아 다음에 정상 노출)
@@ -365,6 +382,20 @@ const HomeScreenV2 = ({navigation}: any) => {
               onConfirmButtonPressed={openStore}
               onCloseButtonPressed={() => {
                 setShowAppUpgradeNeeded(false);
+              }}
+            />
+          )}
+          {activePopup && (
+            <HomePopupModal
+              popup={activePopup}
+              visible={true}
+              onClose={() => setShowPopupThisSession(false)}
+              onDismissPermanently={() => {
+                setDismissedPopupIds(prev => ({
+                  ...prev,
+                  [activePopup.id]: true,
+                }));
+                setShowPopupThisSession(false);
               }}
             />
           )}

--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -100,6 +100,16 @@ const HomeScreenV2 = ({navigation}: any) => {
   const hasShownHomeTutorial = useAtomValue(hasShownHomeTutorialAtom);
   const setHasShownHomeTutorial = useSetAtom(hasShownHomeTutorialAtom);
 
+  // 튜토리얼: 마운트 시점부터 이미지 렌더(디코딩), 1.5초 후 zIndex 올려서 표시
+  // Deferred deep link가 있으면 이번에는 tutorial 스킵 (hasShownHomeTutorial은 세팅하지 않아 다음에 정상 노출)
+  const [needsTutorial] = useState(() => {
+    if (getDeferredDeepLinkUrl()) {
+      return false;
+    }
+    return !hasShownHomeTutorial;
+  });
+  const [tutorialVisible, setTutorialVisible] = useState(false);
+
   // 홈 팝업 상태
   const [dismissedPopupIds, setDismissedPopupIds] = useAtom(
     dismissedHomePopupIdsAtom,
@@ -116,16 +126,6 @@ const HomeScreenV2 = ({navigation}: any) => {
     const popups = homeData?.homePopups ?? [];
     return popups.find(p => !dismissedPopupIds[p.id]) ?? null;
   }, [homeData?.homePopups, dismissedPopupIds, showPopupThisSession, needsTutorial, hasShownHomeTutorial]);
-
-  // 튜토리얼: 마운트 시점부터 이미지 렌더(디코딩), 1.5초 후 zIndex 올려서 표시
-  // Deferred deep link가 있으면 이번에는 tutorial 스킵 (hasShownHomeTutorial은 세팅하지 않아 다음에 정상 노출)
-  const [needsTutorial] = useState(() => {
-    if (getDeferredDeepLinkUrl()) {
-      return false;
-    }
-    return !hasShownHomeTutorial;
-  });
-  const [tutorialVisible, setTutorialVisible] = useState(false);
 
   useEffect(() => {
     if (!needsTutorial) {

--- a/src/screens/HomeScreenV2/components/HomePopupModal.tsx
+++ b/src/screens/HomeScreenV2/components/HomePopupModal.tsx
@@ -1,8 +1,9 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {Dimensions, Image, Modal} from 'react-native';
+import {Dimensions, Modal} from 'react-native';
 import styled from 'styled-components/native';
 
 import CloseIcon from '@/assets/icon/close.svg';
+import SccRemoteImage from '@/components/SccRemoteImage';
 import {SccPressable} from '@/components/SccPressable';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
@@ -26,33 +27,12 @@ export default function HomePopupModal({
   onClose,
   onDismissPermanently,
 }: HomePopupModalProps) {
-  const [imageHeight, setImageHeight] = useState<number>(POPUP_WIDTH);
   const [doNotShowAgain, setDoNotShowAgain] = useState(false);
 
   // 팝업이 바뀌면 체크박스 상태 초기화
   useEffect(() => {
     setDoNotShowAgain(false);
   }, [popup.id]);
-
-  useEffect(() => {
-    let cancelled = false;
-    Image.getSize(
-      popup.imageUrl,
-      (width, height) => {
-        if (!cancelled) {
-          setImageHeight(POPUP_WIDTH * (height / width));
-        }
-      },
-      () => {
-        if (!cancelled) {
-          setImageHeight(POPUP_WIDTH);
-        }
-      },
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, [popup.imageUrl]);
 
   const handleClose = useCallback(() => {
     if (doNotShowAgain) {
@@ -80,10 +60,11 @@ export default function HomePopupModal({
         />
         <ContentContainer>
           <ImageContainer>
-            <PopupImage
-              source={{uri: popup.imageUrl}}
-              style={{width: POPUP_WIDTH, height: imageHeight}}
+            <SccRemoteImage
+              imageUrl={popup.imageUrl}
+              style={{width: POPUP_WIDTH}}
               resizeMode="cover"
+              wrapperBackgroundColor={null}
             />
             <CloseButton
               elementName="home-popup-close-button"
@@ -135,8 +116,6 @@ const ImageContainer = styled.View`
   border-top-right-radius: ${BORDER_RADIUS}px;
   overflow: hidden;
 `;
-
-const PopupImage = styled(Image)``;
 
 const CloseButton = styled(SccPressable)`
   position: absolute;

--- a/src/screens/HomeScreenV2/components/HomePopupModal.tsx
+++ b/src/screens/HomeScreenV2/components/HomePopupModal.tsx
@@ -1,0 +1,183 @@
+import React, {useCallback, useEffect, useState} from 'react';
+import {Dimensions, Image, Modal} from 'react-native';
+import styled from 'styled-components/native';
+
+import CloseIcon from '@/assets/icon/close.svg';
+import {SccPressable} from '@/components/SccPressable';
+import {color} from '@/constant/color';
+import {font} from '@/constant/font';
+import type {HomePopupDto} from '@/generated-sources/openapi';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const POPUP_HORIZONTAL_PADDING = 24;
+const POPUP_WIDTH = SCREEN_WIDTH - POPUP_HORIZONTAL_PADDING * 2;
+const BORDER_RADIUS = 12;
+
+interface HomePopupModalProps {
+  popup: HomePopupDto;
+  visible: boolean;
+  onClose: () => void;
+  onDismissPermanently: () => void;
+}
+
+export default function HomePopupModal({
+  popup,
+  visible,
+  onClose,
+  onDismissPermanently,
+}: HomePopupModalProps) {
+  const [imageHeight, setImageHeight] = useState<number>(POPUP_WIDTH);
+  const [doNotShowAgain, setDoNotShowAgain] = useState(false);
+
+  useEffect(() => {
+    Image.getSize(
+      popup.imageUrl,
+      (width, height) => {
+        setImageHeight(POPUP_WIDTH * (height / width));
+      },
+      () => {
+        // fallback: 1:1 aspect ratio
+        setImageHeight(POPUP_WIDTH);
+      },
+    );
+  }, [popup.imageUrl]);
+
+  const handleClose = useCallback(() => {
+    if (doNotShowAgain) {
+      onDismissPermanently();
+    } else {
+      onClose();
+    }
+  }, [doNotShowAgain, onClose, onDismissPermanently]);
+
+  const toggleDoNotShowAgain = useCallback(() => {
+    setDoNotShowAgain(prev => !prev);
+  }, []);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      statusBarTranslucent>
+      <Overlay>
+        <BackgroundTouchable
+          elementName="home-popup-overlay-background"
+          onPress={handleClose}
+          disableLogging
+        />
+        <ContentContainer>
+          <ImageContainer>
+            <PopupImage
+              source={{uri: popup.imageUrl}}
+              style={{width: POPUP_WIDTH, height: imageHeight}}
+              resizeMode="cover"
+            />
+            <CloseButton
+              elementName="home-popup-close-button"
+              onPress={handleClose}>
+              <CloseIconWrapper>
+                <CloseIcon width={12} height={12} color={color.white} />
+              </CloseIconWrapper>
+            </CloseButton>
+          </ImageContainer>
+          <BottomContainer>
+            <CheckboxRow
+              elementName="home-popup-do-not-show-again"
+              onPress={toggleDoNotShowAgain}>
+              <Checkbox isChecked={doNotShowAgain}>
+                {doNotShowAgain && <CheckMark>✓</CheckMark>}
+              </Checkbox>
+              <CheckboxLabel>다시 보지 않기</CheckboxLabel>
+            </CheckboxRow>
+          </BottomContainer>
+        </ContentContainer>
+      </Overlay>
+    </Modal>
+  );
+}
+
+// Styled components
+
+const Overlay = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  background-color: ${color.blacka50};
+`;
+
+const BackgroundTouchable = styled(SccPressable)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+const ContentContainer = styled.View`
+  width: ${POPUP_WIDTH}px;
+`;
+
+const ImageContainer = styled.View`
+  border-top-left-radius: ${BORDER_RADIUS}px;
+  border-top-right-radius: ${BORDER_RADIUS}px;
+  overflow: hidden;
+`;
+
+const PopupImage = styled(Image)``;
+
+const CloseButton = styled(SccPressable)`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 28px;
+  height: 28px;
+  border-radius: 14px;
+  background-color: ${color.blacka40};
+  justify-content: center;
+  align-items: center;
+`;
+
+const CloseIconWrapper = styled.View`
+  justify-content: center;
+  align-items: center;
+`;
+
+const BottomContainer = styled.View`
+  background-color: ${color.white};
+  border-bottom-left-radius: ${BORDER_RADIUS}px;
+  border-bottom-right-radius: ${BORDER_RADIUS}px;
+  padding-horizontal: 16px;
+  padding-vertical: 12px;
+`;
+
+const CheckboxRow = styled(SccPressable)`
+  flex-direction: row;
+  align-items: center;
+`;
+
+const Checkbox = styled.View<{isChecked: boolean}>`
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border-width: 1.5px;
+  border-color: ${({isChecked}) => (isChecked ? color.brand : color.gray40)};
+  background-color: ${({isChecked}) =>
+    isChecked ? color.brand : 'transparent'};
+  justify-content: center;
+  align-items: center;
+  margin-right: 8px;
+`;
+
+const CheckMark = styled.Text`
+  color: ${color.white};
+  font-size: 13px;
+  font-family: ${font.pretendardBold};
+  line-height: 16px;
+`;
+
+const CheckboxLabel = styled.Text`
+  font-size: 14px;
+  font-family: ${font.pretendardRegular};
+  color: ${color.gray80};
+`;

--- a/src/screens/HomeScreenV2/components/HomePopupModal.tsx
+++ b/src/screens/HomeScreenV2/components/HomePopupModal.tsx
@@ -29,17 +29,29 @@ export default function HomePopupModal({
   const [imageHeight, setImageHeight] = useState<number>(POPUP_WIDTH);
   const [doNotShowAgain, setDoNotShowAgain] = useState(false);
 
+  // 팝업이 바뀌면 체크박스 상태 초기화
   useEffect(() => {
+    setDoNotShowAgain(false);
+  }, [popup.id]);
+
+  useEffect(() => {
+    let cancelled = false;
     Image.getSize(
       popup.imageUrl,
       (width, height) => {
-        setImageHeight(POPUP_WIDTH * (height / width));
+        if (!cancelled) {
+          setImageHeight(POPUP_WIDTH * (height / width));
+        }
       },
       () => {
-        // fallback: 1:1 aspect ratio
-        setImageHeight(POPUP_WIDTH);
+        if (!cancelled) {
+          setImageHeight(POPUP_WIDTH);
+        }
       },
     );
+    return () => {
+      cancelled = true;
+    };
   }, [popup.imageUrl]);
 
   const handleClose = useCallback(() => {

--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -247,7 +247,8 @@ export default function useSearchRequest() {
     onFetchCompleted.current = (result: SearchResultItem[]) => {
       if (keyboardRef.current.keyboardShown) {
         // 키보드가 올라와 있으면 실행 연기
-        cameraFitDeferredUntilKeyboardDismissRef.current = () => callback(result);
+        cameraFitDeferredUntilKeyboardDismissRef.current = () =>
+          callback(result);
       } else {
         // 키보드가 내려가 있으면 즉시 실행
         setTimeout(() => callback(result), 100); // 지도 하단의 카드 리스트가 그려지는 것을 기다리기 위해 100ms 기다렸다가 렌더링한다. (100ms는 heuristic)
@@ -275,7 +276,10 @@ export default function useSearchRequest() {
 
   // 키보드가 내려가면 pending callback 실행
   useEffect(() => {
-    if (!keyboard.keyboardShown && cameraFitDeferredUntilKeyboardDismissRef.current) {
+    if (
+      !keyboard.keyboardShown &&
+      cameraFitDeferredUntilKeyboardDismissRef.current
+    ) {
       const pendingCallback = cameraFitDeferredUntilKeyboardDismissRef.current;
       setTimeout(pendingCallback, 100); // 지도 하단의 카드 리스트가 그려지는 것을 기다리기 위해 100ms 기다렸다가 렌더링한다. (100ms는 heuristic)
       cameraFitDeferredUntilKeyboardDismissRef.current = null;


### PR DESCRIPTION
## Summary
- `HomePopupModal`: 이미지 기반 팝업 (X 닫기 + 다시보지않기 체크박스)
- `HomeScreenV2`에 팝업 통합 (앱 오픈 후 최초 홈 진입 시 표시)
- `dismissedHomePopupIdsAtom`: MMKV 기반 팝업별 영구 dismiss 관리
- 튜토리얼 진행 중 팝업 동시 노출 방지

## Dependencies
- Stair-Crusher-Club/scc-api#100
- Stair-Crusher-Club/scc-server#909

## Test plan
- [x] `yarn tsc --noEmit` 통과
- [x] `yarn lint` 통과
- [x] 에뮬레이터: 팝업 정상 노출 (이미지 + X + 다시보지않기)
- [x] X 닫기 → 세션 내 재노출 없음
- [x] 앱 재시작 → 팝업 다시 뜸 (dismiss 안 한 경우)
- [x] "다시 보지 않기" 체크 후 닫기 → 앱 재시작해도 미노출
- [x] 튜토리얼 + 팝업 동시 노출 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home screen now shows promotional popups with ordered images.
  * Popups can be dismissed for the session or permanently via a "do not show again" option.
  * Popups use responsive image sizing and accessible close controls.

* **Bug Fixes**
  * Adjusted error code mapping related to phone verification flows.

* **Documentation**
  * Added guidelines for using the SccRemoteImage component for remote images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->