### PR TITLE
fix: 폐업 처리 후 goBack + 문 유형 기타 텍스트 수정

### DIFF
--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -91,6 +91,9 @@ function getCategoryLabel(
       const doorTypes = snapshot?.entranceDoorTypes;
       if (doorTypes && doorTypes.length > 0 && doorTypes.length <= 2) {
         const label = doorTypes.map(d => doorTypeMap[d]).join(', ');
+        if (label === '기타') {
+          return '출입문 유형이 잘못됐어요';
+        }
         return `${label}이 아니에요`;
       }
       return '출입문 종류가 잘못됐어요';

--- a/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
+++ b/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
@@ -1,4 +1,4 @@
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
   Alert,
@@ -112,6 +112,7 @@ export default function PlaceDetailV2Screen({
     useNavigateWithLocationCheck();
   const toggleFavorite = useToggleFavoritePlace();
   const toggleRequest = useToggleAccessibilityInfoRequest();
+  const queryClient = useQueryClient();
 
   const featureFlags = useAtomValue(featureFlagAtom);
   const isCrew = featureFlags?.hasBeenCrew ?? false;
@@ -123,6 +124,9 @@ export default function PlaceDetailV2Screen({
       const isCrewClosure = isCrew && params.reason === 'CLOSED';
       if (isCrewClosure) {
         ToastUtils.show('폐업 처리가 완료되었습니다.');
+        queryClient.invalidateQueries({queryKey: ['searchPlaces']});
+        queryClient.invalidateQueries({queryKey: ['PlaceDetailV2']});
+        navigation.goBack();
       } else {
         const isAutoResolved = result.data?.isAutoResolved === true;
         ToastUtils.show(


### PR DESCRIPTION
## Summary
- 크루 폐업 즉시 처리 후 `navigation.goBack()` + 검색 캐시 무효화
- 문 유형 '기타'일 때 "기타이 아니에요" → "출입문 유형이 잘못됐어요" fallback

## Test plan
- [ ] 크루 계정으로 폐업 신고 → 토스트 후 이전 화면으로 돌아가는지 확인
- [ ] 이전 화면 검색 목록에서 폐업된 장소가 제거되는지 확인
- [ ] 문 유형이 '기타'인 장소에서 step2 텍스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced feedback message clarity when reporting inaccurate door type information.
* Improved data synchronization and navigation when crew members report a place as closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->