### PR TITLE
fix: 사진 업로드 안정성 개선 및 앱 강제 종료 원인 제거

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,9 @@
 import {HotUpdater} from '@hot-updater/react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import {getAnalytics} from '@react-native-firebase/analytics';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import globalAxios, {AxiosError, InternalAxiosRequestConfig} from 'axios';
 import {Provider, useAtomValue, useSetAtom} from 'jotai';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import {Platform, StatusBar, View} from 'react-native';
 import Config from 'react-native-config';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
@@ -13,7 +12,6 @@ import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 import {AppComponentsProvider} from '@/AppComponentsContext';
 import {accessTokenAtom} from '@/atoms/Auth';
-import {storage} from '@/atoms/atomForLocal';
 import {LoadingView} from '@/components/LoadingView';
 import {color} from '@/constant/color';
 import SplashOverlay from '@/splash/SplashOverlay';
@@ -118,33 +116,8 @@ const App = () => {
   );
 };
 
-// do migration from AsyncStorage to MMKV
 const AppWithMigration = () => {
-  const [isMigrated, setIsMigrated] = useState(false);
-  useEffect(() => {
-    const migrateAsyncStorageToMMKV = async () => {
-      const allKeys = await AsyncStorage.multiGet([
-        'userInfo',
-        'hasShownGuideForFirstVisit',
-        'hasShownGuideForEnterancePhoto',
-        'scc-token',
-      ]);
-      allKeys.forEach(([key, value]) => {
-        if (value && storage.getString(key) === undefined) {
-          if (key === 'scc-token') {
-            // 토큰은 JSON 화된 문자열이 아닌 그대로 저장되어 있던 값이므로
-            // JSON 에 호환되는 문자열로 저장해야 한다.
-            storage.set(key, `"${value}"`);
-          } else {
-            storage.set(key, value);
-          }
-        }
-      });
-      setIsMigrated(true);
-    };
-    migrateAsyncStorageToMMKV();
-  }, []);
-  return isMigrated ? <AppWithProviders /> : null;
+  return <AppWithProviders />;
 };
 
 const HotUpdatedApp = HotUpdater.wrap({

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@hapi/hoek": "^11.0.4",
     "@hot-updater/react-native": "^0.12.4",
     "@invertase/react-native-apple-authentication": "^2.4.1",
-    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/geolocation": "^3.4.0",
     "@react-native-community/hooks": "^100.1.0",

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -125,6 +125,27 @@ const Logger = {
     getAnalytics().logEvent('upload_image', eventParams);
   },
 
+  async logUploadImageFailed(params: {
+    errorType: 'timeout' | 'network' | 'http_error' | 'unknown';
+    httpStatus?: number;
+    imageCount: number;
+    retryCount: number;
+    errorMessage: string;
+  }) {
+    logDebug('logUploadImageFailed', params, currUserPropertiesForDebugging);
+    const eventParams = {
+      error_type: params.errorType,
+      ...(params.httpStatus !== undefined && {
+        http_status: params.httpStatus,
+      }),
+      image_count: params.imageCount,
+      retry_count: params.retryCount,
+      error_message: params.errorMessage,
+    };
+    trackEvent('upload_image_failed', eventParams);
+    getAnalytics().logEvent('upload_image_failed', eventParams);
+  },
+
   async logError(error: Error) {
     logDebug('logError', error, currUserPropertiesForDebugging);
     crashlytics().recordError(error);

--- a/src/screens/CameraScreen/CameraScreen.tsx
+++ b/src/screens/CameraScreen/CameraScreen.tsx
@@ -1,7 +1,7 @@
 import ImageEditor from '@react-native-community/image-editor';
 import {useAtomValue} from 'jotai';
 import React, {useEffect, useState} from 'react';
-import {Dimensions, InteractionManager, Platform} from 'react-native';
+import {Dimensions, Platform} from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import {
   ImagePickerResponse,
@@ -105,12 +105,10 @@ export default function CameraScreen({
       return;
     }
     // TODO: navigation 에 non-serializable 값을 넘겨주면 안된다. (https://reactnavigation.org/docs/troubleshooting/#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state)
+    if (route.params && route.params.onPhotosTaken) {
+      route.params.onPhotosTaken(_photoFiles);
+    }
     navigation.goBack();
-    InteractionManager.runAfterInteractions(() => {
-      if (route.params && route.params.onPhotosTaken) {
-        route.params.onPhotosTaken(_photoFiles);
-      }
-    });
   }
 
   function onPressX(target: ImageFile) {

--- a/src/screens/CameraScreen/CameraScreen.tsx
+++ b/src/screens/CameraScreen/CameraScreen.tsx
@@ -164,8 +164,6 @@ export default function CameraScreen({
     const options = {
       mediaType: 'photo' as MediaType,
       includeBase64: false,
-      maxHeight: 2000,
-      maxWidth: 2000,
       selectionLimit: MAX_NUMBER_OF_TAKEN_PHOTOS,
     };
 

--- a/src/screens/CameraScreen/CameraScreen.tsx
+++ b/src/screens/CameraScreen/CameraScreen.tsx
@@ -1,7 +1,7 @@
 import ImageEditor from '@react-native-community/image-editor';
 import {useAtomValue} from 'jotai';
 import React, {useEffect, useState} from 'react';
-import {Dimensions, Platform} from 'react-native';
+import {Dimensions, InteractionManager, Platform} from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import {
   ImagePickerResponse,
@@ -105,10 +105,12 @@ export default function CameraScreen({
       return;
     }
     // TODO: navigation 에 non-serializable 값을 넘겨주면 안된다. (https://reactnavigation.org/docs/troubleshooting/#i-get-the-warning-non-serializable-values-were-found-in-the-navigation-state)
-    if (route.params && route.params.onPhotosTaken) {
-      route.params.onPhotosTaken(_photoFiles);
-    }
     navigation.goBack();
+    InteractionManager.runAfterInteractions(() => {
+      if (route.params && route.params.onPhotosTaken) {
+        route.params.onPhotosTaken(_photoFiles);
+      }
+    });
   }
 
   function onPressX(target: ImageFile) {
@@ -183,7 +185,6 @@ export default function CameraScreen({
             width: asset.width || 0,
             height: asset.height || 0,
           }));
-          setPhotoFiles(newImages); // 카메라로 찍은 사진을 무시하고 앨범에서 선택한 사진만 남긴다.
           confirm(newImages); // 즉시 카메라 스크린을 벗어난다.
         }
       });

--- a/src/utils/ImageFileUtils.ts
+++ b/src/utils/ImageFileUtils.ts
@@ -5,9 +5,44 @@ import {DefaultApi, ImageUploadPurpose} from '@/generated-sources/openapi';
 import Logger from '@/logging/Logger';
 import ImageFile from '@/models/ImageFile';
 
+const UPLOAD_TIMEOUT_MS = 30_000;
+
 interface UploadImageResult {
   url: string;
   size: number;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function classifyError(error: unknown): {
+  errorType: 'timeout' | 'network' | 'http_error' | 'unknown';
+  httpStatus?: number;
+} {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return {errorType: 'timeout'};
+  }
+  if (error instanceof Error && error.message.includes('timed out')) {
+    return {errorType: 'timeout'};
+  }
+  if (error instanceof UploadHttpError) {
+    return {errorType: 'http_error', httpStatus: error.httpStatus};
+  }
+  if (error instanceof TypeError) {
+    // fetch throws TypeError for network failures
+    return {errorType: 'network'};
+  }
+  return {errorType: 'unknown'};
+}
+
+class UploadHttpError extends Error {
+  httpStatus: number;
+  constructor(message: string, httpStatus: number) {
+    super(message);
+    this.name = 'UploadHttpError';
+    this.httpStatus = httpStatus;
+  }
 }
 
 /** presigned URL에 이미지 업로드 (내부 전용) */
@@ -18,26 +53,56 @@ async function uploadToPresignedUrl(
   const url = new URL(presignedUrl);
   const resp = await fetch(imageFileUrl);
   const imageBody = await resp.blob();
-  const result = await fetch(url.href, {
-    method: 'PUT',
-    headers: {
-      'content-type': imageBody.type,
-      'x-amz-acl': 'public-read',
-    },
-    body: imageBody,
-  });
-  if (result.ok) {
-    return {
-      url: url.protocol + '//' + url.host + url.pathname,
-      size: imageBody.size,
-    };
-  } else {
-    const resultString = await result.text();
-    const error = new Error(
-      `Upload image to ${result.url} is failed. cause: ${resultString}`,
-    );
-    Logger.logError(error);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+
+  try {
+    const result = await fetch(url.href, {
+      method: 'PUT',
+      headers: {
+        'content-type': imageBody.type,
+        'x-amz-acl': 'public-read',
+      },
+      body: imageBody,
+
+      signal: controller.signal as any,
+    });
+
+    if (result.ok) {
+      return {
+        url: url.protocol + '//' + url.host + url.pathname,
+        size: imageBody.size,
+      };
+    } else {
+      const resultString = await result.text();
+      throw new UploadHttpError(
+        `Upload image to ${result.url} is failed. cause: ${resultString}`,
+        result.status,
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(
+        `Image upload timed out after ${UPLOAD_TIMEOUT_MS / 1000}s`,
+      );
+    }
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/** 1회 재시도 포함 업로드 */
+async function uploadToPresignedUrlWithRetry(
+  presignedUrl: string,
+  imageFileUrl: string,
+): Promise<UploadImageResult> {
+  try {
+    return await uploadToPresignedUrl(presignedUrl, imageFileUrl);
+  } catch (_firstError) {
+    await delay(1000);
+    return await uploadToPresignedUrl(presignedUrl, imageFileUrl);
   }
 }
 
@@ -88,39 +153,76 @@ const ImageFileUtils = {
       Date.now() - startTimeOfGettingPresignedUrls;
 
     let durationOfUploadImages: Record<string, number> = {};
-    const uploadedUrls = await Promise.all(
-      images.map(async (image, index) => {
-        const url = uploadUrls[index];
-        if (url === undefined) {
-          throw new Error('There are not enough urls.');
-        }
-        const startTimeOfImageUpload = Date.now();
+    try {
+      const uploadedUrls = await Promise.all(
+        images.map(async (image, index) => {
+          const url = uploadUrls[index];
+          if (url === undefined) {
+            throw new Error('There are not enough urls.');
+          }
+          const startTimeOfImageUpload = Date.now();
 
-        const compressed = await ImageCompressor.compress(image.uri, {
-          compressionMethod: 'auto',
-          maxWidth: 2560,
-          maxHeight: 2560,
-          quality: 0.9,
-        });
-        const result = await uploadToPresignedUrl(url, compressed);
+          if (image.width === 0 || image.height === 0) {
+            Logger.logError(
+              new Error(
+                `Image at index ${index} has zero dimension: width=${image.width}, height=${image.height}`,
+              ),
+            );
+          }
 
-        durationOfUploadImages[`duration_millis_of_upload_image_${index}`] =
-          Date.now() - startTimeOfImageUpload;
-        durationOfUploadImages[`size_mb_of_image_${index}`] = floor(
-          result.size / (1024 * 1024),
-          2,
-        );
+          let compressedUri: string;
+          try {
+            compressedUri = await ImageCompressor.compress(image.uri, {
+              compressionMethod: 'auto',
+              maxWidth: 2560,
+              maxHeight: 2560,
+              quality: 0.9,
+            });
+          } catch (compressError) {
+            Logger.logError(
+              compressError instanceof Error
+                ? compressError
+                : new Error(String(compressError)),
+            );
+            compressedUri = image.uri;
+          }
 
-        return result.url;
-      }),
-    );
+          const result = await uploadToPresignedUrlWithRetry(
+            url,
+            compressedUri,
+          );
 
-    await Logger.logUploadImage({
-      ...durationOfUploadImages,
-      duration_millis_of_presigned_urls: durationOfGettingPresignedUrls,
-    });
+          durationOfUploadImages[`duration_millis_of_upload_image_${index}`] =
+            Date.now() - startTimeOfImageUpload;
+          durationOfUploadImages[`size_mb_of_image_${index}`] = floor(
+            result.size / (1024 * 1024),
+            2,
+          );
 
-    return uploadedUrls;
+          return result.url;
+        }),
+      );
+
+      await Logger.logUploadImage({
+        ...durationOfUploadImages,
+        duration_millis_of_presigned_urls: durationOfGettingPresignedUrls,
+      });
+
+      return uploadedUrls;
+    } catch (error) {
+      const {errorType, httpStatus} = classifyError(error);
+      await Logger.logUploadImageFailed({
+        errorType,
+        httpStatus,
+        imageCount: images.length,
+        retryCount: 1,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+      Logger.logError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      throw error;
+    }
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4807,17 +4807,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-async-storage/async-storage@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@react-native-async-storage/async-storage@npm:2.2.0"
-  dependencies:
-    merge-options: "npm:^3.0.4"
-  peerDependencies:
-    react-native: ^0.0.0-0 || >=0.65 <1.0
-  checksum: 10c0/84900eba46a40225c4ac9bf5eb58885200dc1e789d873ecda46a2a213870cc7110536ed1fd7a74b873071f3603c093958fbd84c635d6f6d4f94bfbb616ffa0ef
-  languageName: node
-  linkType: hard
-
 "@react-native-clipboard/clipboard@npm:^1.16.3":
   version: 1.16.3
   resolution: "@react-native-clipboard/clipboard@npm:1.16.3"
@@ -12284,13 +12273,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "is-plain-obj@npm:2.1.0"
-  checksum: 10c0/e5c9814cdaa627a9ad0a0964ded0e0491bfd9ace405c49a5d63c88b30a162f1512c069d5b80997893c4d0181eadc3fed02b4ab4b81059aba5620bfcdfdeb9c53
-  languageName: node
-  linkType: hard
-
 "is-plain-obj@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-plain-obj@npm:3.0.0"
@@ -13816,15 +13798,6 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
-  languageName: node
-  linkType: hard
-
-"merge-options@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "merge-options@npm:3.0.4"
-  dependencies:
-    is-plain-obj: "npm:^2.1.0"
-  checksum: 10c0/02b5891ceef09b0b497b5a0154c37a71784e68ed71b14748f6fd4258ffd3fe4ecd5cb0fd6f7cae3954fd11e7686c5cb64486daffa63c2793bbe8b614b61c7055
   languageName: node
   linkType: hard
 
@@ -16970,7 +16943,6 @@ __metadata:
     "@invertase/react-native-apple-authentication": "npm:^2.4.1"
     "@openapitools/openapi-generator-cli": "npm:^2.5.2"
     "@playwright/test": "npm:^1.55.0"
-    "@react-native-async-storage/async-storage": "npm:^2.2.0"
     "@react-native-clipboard/clipboard": "npm:^1.16.3"
     "@react-native-community/cli": "npm:^18.0.0"
     "@react-native-community/geolocation": "npm:^3.4.0"


### PR DESCRIPTION
## Summary

사용자 피드백 3건(사진 업로드 실패, 앨범 선택 느림, 앱 강제 종료)에 대한 대응

### 1. 사진 업로드 실패 빈도 감소
- S3 업로드에 **30초 timeout** 추가 (기존: 무제한)
- 실패 시 **1회 자동 retry** (1초 대기 후)
- 이미지 압축 실패 시 원본 URI로 fallback
- `upload_image_failed` Firebase Analytics 이벤트 추가 (에러 유형, HTTP status, 이미지 수 등)

### 2. 앨범 선택 후 화면 전환 속도 개선
- `CameraScreen`에서 앨범 선택 시 불필요한 `setPhotoFiles()` 리렌더 제거
- `goBack()` 먼저 호출 → 부모 콜백은 `InteractionManager.runAfterInteractions()`로 지연

### 3. 앱 강제 종료 원인 제거
- AsyncStorage 마이그레이션 코드 및 `@react-native-async-storage/async-storage` 의존성 제거
- Crashlytics에서 `AsyncStorageModule$1.doInBackgroundGuarded` crash 6건/6명 확인 — 앱 시작 시 매번 AsyncStorage.multiGet() 호출이 원인
- MMKV 마이그레이션은 이미 완료된 상태이므로 안전하게 제거 가능

## Test plan
- [ ] 네트워크 스로틀링 상태에서 사진 업로드 → timeout 후 retry 동작 확인
- [ ] 업로드 실패 시 Firebase Analytics에 `upload_image_failed` 이벤트 기록 확인
- [ ] 앨범에서 사진 3장 선택 → CameraScreen 닫히는 속도 체감 개선 확인
- [ ] 앱 설치 후 정상 동작 확인 (AsyncStorage 제거 후 regression 없는지)
- [ ] 지도 앱 전환 후 복귀 시 crash 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry logic for failed image uploads with timeout detection

* **Bug Fixes**
  * Improved error handling and classification for network, server, and timeout failures during image uploads
  * Enhanced error recovery for image compression

* **Chores**
  * Removed legacy storage migration flow
  * Cleaned up dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->