### PR TITLE
feat: 이미지 업로드 프로그레스 바 UI

### DIFF
--- a/src/components/UploadProgressOverlay.tsx
+++ b/src/components/UploadProgressOverlay.tsx
@@ -1,0 +1,200 @@
+import React, {useCallback, useEffect, useRef} from 'react';
+import {Animated, BackHandler, Dimensions} from 'react-native';
+import styled from 'styled-components/native';
+
+import {color} from '@/constant/color';
+import {font} from '@/constant/font';
+
+export interface UploadProgressOverlayProps {
+  visible: boolean;
+  stage: 'compressing' | 'uploading' | 'registering';
+  currentIndex: number;
+  totalImages: number;
+  progress: number; // 0-1
+  imageSizeMb: number;
+}
+
+export function UploadProgressOverlay({
+  visible,
+  stage,
+  currentIndex,
+  totalImages,
+  progress,
+  imageSizeMb,
+}: UploadProgressOverlayProps) {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const width = Dimensions.get('window').width;
+  const height = Dimensions.get('window').height;
+
+  const fadeIn = useCallback(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 150,
+      useNativeDriver: false,
+    }).start();
+  }, [fadeAnim]);
+
+  const fadeOut = useCallback(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 0,
+      duration: 150,
+      useNativeDriver: false,
+    }).start();
+  }, [fadeAnim]);
+
+  useEffect(() => {
+    if (visible) {
+      fadeIn();
+    } else {
+      fadeOut();
+    }
+  }, [visible, fadeIn, fadeOut]);
+
+  // Block hardware back button while visible
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    const handler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => true,
+    );
+    return () => handler.remove();
+  }, [visible]);
+
+  const isIndeterminate = stage === 'compressing' || stage === 'registering';
+
+  const titleText = (() => {
+    switch (stage) {
+      case 'compressing':
+        return `사진 압축 중 (${currentIndex + 1}/${totalImages})`;
+      case 'uploading':
+        return `사진 업로드 중 (${currentIndex + 1}/${totalImages})`;
+      case 'registering':
+        return '정보 등록 중...';
+      default: {
+        const _exhaustiveCheck: never = stage;
+        return _exhaustiveCheck;
+      }
+    }
+  })();
+
+  const progressPercent = Math.round(progress * 100);
+
+  return (
+    <Overlay
+      style={{opacity: fadeAnim, width, height}}
+      pointerEvents={visible ? 'auto' : 'none'}>
+      <Card>
+        <TitleText>{titleText}</TitleText>
+        {stage === 'uploading' && (
+          <SizeText>{imageSizeMb.toFixed(2)} MB</SizeText>
+        )}
+        <ProgressBarContainer>
+          {isIndeterminate ? (
+            <IndeterminateBar />
+          ) : (
+            <ProgressBarFill style={{width: `${progressPercent}%`}} />
+          )}
+        </ProgressBarContainer>
+        {stage === 'uploading' && <PercentText>{progressPercent}%</PercentText>}
+      </Card>
+    </Overlay>
+  );
+}
+
+// Indeterminate animated bar
+function IndeterminateBar() {
+  const translateX = useRef(new Animated.Value(-100)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(translateX, {
+          toValue: 200,
+          duration: 1200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateX, {
+          toValue: -100,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [translateX]);
+
+  return (
+    <Animated.View
+      style={{
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        bottom: 0,
+        width: '40%',
+        backgroundColor: color.lightOrange,
+        borderRadius: 3,
+        transform: [{translateX}],
+      }}
+    />
+  );
+}
+
+const Overlay = styled(Animated.View)`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: ${color.blacka50};
+  align-items: center;
+  justify-content: center;
+`;
+
+const Card = styled.View`
+  background-color: ${color.white};
+  border-radius: 16px;
+  padding: 24px;
+  align-items: center;
+  min-width: 260px;
+`;
+
+const TitleText = styled.Text`
+  font-family: ${font.pretendardMedium};
+  font-size: 16px;
+  line-height: 24px;
+  color: ${color.gray80};
+  margin-bottom: 8px;
+`;
+
+const SizeText = styled.Text`
+  font-family: ${font.pretendardRegular};
+  font-size: 13px;
+  line-height: 18px;
+  color: ${color.gray50};
+  margin-bottom: 12px;
+`;
+
+const ProgressBarContainer = styled.View`
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background-color: #e5e5e5;
+  overflow: hidden;
+`;
+
+const ProgressBarFill = styled.View`
+  height: 6px;
+  border-radius: 3px;
+  background-color: ${color.lightOrange};
+`;
+
+const PercentText = styled.Text`
+  font-family: ${font.pretendardMedium};
+  font-size: 13px;
+  line-height: 18px;
+  color: ${color.gray50};
+  margin-top: 8px;
+`;

--- a/src/components/UploadProgressOverlay.tsx
+++ b/src/components/UploadProgressOverlay.tsx
@@ -12,6 +12,7 @@ export interface UploadProgressOverlayProps {
   totalImages: number;
   progress: number; // 0-1
   imageSizeMb: number;
+  label?: string; // e.g. '입구 사진', '엘리베이터 사진'
 }
 
 export function UploadProgressOverlay({
@@ -21,6 +22,7 @@ export function UploadProgressOverlay({
   totalImages,
   progress,
   imageSizeMb,
+  label,
 }: UploadProgressOverlayProps) {
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const width = Dimensions.get('window').width;
@@ -64,12 +66,13 @@ export function UploadProgressOverlay({
 
   const isIndeterminate = stage === 'compressing' || stage === 'registering';
 
+  const photoLabel = label ?? '사진';
   const titleText = (() => {
     switch (stage) {
       case 'compressing':
-        return `사진 압축 중 (${currentIndex + 1}/${totalImages})`;
+        return `${photoLabel} 압축 중 (${currentIndex + 1}/${totalImages})`;
       case 'uploading':
-        return `사진 업로드 중 (${currentIndex + 1}/${totalImages})`;
+        return `${photoLabel} 업로드 중 (${currentIndex + 1}/${totalImages})`;
       case 'registering':
         return '정보 등록 중...';
       default: {

--- a/src/hooks/useImageUploadWithProgress.tsx
+++ b/src/hooks/useImageUploadWithProgress.tsx
@@ -1,0 +1,55 @@
+import React, {useCallback, useState} from 'react';
+
+import {
+  UploadProgressOverlay,
+  UploadProgressOverlayProps,
+} from '@/components/UploadProgressOverlay';
+import {DefaultApi, ImageUploadPurpose} from '@/generated-sources/openapi';
+import ImageFile from '@/models/ImageFile';
+import ImageFileUtils, {UploadProgress} from '@/utils/ImageFileUtils';
+
+export type UploadImagesFn = (
+  api: DefaultApi,
+  images: ImageFile[],
+  purposeType?: ImageUploadPurpose,
+) => Promise<string[]>;
+
+export function useImageUploadWithProgress() {
+  const [props, setProps] = useState<UploadProgressOverlayProps | null>(null);
+
+  const uploadImages: UploadImagesFn = useCallback(
+    async (
+      api: DefaultApi,
+      images: ImageFile[],
+      purposeType?: ImageUploadPurpose,
+    ) => {
+      try {
+        return await ImageFileUtils.uploadImages(
+          api,
+          images,
+          purposeType,
+          (p: UploadProgress) => {
+            setProps({
+              visible: true,
+              stage: p.stage,
+              currentIndex: p.currentIndex,
+              totalImages: p.totalImages,
+              progress: p.totalBytes > 0 ? p.bytesUploaded / p.totalBytes : 0,
+              imageSizeMb: p.imageSizeMb,
+            });
+          },
+        );
+      } finally {
+        setProps(null);
+      }
+    },
+    [],
+  );
+
+  const UploadOverlay = useCallback(
+    () => (props ? <UploadProgressOverlay {...props} /> : null),
+    [props],
+  );
+
+  return {uploadImages, UploadOverlay};
+}

--- a/src/hooks/useImageUploadWithProgress.tsx
+++ b/src/hooks/useImageUploadWithProgress.tsx
@@ -12,6 +12,7 @@ export type UploadImagesFn = (
   api: DefaultApi,
   images: ImageFile[],
   purposeType?: ImageUploadPurpose,
+  label?: string,
 ) => Promise<string[]>;
 
 export function useImageUploadWithProgress() {
@@ -22,6 +23,7 @@ export function useImageUploadWithProgress() {
       api: DefaultApi,
       images: ImageFile[],
       purposeType?: ImageUploadPurpose,
+      label?: string,
     ) => {
       try {
         return await ImageFileUtils.uploadImages(
@@ -36,6 +38,7 @@ export function useImageUploadWithProgress() {
               totalImages: p.totalImages,
               progress: p.totalBytes > 0 ? p.bytesUploaded / p.totalBytes : 0,
               imageSizeMb: p.imageSizeMb,
+              label,
             });
           },
         );

--- a/src/screens/BuildingFormV2Screen/BuildingFormV2Screen.tsx
+++ b/src/screens/BuildingFormV2Screen/BuildingFormV2Screen.tsx
@@ -889,11 +889,23 @@ async function register(
     (values.enterancePhotos?.length ?? 0) +
     (values.elevatorPhotos?.length ?? 0);
   try {
-    const upload =
-      uploadImagesFn ?? ImageFileUtils.uploadImages.bind(ImageFileUtils);
+    const upload: UploadImagesFn =
+      uploadImagesFn ??
+      ((a, images, purposeType) =>
+        ImageFileUtils.uploadImages(a, images, purposeType));
     const startImageUpload = Date.now();
-    const enteranceImages = await upload(api, values.enterancePhotos);
-    const elevatorImages = await upload(api, values.elevatorPhotos);
+    const enteranceImages = await upload(
+      api,
+      values.enterancePhotos,
+      undefined,
+      '입구 사진',
+    );
+    const elevatorImages = await upload(
+      api,
+      values.elevatorPhotos,
+      undefined,
+      '엘리베이터 사진',
+    );
     const durationImageUpload = Date.now() - startImageUpload;
 
     try {

--- a/src/screens/BuildingFormV2Screen/BuildingFormV2Screen.tsx
+++ b/src/screens/BuildingFormV2Screen/BuildingFormV2Screen.tsx
@@ -14,9 +14,9 @@ import {
 import {SccPressable} from '@/components/SccPressable';
 import TabBar from '@/components/TabBar';
 import {
-  UploadProgressOverlay,
-  UploadProgressOverlayProps,
-} from '@/components/UploadProgressOverlay';
+  useImageUploadWithProgress,
+  UploadImagesFn,
+} from '@/hooks/useImageUploadWithProgress';
 import {SccButton} from '@/components/atoms';
 import {MAX_NUMBER_OF_TAKEN_PHOTOS} from '@/constant/constant';
 import {font} from '@/constant/font';
@@ -44,7 +44,7 @@ import Logger from '@/logging/Logger';
 import FormExitConfirmBottomSheet from '@/modals/FormExitConfirmBottomSheet';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
-import ImageFileUtils, {UploadProgress} from '@/utils/ImageFileUtils';
+import ImageFileUtils from '@/utils/ImageFileUtils';
 import {updateSearchCacheForPlaceAsync} from '@/utils/SearchPlacesUtils';
 import ToastUtils from '@/utils/ToastUtils';
 
@@ -98,8 +98,7 @@ export default function BuildingFormV2Screen({
   const pushItems = useSetAtom(pushItemsAtom);
   const queryClient = useQueryClient();
 
-  const [uploadProgress, setUploadProgress] =
-    useState<UploadProgressOverlayProps | null>(null);
+  const {uploadImages, UploadOverlay} = useImageUploadWithProgress();
   const [currentTab, setCurrentTab] = useState<TabType>('entrance');
   const isKeyboardVisible = useKeyboardVisible();
 
@@ -353,21 +352,8 @@ export default function BuildingFormV2Screen({
           place.id,
           building.id,
           values,
-          (progress: UploadProgress) => {
-            setUploadProgress({
-              visible: true,
-              stage: progress.stage,
-              currentIndex: progress.currentIndex,
-              totalImages: progress.totalImages,
-              progress:
-                progress.totalBytes > 0
-                  ? progress.bytesUploaded / progress.totalBytes
-                  : 0,
-              imageSizeMb: progress.imageSizeMb,
-            });
-          },
+          uploadImages,
         );
-        setUploadProgress(null);
 
         // 장소 정보 등록에 실패, 이후 과정을 진행하지 않음
         if (!registered.success) {
@@ -387,7 +373,7 @@ export default function BuildingFormV2Screen({
           },
         });
       }, 1000),
-    [api, place, building, navigation],
+    [api, place, building, navigation, uploadImages],
   );
 
   function noticeError(errorKey: keyof FormValues) {
@@ -869,7 +855,7 @@ export default function BuildingFormV2Screen({
           onConfirm={formExitConfirm.onConfirm}
           onCancel={formExitConfirm.onCancel}
         />
-        {uploadProgress && <UploadProgressOverlay {...uploadProgress} />}
+        <UploadOverlay />
       </FormProvider>
     </LogParamsProvider>
   );
@@ -896,39 +882,21 @@ async function register(
   placeId: string,
   buildingId: string,
   values: FormValues,
-  onProgress?: (progress: UploadProgress) => void,
+  uploadImagesFn?: UploadImagesFn,
 ) {
   const startTotal = Date.now();
   const imageCount =
     (values.enterancePhotos?.length ?? 0) +
     (values.elevatorPhotos?.length ?? 0);
   try {
+    const upload =
+      uploadImagesFn ?? ImageFileUtils.uploadImages.bind(ImageFileUtils);
     const startImageUpload = Date.now();
-    const enteranceImages = await ImageFileUtils.uploadImages(
-      api,
-      values.enterancePhotos,
-      undefined,
-      onProgress,
-    );
-    const elevatorImages = await ImageFileUtils.uploadImages(
-      api,
-      values.elevatorPhotos,
-      undefined,
-      onProgress,
-    );
+    const enteranceImages = await upload(api, values.enterancePhotos);
+    const elevatorImages = await upload(api, values.elevatorPhotos);
     const durationImageUpload = Date.now() - startImageUpload;
 
     try {
-      // Registering stage
-      onProgress?.({
-        stage: 'registering',
-        currentIndex: 0,
-        totalImages: imageCount,
-        bytesUploaded: 0,
-        totalBytes: 0,
-        imageSizeMb: 0,
-      });
-
       const startApiCall = Date.now();
       const res = await api.registerBuildingAccessibilityV2Post({
         buildingId,

--- a/src/screens/BuildingFormV2Screen/BuildingFormV2Screen.tsx
+++ b/src/screens/BuildingFormV2Screen/BuildingFormV2Screen.tsx
@@ -1,5 +1,5 @@
 import {useQueryClient} from '@tanstack/react-query';
-import {useAtom, useSetAtom} from 'jotai';
+import {useSetAtom} from 'jotai';
 import {throttle} from 'lodash';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {Controller, FormProvider, useForm} from 'react-hook-form';
@@ -11,9 +11,12 @@ import {
   View,
 } from 'react-native';
 
-import {loadingState} from '@/components/LoadingView';
 import {SccPressable} from '@/components/SccPressable';
 import TabBar from '@/components/TabBar';
+import {
+  UploadProgressOverlay,
+  UploadProgressOverlayProps,
+} from '@/components/UploadProgressOverlay';
 import {SccButton} from '@/components/atoms';
 import {MAX_NUMBER_OF_TAKEN_PHOTOS} from '@/constant/constant';
 import {font} from '@/constant/font';
@@ -41,7 +44,7 @@ import Logger from '@/logging/Logger';
 import FormExitConfirmBottomSheet from '@/modals/FormExitConfirmBottomSheet';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
-import ImageFileUtils from '@/utils/ImageFileUtils';
+import ImageFileUtils, {UploadProgress} from '@/utils/ImageFileUtils';
 import {updateSearchCacheForPlaceAsync} from '@/utils/SearchPlacesUtils';
 import ToastUtils from '@/utils/ToastUtils';
 
@@ -95,7 +98,8 @@ export default function BuildingFormV2Screen({
   const pushItems = useSetAtom(pushItemsAtom);
   const queryClient = useQueryClient();
 
-  const [loading, setLoading] = useAtom(loadingState);
+  const [uploadProgress, setUploadProgress] =
+    useState<UploadProgressOverlayProps | null>(null);
   const [currentTab, setCurrentTab] = useState<TabType>('entrance');
   const isKeyboardVisible = useKeyboardVisible();
 
@@ -343,15 +347,27 @@ export default function BuildingFormV2Screen({
   const registerBuilding = useMemo(
     () =>
       throttle(async (values: FormValues) => {
-        setLoading(new Map(loading).set('BuildingForm', true));
         const registered = await register(
           api,
           queryClient,
           place.id,
           building.id,
           values,
+          (progress: UploadProgress) => {
+            setUploadProgress({
+              visible: true,
+              stage: progress.stage,
+              currentIndex: progress.currentIndex,
+              totalImages: progress.totalImages,
+              progress:
+                progress.totalBytes > 0
+                  ? progress.bytesUploaded / progress.totalBytes
+                  : 0,
+              imageSizeMb: progress.imageSizeMb,
+            });
+          },
         );
-        setLoading(new Map(loading).set('BuildingForm', false));
+        setUploadProgress(null);
 
         // 장소 정보 등록에 실패, 이후 과정을 진행하지 않음
         if (!registered.success) {
@@ -371,7 +387,7 @@ export default function BuildingFormV2Screen({
           },
         });
       }, 1000),
-    [api, place, building, navigation, loading, setLoading],
+    [api, place, building, navigation],
   );
 
   function noticeError(errorKey: keyof FormValues) {
@@ -853,6 +869,7 @@ export default function BuildingFormV2Screen({
           onConfirm={formExitConfirm.onConfirm}
           onCancel={formExitConfirm.onCancel}
         />
+        {uploadProgress && <UploadProgressOverlay {...uploadProgress} />}
       </FormProvider>
     </LogParamsProvider>
   );
@@ -879,6 +896,7 @@ async function register(
   placeId: string,
   buildingId: string,
   values: FormValues,
+  onProgress?: (progress: UploadProgress) => void,
 ) {
   const startTotal = Date.now();
   const imageCount =
@@ -889,14 +907,28 @@ async function register(
     const enteranceImages = await ImageFileUtils.uploadImages(
       api,
       values.enterancePhotos,
+      undefined,
+      onProgress,
     );
     const elevatorImages = await ImageFileUtils.uploadImages(
       api,
       values.elevatorPhotos,
+      undefined,
+      onProgress,
     );
     const durationImageUpload = Date.now() - startImageUpload;
 
     try {
+      // Registering stage
+      onProgress?.({
+        stage: 'registering',
+        currentIndex: 0,
+        totalImages: imageCount,
+        bytesUploaded: 0,
+        totalBytes: 0,
+        imageSizeMb: 0,
+      });
+
       const startApiCall = Date.now();
       const res = await api.registerBuildingAccessibilityV2Post({
         buildingId,

--- a/src/screens/PlaceFormV2Screen/PlaceFormV2Screen.tsx
+++ b/src/screens/PlaceFormV2Screen/PlaceFormV2Screen.tsx
@@ -4,9 +4,9 @@ import {
 } from '@/atoms/User';
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {
-  UploadProgressOverlay,
-  UploadProgressOverlayProps,
-} from '@/components/UploadProgressOverlay';
+  useImageUploadWithProgress,
+  UploadImagesFn,
+} from '@/hooks/useImageUploadWithProgress';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 import {
@@ -26,7 +26,7 @@ import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import FormExitConfirmBottomSheet from '@/modals/FormExitConfirmBottomSheet';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
-import ImageFileUtils, {UploadProgress} from '@/utils/ImageFileUtils';
+import ImageFileUtils from '@/utils/ImageFileUtils';
 import {updateSearchCacheForPlaceAsync} from '@/utils/SearchPlacesUtils';
 import ToastUtils from '@/utils/ToastUtils';
 import {useBackHandler} from '@react-native-community/hooks';
@@ -93,8 +93,7 @@ export default function PlaceFormV2Screen({
   const queryClient = useQueryClient();
   const pushItems = useSetAtom(pushItemsAtom);
 
-  const [uploadProgress, setUploadProgress] =
-    useState<UploadProgressOverlayProps | null>(null);
+  const {uploadImages, UploadOverlay} = useImageUploadWithProgress();
   const [stepIndex, setStepIndex] = useState(0);
 
   // 뒤로가기 confirm
@@ -220,21 +219,8 @@ export default function PlaceFormV2Screen({
       selectedStandaloneType,
       selectedFloor,
       doorDirection,
-      (progress: UploadProgress) => {
-        setUploadProgress({
-          visible: true,
-          stage: progress.stage,
-          currentIndex: progress.currentIndex,
-          totalImages: progress.totalImages,
-          progress:
-            progress.totalBytes > 0
-              ? progress.bytesUploaded / progress.totalBytes
-              : 0,
-          imageSizeMb: progress.imageSizeMb,
-        });
-      },
+      uploadImages,
     );
-    setUploadProgress(null);
 
     if (!registered.success) {
       return;
@@ -419,7 +405,7 @@ export default function PlaceFormV2Screen({
           onConfirm={formExitConfirm.onConfirm}
           onCancel={formExitConfirm.onCancel}
         />
-        {uploadProgress && <UploadProgressOverlay {...uploadProgress} />}
+        <UploadOverlay />
       </FormProvider>
     </LogParamsProvider>
   );
@@ -544,20 +530,17 @@ async function register(
   selectedStandaloneType: StandaloneBuildingType | null,
   selectedFloor: number | undefined,
   doorDirection?: BuildingDoorDirectionType,
-  onProgress?: (progress: UploadProgress) => void,
+  uploadImagesFn?: UploadImagesFn,
 ) {
   const startTotal = Date.now();
   const imageCount =
     (values.entrancePhotos?.length ?? 0) + (values.elevatorPhotos?.length ?? 0);
+  const upload =
+    uploadImagesFn ?? ImageFileUtils.uploadImages.bind(ImageFileUtils);
   try {
     // Upload images first
     const startImageUpload = Date.now();
-    const uploadedImageUrls = await ImageFileUtils.uploadImages(
-      api,
-      values.entrancePhotos,
-      undefined,
-      onProgress,
-    );
+    const uploadedImageUrls = await upload(api, values.entrancePhotos);
 
     // Prepare floor moving elevator accessibility if needed
     let floorMovingElevatorAccessibility;
@@ -571,12 +554,7 @@ async function register(
         FloorMovingMethodTypeDto.PlaceElevator,
       )
     ) {
-      const elevatorImageUrls = await ImageFileUtils.uploadImages(
-        api,
-        values.elevatorPhotos || [],
-        undefined,
-        onProgress,
-      );
+      const elevatorImageUrls = await upload(api, values.elevatorPhotos || []);
 
       floorMovingElevatorAccessibility = {
         imageUrls: elevatorImageUrls,
@@ -596,16 +574,6 @@ async function register(
             : undefined,
       };
     }
-
-    // Registering stage
-    onProgress?.({
-      stage: 'registering',
-      currentIndex: 0,
-      totalImages: imageCount,
-      bytesUploaded: 0,
-      totalBytes: 0,
-      imageSizeMb: 0,
-    });
 
     // Build API request
     const requestData: RegisterPlaceAccessibilityRequestDtoV2 = {

--- a/src/screens/PlaceFormV2Screen/PlaceFormV2Screen.tsx
+++ b/src/screens/PlaceFormV2Screen/PlaceFormV2Screen.tsx
@@ -2,8 +2,11 @@ import {
   placeFormV2GuideDismissedAtom,
   placeFormV2GuideDismissedUntilAtom,
 } from '@/atoms/User';
-import {loadingState} from '@/components/LoadingView';
 import {ScreenLayout} from '@/components/ScreenLayout';
+import {
+  UploadProgressOverlay,
+  UploadProgressOverlayProps,
+} from '@/components/UploadProgressOverlay';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 import {
@@ -23,7 +26,7 @@ import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import FormExitConfirmBottomSheet from '@/modals/FormExitConfirmBottomSheet';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
-import ImageFileUtils from '@/utils/ImageFileUtils';
+import ImageFileUtils, {UploadProgress} from '@/utils/ImageFileUtils';
 import {updateSearchCacheForPlaceAsync} from '@/utils/SearchPlacesUtils';
 import ToastUtils from '@/utils/ToastUtils';
 import {useBackHandler} from '@react-native-community/hooks';
@@ -90,7 +93,8 @@ export default function PlaceFormV2Screen({
   const queryClient = useQueryClient();
   const pushItems = useSetAtom(pushItemsAtom);
 
-  const [loading, setLoading] = useAtom(loadingState);
+  const [uploadProgress, setUploadProgress] =
+    useState<UploadProgressOverlayProps | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
 
   // 뒤로가기 confirm
@@ -207,7 +211,6 @@ export default function PlaceFormV2Screen({
   const handleSubmit = async () => {
     const values = form.getValues();
 
-    setLoading(new Map(loading).set('PlaceForm', true));
     const registered = await register(
       api,
       queryClient,
@@ -217,8 +220,21 @@ export default function PlaceFormV2Screen({
       selectedStandaloneType,
       selectedFloor,
       doorDirection,
+      (progress: UploadProgress) => {
+        setUploadProgress({
+          visible: true,
+          stage: progress.stage,
+          currentIndex: progress.currentIndex,
+          totalImages: progress.totalImages,
+          progress:
+            progress.totalBytes > 0
+              ? progress.bytesUploaded / progress.totalBytes
+              : 0,
+          imageSizeMb: progress.imageSizeMb,
+        });
+      },
     );
-    setLoading(new Map(loading).set('PlaceForm', false));
+    setUploadProgress(null);
 
     if (!registered.success) {
       return;
@@ -403,6 +419,7 @@ export default function PlaceFormV2Screen({
           onConfirm={formExitConfirm.onConfirm}
           onCancel={formExitConfirm.onCancel}
         />
+        {uploadProgress && <UploadProgressOverlay {...uploadProgress} />}
       </FormProvider>
     </LogParamsProvider>
   );
@@ -527,6 +544,7 @@ async function register(
   selectedStandaloneType: StandaloneBuildingType | null,
   selectedFloor: number | undefined,
   doorDirection?: BuildingDoorDirectionType,
+  onProgress?: (progress: UploadProgress) => void,
 ) {
   const startTotal = Date.now();
   const imageCount =
@@ -537,6 +555,8 @@ async function register(
     const uploadedImageUrls = await ImageFileUtils.uploadImages(
       api,
       values.entrancePhotos,
+      undefined,
+      onProgress,
     );
 
     // Prepare floor moving elevator accessibility if needed
@@ -554,6 +574,8 @@ async function register(
       const elevatorImageUrls = await ImageFileUtils.uploadImages(
         api,
         values.elevatorPhotos || [],
+        undefined,
+        onProgress,
       );
 
       floorMovingElevatorAccessibility = {
@@ -574,6 +596,16 @@ async function register(
             : undefined,
       };
     }
+
+    // Registering stage
+    onProgress?.({
+      stage: 'registering',
+      currentIndex: 0,
+      totalImages: imageCount,
+      bytesUploaded: 0,
+      totalBytes: 0,
+      imageSizeMb: 0,
+    });
 
     // Build API request
     const requestData: RegisterPlaceAccessibilityRequestDtoV2 = {

--- a/src/screens/PlaceFormV2Screen/PlaceFormV2Screen.tsx
+++ b/src/screens/PlaceFormV2Screen/PlaceFormV2Screen.tsx
@@ -535,12 +535,19 @@ async function register(
   const startTotal = Date.now();
   const imageCount =
     (values.entrancePhotos?.length ?? 0) + (values.elevatorPhotos?.length ?? 0);
-  const upload =
-    uploadImagesFn ?? ImageFileUtils.uploadImages.bind(ImageFileUtils);
+  const upload: UploadImagesFn =
+    uploadImagesFn ??
+    ((a, images, purposeType) =>
+      ImageFileUtils.uploadImages(a, images, purposeType));
   try {
     // Upload images first
     const startImageUpload = Date.now();
-    const uploadedImageUrls = await upload(api, values.entrancePhotos);
+    const uploadedImageUrls = await upload(
+      api,
+      values.entrancePhotos,
+      undefined,
+      '입구 사진',
+    );
 
     // Prepare floor moving elevator accessibility if needed
     let floorMovingElevatorAccessibility;
@@ -554,7 +561,12 @@ async function register(
         FloorMovingMethodTypeDto.PlaceElevator,
       )
     ) {
-      const elevatorImageUrls = await upload(api, values.elevatorPhotos || []);
+      const elevatorImageUrls = await upload(
+        api,
+        values.elevatorPhotos || [],
+        undefined,
+        '엘리베이터 사진',
+      );
 
       floorMovingElevatorAccessibility = {
         imageUrls: elevatorImageUrls,

--- a/src/screens/PlaceReviewFormScreen/views/IndoorReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/IndoorReviewView.tsx
@@ -1,5 +1,5 @@
 import {QueryClient, useQueryClient} from '@tanstack/react-query';
-import {useAtom, useSetAtom} from 'jotai';
+import {useSetAtom} from 'jotai';
 import {throttle} from 'lodash';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {FieldErrors, FormProvider, useForm} from 'react-hook-form';
@@ -8,7 +8,6 @@ import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
 
 import {useMe} from '@/atoms/Auth';
 import {recentlyUsedMobilityToolAtom} from '@/atoms/User';
-import {loadingState} from '@/components/LoadingView';
 import {
   getMobilityToolDefaultValue,
   UserMobilityToolMapDto,
@@ -21,6 +20,10 @@ import {
   UpvoteTargetTypeDto,
 } from '@/generated-sources/openapi';
 import useAppComponents from '@/hooks/useAppComponents';
+import {
+  useImageUploadWithProgress,
+  UploadImagesFn,
+} from '@/hooks/useImageUploadWithProgress';
 import ImageFile from '@/models/ImageFile';
 import ImageFileUtils from '@/utils/ImageFileUtils';
 import {updateSearchCacheForPlaceAsync} from '@/utils/SearchPlacesUtils';
@@ -29,7 +32,6 @@ import ToastUtils from '@/utils/ToastUtils';
 import {SafeAreaWrapper} from '@/components/SafeAreaWrapper';
 import PhotoConfirmBottomSheet from '@/modals/PhotoConfirmBottomSheet';
 import {pushItemsAtom} from '@/screens/SearchScreen/atoms/quest';
-import PlaceReviewFormScreen from '..';
 import IndoorInfoSection from '../sections/IndoorInfoSection';
 import PlaceInfoSection from '../sections/PlaceInfoSection';
 import UserTypeSection from '../sections/UserTypeSection';
@@ -64,7 +66,7 @@ export default function IndoorReviewView({
   const {api} = useAppComponents();
   const queryClient = useQueryClient();
   const {userInfo} = useMe();
-  const [loading, setLoading] = useAtom(loadingState);
+  const {uploadImages, UploadOverlay} = useImageUploadWithProgress();
   const form = useForm<FormValues>({
     defaultValues: {
       mobilityTool: getMobilityToolDefaultValue(userInfo?.mobilityTools),
@@ -143,7 +145,6 @@ export default function IndoorReviewView({
   const registerPlace = useMemo(
     () =>
       throttle(async (values: FormValues, afterSuccess: () => void) => {
-        setLoading(new Map(loading).set(PlaceReviewFormScreen.name, true));
         setRecentlyUsedMobilityTool({
           name: values.mobilityTool,
           timestamp: Date.now(),
@@ -153,8 +154,8 @@ export default function IndoorReviewView({
           queryClient,
           placeId: place?.id!,
           values,
+          uploadImagesFn: uploadImages,
         });
-        setLoading(new Map(loading).set(PlaceReviewFormScreen.name, false));
 
         if (!registered.success) {
           return;
@@ -167,7 +168,7 @@ export default function IndoorReviewView({
         ToastUtils.show('리뷰를 등록했어요.');
         afterSuccess();
       }, 1000),
-    [api, place, loading, setLoading, setRecentlyUsedMobilityTool],
+    [api, place, uploadImages, setRecentlyUsedMobilityTool],
   );
 
   return (
@@ -210,6 +211,7 @@ export default function IndoorReviewView({
           onConfirm={handlePhotoModalConfirm}
           onCancel={handlePhotoModalCancel}
         />
+        <UploadOverlay />
       </SafeAreaWrapper>
     </FormProvider>
   );
@@ -220,18 +222,18 @@ async function register({
   queryClient,
   placeId,
   values,
+  uploadImagesFn,
 }: {
   api: DefaultApi;
   queryClient: QueryClient;
   placeId: string;
   values: FormValues;
+  uploadImagesFn?: UploadImagesFn;
 }) {
+  const upload =
+    uploadImagesFn ?? ImageFileUtils.uploadImages.bind(ImageFileUtils);
   try {
-    const images = await ImageFileUtils.uploadImages(
-      api,
-      values.indoorPhotos,
-      'PLACE_REVIEW',
-    );
+    const images = await upload(api, values.indoorPhotos, 'PLACE_REVIEW');
     try {
       const res = await api.registerPlaceReviewPost({
         placeId,

--- a/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
+++ b/src/screens/PlaceReviewFormScreen/views/ToiletReviewView.tsx
@@ -1,12 +1,11 @@
 import {QueryClient, useQueryClient} from '@tanstack/react-query';
-import {useAtom, useSetAtom} from 'jotai';
+import {useSetAtom} from 'jotai';
 import {throttle} from 'lodash';
 import React, {useMemo} from 'react';
 import {FormProvider, useForm} from 'react-hook-form';
 import {View} from 'react-native';
 
 import {recentlyUsedMobilityToolAtom} from '@/atoms/User';
-import {loadingState} from '@/components/LoadingView';
 import {
   getMobilityToolDefaultValue,
   UserMobilityToolMapDto,
@@ -20,6 +19,10 @@ import {
   UpvoteTargetTypeDto,
 } from '@/generated-sources/openapi';
 import useAppComponents from '@/hooks/useAppComponents';
+import {
+  useImageUploadWithProgress,
+  UploadImagesFn,
+} from '@/hooks/useImageUploadWithProgress';
 import {useMe} from '@/atoms/Auth';
 import ImageFile from '@/models/ImageFile';
 import ImageFileUtils from '@/utils/ImageFileUtils';
@@ -27,7 +30,6 @@ import {updateSearchCacheForPlaceAsync} from '@/utils/SearchPlacesUtils';
 import ToastUtils from '@/utils/ToastUtils';
 
 import {KeyboardAwareScrollView} from 'react-native-keyboard-aware-scroll-view';
-import PlaceReviewFormScreen from '..';
 import PlaceInfoSection from '../sections/PlaceInfoSection';
 import ToiletSection from '../sections/ToiletSection';
 import UserTypeSection from '../sections/UserTypeSection';
@@ -57,7 +59,7 @@ export default function ToiletReviewView({
   const {api} = useAppComponents();
   const queryClient = useQueryClient();
   const {userInfo} = useMe();
-  const [loading, setLoading] = useAtom(loadingState);
+  const {uploadImages, UploadOverlay} = useImageUploadWithProgress();
   const setRecentlyUsedMobilityTool = useSetAtom(recentlyUsedMobilityToolAtom);
 
   const form = useForm<FormValues>({
@@ -77,7 +79,6 @@ export default function ToiletReviewView({
   const registerPlace = useMemo(
     () =>
       throttle(async (values: FormValues, afterSuccess: () => void) => {
-        setLoading(new Map(loading).set(PlaceReviewFormScreen.name, true));
         setRecentlyUsedMobilityTool({
           name: values.mobilityTool,
           timestamp: Date.now(),
@@ -87,8 +88,8 @@ export default function ToiletReviewView({
           queryClient,
           placeId: place?.id!,
           values,
+          uploadImagesFn: uploadImages,
         });
-        setLoading(new Map(loading).set(PlaceReviewFormScreen.name, false));
 
         if (!registered) {
           return;
@@ -97,7 +98,7 @@ export default function ToiletReviewView({
         ToastUtils.show('화장실 리뷰를 등록했어요.');
         afterSuccess();
       }, 1000),
-    [api, place, loading, setLoading, setRecentlyUsedMobilityTool],
+    [api, place, uploadImages, setRecentlyUsedMobilityTool],
   );
 
   return (
@@ -116,6 +117,7 @@ export default function ToiletReviewView({
 
           <ToiletSection onSave={form.handleSubmit(onValid)} />
         </KeyboardAwareScrollView>
+        <UploadOverlay />
       </SafeAreaWrapper>
     </FormProvider>
   );
@@ -126,18 +128,18 @@ async function register({
   queryClient,
   placeId,
   values,
+  uploadImagesFn,
 }: {
   api: DefaultApi;
   queryClient: QueryClient;
   placeId: string;
   values: FormValues;
+  uploadImagesFn?: UploadImagesFn;
 }) {
+  const upload =
+    uploadImagesFn ?? ImageFileUtils.uploadImages.bind(ImageFileUtils);
   try {
-    const images = await ImageFileUtils.uploadImages(
-      api,
-      values.toiletPhotos,
-      'TOILET_REVIEW',
-    );
+    const images = await upload(api, values.toiletPhotos, 'TOILET_REVIEW');
     try {
       const isNoneOrEtc =
         values.toiletLocationType === 'NONE' ||

--- a/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
+++ b/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
@@ -546,11 +546,16 @@ export default function ReportCorrectionFormScreen({
       // 1. Upload new PA photos and replaced PA photos
       const uploadedEntranceUrls =
         newEntrancePhotos.length > 0
-          ? await uploadImages(api, newEntrancePhotos)
+          ? await uploadImages(api, newEntrancePhotos, undefined, '입구 사진')
           : [];
       const uploadedElevatorUrls =
         newElevatorPhotos.length > 0
-          ? await uploadImages(api, newElevatorPhotos)
+          ? await uploadImages(
+              api,
+              newElevatorPhotos,
+              undefined,
+              '엘리베이터 사진',
+            )
           : [];
 
       // Upload replaced PA entrance photos
@@ -562,6 +567,8 @@ export default function ReportCorrectionFormScreen({
           ? await uploadImages(
               api,
               replacedEntranceEntries.map(([_, photo]) => photo),
+              undefined,
+              '입구 사진',
             )
           : [];
       const replacedEntranceUrlMap = new Map<number, string>();
@@ -578,6 +585,8 @@ export default function ReportCorrectionFormScreen({
           ? await uploadImages(
               api,
               replacedElevatorEntries.map(([_, photo]) => photo),
+              undefined,
+              '엘리베이터 사진',
             )
           : [];
       const replacedElevatorUrlMap = new Map<number, string>();
@@ -588,11 +597,21 @@ export default function ReportCorrectionFormScreen({
       // 1b. Upload BA photos (only if needsBaPhotos)
       const uploadedBaEntranceUrls =
         needsBaPhotos && newBaEntrancePhotos.length > 0
-          ? await uploadImages(api, newBaEntrancePhotos)
+          ? await uploadImages(
+              api,
+              newBaEntrancePhotos,
+              undefined,
+              '건물 입구 사진',
+            )
           : [];
       const uploadedBaElevatorUrls =
         needsBaPhotos && newBaElevatorPhotos.length > 0
-          ? await uploadImages(api, newBaElevatorPhotos)
+          ? await uploadImages(
+              api,
+              newBaElevatorPhotos,
+              undefined,
+              '건물 엘리베이터 사진',
+            )
           : [];
 
       // Upload replaced BA entrance photos
@@ -604,6 +623,8 @@ export default function ReportCorrectionFormScreen({
           ? await uploadImages(
               api,
               replacedBaEntranceEntries.map(([_, photo]) => photo),
+              undefined,
+              '건물 입구 사진',
             )
           : [];
       const replacedBaEntranceUrlMap = new Map<number, string>();
@@ -620,6 +641,8 @@ export default function ReportCorrectionFormScreen({
           ? await uploadImages(
               api,
               replacedBaElevatorEntries.map(([_, photo]) => photo),
+              undefined,
+              '건물 엘리베이터 사진',
             )
           : [];
       const replacedBaElevatorUrlMap = new Map<number, string>();

--- a/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
+++ b/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
@@ -27,10 +27,10 @@ import {
   StairHeightLevel,
 } from '@/generated-sources/openapi';
 import useAppComponents from '@/hooks/useAppComponents';
+import {useImageUploadWithProgress} from '@/hooks/useImageUploadWithProgress';
 import usePost from '@/hooks/usePost';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
-import ImageFileUtils from '@/utils/ImageFileUtils';
 import ToastUtils from '@/utils/ToastUtils';
 
 /** Local form state types (removed from codegen) */
@@ -291,6 +291,7 @@ export default function ReportCorrectionFormScreen({
   const category = inaccurateCategory as InaccurateInfoCategoryDto;
   const {api} = useAppComponents();
   const queryClient = useQueryClient();
+  const {uploadImages, UploadOverlay} = useImageUploadWithProgress();
 
   const [isLoading, setIsLoading] = useState(true);
   const [accessibilityData, setAccessibilityData] =
@@ -545,11 +546,11 @@ export default function ReportCorrectionFormScreen({
       // 1. Upload new PA photos and replaced PA photos
       const uploadedEntranceUrls =
         newEntrancePhotos.length > 0
-          ? await ImageFileUtils.uploadImages(api, newEntrancePhotos)
+          ? await uploadImages(api, newEntrancePhotos)
           : [];
       const uploadedElevatorUrls =
         newElevatorPhotos.length > 0
-          ? await ImageFileUtils.uploadImages(api, newElevatorPhotos)
+          ? await uploadImages(api, newElevatorPhotos)
           : [];
 
       // Upload replaced PA entrance photos
@@ -558,7 +559,7 @@ export default function ReportCorrectionFormScreen({
       );
       const uploadedReplacedEntranceUrls =
         replacedEntranceEntries.length > 0
-          ? await ImageFileUtils.uploadImages(
+          ? await uploadImages(
               api,
               replacedEntranceEntries.map(([_, photo]) => photo),
             )
@@ -574,7 +575,7 @@ export default function ReportCorrectionFormScreen({
       );
       const uploadedReplacedElevatorUrls =
         replacedElevatorEntries.length > 0
-          ? await ImageFileUtils.uploadImages(
+          ? await uploadImages(
               api,
               replacedElevatorEntries.map(([_, photo]) => photo),
             )
@@ -587,11 +588,11 @@ export default function ReportCorrectionFormScreen({
       // 1b. Upload BA photos (only if needsBaPhotos)
       const uploadedBaEntranceUrls =
         needsBaPhotos && newBaEntrancePhotos.length > 0
-          ? await ImageFileUtils.uploadImages(api, newBaEntrancePhotos)
+          ? await uploadImages(api, newBaEntrancePhotos)
           : [];
       const uploadedBaElevatorUrls =
         needsBaPhotos && newBaElevatorPhotos.length > 0
-          ? await ImageFileUtils.uploadImages(api, newBaElevatorPhotos)
+          ? await uploadImages(api, newBaElevatorPhotos)
           : [];
 
       // Upload replaced BA entrance photos
@@ -600,7 +601,7 @@ export default function ReportCorrectionFormScreen({
       );
       const uploadedReplacedBaEntranceUrls =
         needsBaPhotos && replacedBaEntranceEntries.length > 0
-          ? await ImageFileUtils.uploadImages(
+          ? await uploadImages(
               api,
               replacedBaEntranceEntries.map(([_, photo]) => photo),
             )
@@ -616,7 +617,7 @@ export default function ReportCorrectionFormScreen({
       );
       const uploadedReplacedBaElevatorUrls =
         needsBaPhotos && replacedBaElevatorEntries.length > 0
-          ? await ImageFileUtils.uploadImages(
+          ? await uploadImages(
               api,
               replacedBaElevatorEntries.map(([_, photo]) => photo),
             )
@@ -1262,6 +1263,7 @@ export default function ReportCorrectionFormScreen({
           />
         </SubmitButtonContainer>
       </ScrollView>
+      <UploadOverlay />
     </ScreenLayout>
   );
 }

--- a/src/utils/ImageFileUtils.ts
+++ b/src/utils/ImageFileUtils.ts
@@ -7,6 +7,15 @@ import ImageFile from '@/models/ImageFile';
 
 const UPLOAD_TIMEOUT_MS = 30_000;
 
+export interface UploadProgress {
+  stage: 'compressing' | 'uploading' | 'registering';
+  currentIndex: number;
+  totalImages: number;
+  bytesUploaded: number;
+  totalBytes: number;
+  imageSizeMb: number;
+}
+
 interface UploadImageResult {
   url: string;
   size: number;
@@ -45,64 +54,70 @@ class UploadHttpError extends Error {
   }
 }
 
-/** presigned URL에 이미지 업로드 (내부 전용) */
+/** presigned URL에 이미지 업로드 (내부 전용) — XMLHttpRequest 사용으로 progress 지원 */
 async function uploadToPresignedUrl(
   presignedUrl: string,
   imageFileUrl: string,
+  onProgress?: (loaded: number, total: number) => void,
 ): Promise<UploadImageResult> {
   const url = new URL(presignedUrl);
   const resp = await fetch(imageFileUrl);
   const imageBody = await resp.blob();
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
+  return new Promise<UploadImageResult>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.timeout = UPLOAD_TIMEOUT_MS;
 
-  try {
-    const result = await fetch(url.href, {
-      method: 'PUT',
-      headers: {
-        'content-type': imageBody.type,
-        'x-amz-acl': 'public-read',
-      },
-      body: imageBody,
+    xhr.upload.onprogress = (e: ProgressEvent) => {
+      if (e.lengthComputable) {
+        onProgress?.(e.loaded, e.total);
+      }
+    };
 
-      signal: controller.signal as any,
-    });
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve({
+          url: url.protocol + '//' + url.host + url.pathname,
+          size: imageBody.size,
+        });
+      } else {
+        reject(
+          new UploadHttpError(
+            `Upload image to ${url.href} is failed. cause: ${xhr.responseText}`,
+            xhr.status,
+          ),
+        );
+      }
+    };
 
-    if (result.ok) {
-      return {
-        url: url.protocol + '//' + url.host + url.pathname,
-        size: imageBody.size,
-      };
-    } else {
-      const resultString = await result.text();
-      throw new UploadHttpError(
-        `Upload image to ${result.url} is failed. cause: ${resultString}`,
-        result.status,
+    xhr.ontimeout = () => {
+      reject(
+        new Error(`Image upload timed out after ${UPLOAD_TIMEOUT_MS / 1000}s`),
       );
-    }
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(
-        `Image upload timed out after ${UPLOAD_TIMEOUT_MS / 1000}s`,
-      );
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
-  }
+    };
+
+    xhr.onerror = () => {
+      reject(new TypeError('Network request failed'));
+    };
+
+    xhr.open('PUT', url.href);
+    xhr.setRequestHeader('content-type', imageBody.type);
+    xhr.setRequestHeader('x-amz-acl', 'public-read');
+    xhr.send(imageBody);
+  });
 }
 
 /** 1회 재시도 포함 업로드 */
 async function uploadToPresignedUrlWithRetry(
   presignedUrl: string,
   imageFileUrl: string,
+  onProgress?: (loaded: number, total: number) => void,
 ): Promise<UploadImageResult> {
   try {
-    return await uploadToPresignedUrl(presignedUrl, imageFileUrl);
+    return await uploadToPresignedUrl(presignedUrl, imageFileUrl, onProgress);
   } catch (_firstError) {
     await delay(1000);
-    return await uploadToPresignedUrl(presignedUrl, imageFileUrl);
+    return await uploadToPresignedUrl(presignedUrl, imageFileUrl, onProgress);
   }
 }
 
@@ -140,6 +155,7 @@ const ImageFileUtils = {
     api: DefaultApi,
     images: ImageFile[] = [],
     purposeType?: ImageUploadPurpose,
+    onProgress?: (progress: UploadProgress) => void,
   ) {
     const startTimeOfTotal = Date.now();
     const startTimeOfGettingPresignedUrls = Date.now();
@@ -155,62 +171,85 @@ const ImageFileUtils = {
 
     let durationOfUploadImages: Record<string, number> = {};
     try {
-      const uploadedUrls = await Promise.all(
-        images.map(async (image, index) => {
-          const url = uploadUrls[index];
-          if (url === undefined) {
-            throw new Error('There are not enough urls.');
-          }
-          const startTimeOfImageUpload = Date.now();
+      const uploadedUrls: string[] = [];
 
-          if (image.width === 0 || image.height === 0) {
-            Logger.logError(
-              new Error(
-                `Image at index ${index} has zero dimension: width=${image.width}, height=${image.height}`,
-              ),
-            );
-          }
+      for (let index = 0; index < images.length; index++) {
+        const image = images[index];
+        const url = uploadUrls[index];
+        if (url === undefined) {
+          throw new Error('There are not enough urls.');
+        }
+        const startTimeOfImageUpload = Date.now();
 
-          const startCompress = Date.now();
-          let compressedUri: string;
-          try {
-            compressedUri = await ImageCompressor.compress(image.uri, {
-              compressionMethod: 'auto',
-              maxWidth: 2560,
-              maxHeight: 2560,
-              quality: 0.7,
+        if (image.width === 0 || image.height === 0) {
+          Logger.logError(
+            new Error(
+              `Image at index ${index} has zero dimension: width=${image.width}, height=${image.height}`,
+            ),
+          );
+        }
+
+        // Compressing stage
+        onProgress?.({
+          stage: 'compressing',
+          currentIndex: index,
+          totalImages: images.length,
+          bytesUploaded: 0,
+          totalBytes: 0,
+          imageSizeMb: 0,
+        });
+
+        const startCompress = Date.now();
+        let compressedUri: string;
+        try {
+          compressedUri = await ImageCompressor.compress(image.uri, {
+            compressionMethod: 'auto',
+            maxWidth: 2560,
+            maxHeight: 2560,
+            quality: 0.7,
+          });
+        } catch (compressError) {
+          Logger.logError(
+            compressError instanceof Error
+              ? compressError
+              : new Error(String(compressError)),
+          );
+          compressedUri = image.uri;
+        }
+        const durationCompress = Date.now() - startCompress;
+
+        // Uploading stage
+        const startUpload = Date.now();
+        const result = await uploadToPresignedUrlWithRetry(
+          url,
+          compressedUri,
+          (loaded, total) => {
+            const imageSizeMb = floor(total / (1024 * 1024), 2);
+            onProgress?.({
+              stage: 'uploading',
+              currentIndex: index,
+              totalImages: images.length,
+              bytesUploaded: loaded,
+              totalBytes: total,
+              imageSizeMb,
             });
-          } catch (compressError) {
-            Logger.logError(
-              compressError instanceof Error
-                ? compressError
-                : new Error(String(compressError)),
-            );
-            compressedUri = image.uri;
-          }
-          const durationCompress = Date.now() - startCompress;
+          },
+        );
+        const durationUpload = Date.now() - startUpload;
 
-          const startUpload = Date.now();
-          const result = await uploadToPresignedUrlWithRetry(
-            url,
-            compressedUri,
-          );
-          const durationUpload = Date.now() - startUpload;
+        durationOfUploadImages[`duration_millis_of_upload_image_${index}`] =
+          Date.now() - startTimeOfImageUpload;
+        durationOfUploadImages[`duration_millis_of_compress_${index}`] =
+          durationCompress;
+        durationOfUploadImages[`duration_millis_of_s3_upload_${index}`] =
+          durationUpload;
+        durationOfUploadImages[`size_mb_of_image_${index}`] = floor(
+          result.size / (1024 * 1024),
+          2,
+        );
 
-          durationOfUploadImages[`duration_millis_of_upload_image_${index}`] =
-            Date.now() - startTimeOfImageUpload;
-          durationOfUploadImages[`duration_millis_of_compress_${index}`] =
-            durationCompress;
-          durationOfUploadImages[`duration_millis_of_s3_upload_${index}`] =
-            durationUpload;
-          durationOfUploadImages[`size_mb_of_image_${index}`] = floor(
-            result.size / (1024 * 1024),
-            2,
-          );
-
-          return result.url;
-        }),
-      );
+        uploadedUrls.push(result.url);
+      }
 
       await Logger.logUploadImage({
         ...durationOfUploadImages,


### PR DESCRIPTION
## Summary

- 접근성 정보 등록 시 이미지 업로드 진행 상황을 단계별로 표시
- 기존 Lottie 로딩 화면 → 이미지별 프로그레스 바 + 용량 + 퍼센트 표시로 교체
- fetch → XMLHttpRequest 변경으로 byte-level upload progress 지원

### 변경 전
전체 화면 Lottie 로딩 (진행 상황 알 수 없음)

### 변경 후
```
┌─────────────────────────┐
│   사진 업로드 중 (1/3)    │
│   0.95 MB               │
│   ████████░░░░  67%     │
└─────────────────────────┘
```

### 기술 변경
- `fetch` → `XMLHttpRequest` (xhr.upload.onprogress로 progress callback)
- `Promise.all` 병렬 → `for...of` 순차 (이미지별 진행 표시를 위해)
- `UploadProgressOverlay` 컴포넌트 신규 생성
- Building/PlaceFormV2Screen에서 `loadingState` 대신 `uploadProgress` state 사용

## Test plan
- [ ] 장소 접근성 등록: 사진 1-3장 → 압축/업로드/등록 단계별 프로그레스 표시 확인
- [ ] 건물 접근성 등록: 입구 사진 + 엘리베이터 사진 → 프로그레스 표시 확인
- [ ] 네트워크 느린 환경에서 프로그레스 바가 천천히 차는지 확인
- [ ] 업로드 실패 시 기존 에러 토스트 정상 동작 확인
- [ ] 뒤로가기 버튼으로 업로드 중 이탈 방지 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual upload progress overlay now appears across place/building/report forms.
  * Shows upload stages (compressing, uploading, registering), file size and percent during uploading.
  * Progress bar switches between animated indeterminate and determinate (reflecting actual progress).
  * Prevents back navigation while uploads are active to avoid interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->