### PR TITLE
feat: 홈 팝업 UX 개선 — 로딩/딥링크/다시보지않기

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -2739,6 +2739,12 @@ export interface HomePopupDto {
      */
     'imageUrl': string;
     /**
+     * 클릭 시 이동할 URL (딥링크). 없으면 클릭 시 dismiss만.
+     * @type {string}
+     * @memberof HomePopupDto
+     */
+    'clickUrl'?: string;
+    /**
      * 노출 순서 (작을수록 높은 우선순위)
      * @type {number}
      * @memberof HomePopupDto

--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -134,6 +134,12 @@ const HomeScreenV2 = ({navigation}: any) => {
   ]);
 
   useEffect(() => {
+    if (activePopup) {
+      Image.prefetch(activePopup.imageUrl);
+    }
+  }, [activePopup?.imageUrl]);
+
+  useEffect(() => {
     if (!needsTutorial) {
       return;
     }
@@ -401,6 +407,9 @@ const HomeScreenV2 = ({navigation}: any) => {
               visible={true}
               onClose={() => setShowPopupThisSession(false)}
               onDismissPermanently={() => {
+                if (activePopup.clickUrl) {
+                  Linking.openURL(activePopup.clickUrl).catch(() => {});
+                }
                 setDismissedPopupIds(prev => ({
                   ...prev,
                   [activePopup.id]: true,

--- a/src/screens/HomeScreenV2/components/HomePopupModal.tsx
+++ b/src/screens/HomeScreenV2/components/HomePopupModal.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {Dimensions, Modal} from 'react-native';
 import styled from 'styled-components/native';
 
@@ -27,24 +27,7 @@ export default function HomePopupModal({
   onClose,
   onDismissPermanently,
 }: HomePopupModalProps) {
-  const [doNotShowAgain, setDoNotShowAgain] = useState(false);
-
-  // 팝업이 바뀌면 체크박스 상태 초기화
-  useEffect(() => {
-    setDoNotShowAgain(false);
-  }, [popup.id]);
-
-  const handleClose = useCallback(() => {
-    if (doNotShowAgain) {
-      onDismissPermanently();
-    } else {
-      onClose();
-    }
-  }, [doNotShowAgain, onClose, onDismissPermanently]);
-
-  const toggleDoNotShowAgain = useCallback(() => {
-    setDoNotShowAgain(prev => !prev);
-  }, []);
+  const [imageReady, setImageReady] = useState(false);
 
   return (
     <Modal
@@ -55,36 +38,51 @@ export default function HomePopupModal({
       <Overlay>
         <BackgroundTouchable
           elementName="home-popup-overlay-background"
-          onPress={handleClose}
+          onPress={onClose}
           disableLogging
         />
-        <ContentContainer>
-          <ImageContainer>
+        {imageReady && (
+          <ContentContainer>
+            <ImageContainer>
+              <SccPressable
+                elementName="home-popup-image"
+                onPress={onDismissPermanently}>
+                <SccRemoteImage
+                  imageUrl={popup.imageUrl}
+                  style={{width: POPUP_WIDTH}}
+                  resizeMode="cover"
+                  wrapperBackgroundColor={null}
+                  onReady={() => setImageReady(true)}
+                />
+              </SccPressable>
+              <CloseButton
+                elementName="home-popup-close-button"
+                onPress={onClose}>
+                <CloseIconWrapper>
+                  <CloseIcon width={12} height={12} color={color.white} />
+                </CloseIconWrapper>
+              </CloseButton>
+            </ImageContainer>
+            <BottomContainer>
+              <SccPressable
+                elementName="home-popup-do-not-show-again"
+                onPress={onDismissPermanently}>
+                <DismissText>다시 보지 않기</DismissText>
+              </SccPressable>
+            </BottomContainer>
+          </ContentContainer>
+        )}
+        {!imageReady && (
+          <HiddenImageLoader>
             <SccRemoteImage
               imageUrl={popup.imageUrl}
               style={{width: POPUP_WIDTH}}
               resizeMode="cover"
               wrapperBackgroundColor={null}
+              onReady={() => setImageReady(true)}
             />
-            <CloseButton
-              elementName="home-popup-close-button"
-              onPress={handleClose}>
-              <CloseIconWrapper>
-                <CloseIcon width={12} height={12} color={color.white} />
-              </CloseIconWrapper>
-            </CloseButton>
-          </ImageContainer>
-          <BottomContainer>
-            <CheckboxRow
-              elementName="home-popup-do-not-show-again"
-              onPress={toggleDoNotShowAgain}>
-              <Checkbox isChecked={doNotShowAgain}>
-                {doNotShowAgain && <CheckMark>✓</CheckMark>}
-              </Checkbox>
-              <CheckboxLabel>다시 보지 않기</CheckboxLabel>
-            </CheckboxRow>
-          </BottomContainer>
-        </ContentContainer>
+          </HiddenImageLoader>
+        )}
       </Overlay>
     </Modal>
   );
@@ -142,33 +140,15 @@ const BottomContainer = styled.View`
   padding-vertical: 12px;
 `;
 
-const CheckboxRow = styled(SccPressable)`
-  flex-direction: row;
-  align-items: center;
-`;
-
-const Checkbox = styled.View<{isChecked: boolean}>`
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
-  border-width: 1.5px;
-  border-color: ${({isChecked}) => (isChecked ? color.brand : color.gray40)};
-  background-color: ${({isChecked}) =>
-    isChecked ? color.brand : 'transparent'};
-  justify-content: center;
-  align-items: center;
-  margin-right: 8px;
-`;
-
-const CheckMark = styled.Text`
-  color: ${color.white};
-  font-size: 13px;
-  font-family: ${font.pretendardBold};
-  line-height: 16px;
-`;
-
-const CheckboxLabel = styled.Text`
+const DismissText = styled.Text`
   font-size: 14px;
   font-family: ${font.pretendardRegular};
   color: ${color.gray80};
+  text-decoration-line: underline;
+`;
+
+const HiddenImageLoader = styled.View`
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 `;


### PR DESCRIPTION
## Summary
- 이미지 로드 완료 후 팝업 표시 (SccRemoteImage onReady + Image.prefetch)
- 이미지 클릭 → clickUrl 딥링크 + 영구 dismiss
- '다시 보지 않기' → 밑줄 텍스트, 즉시 영구 dismiss
- X 버튼/배경 탭 → 세션 dismiss만

## Test plan
- [x] `yarn tsc --noEmit` 통과
- [x] `yarn lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)