### PR TITLE
feat: 신고하기 플로우 디자인 개편

### DIFF
--- a/src/components/atoms/SccPrimaryButton.tsx
+++ b/src/components/atoms/SccPrimaryButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {TextStyle, ViewStyle} from 'react-native';
+
+import {font} from '@/constant/font';
+
+import {SccButton} from './SccButton';
+
+interface SccPrimaryButtonProps {
+  text: string;
+  onPress?: () => void;
+  isDisabled?: boolean;
+  elementName: string;
+  logParams?: Record<string, any>;
+  style?: ViewStyle;
+  width?: ViewStyle['width'];
+  height?: ViewStyle['height'];
+  fontSize?: TextStyle['fontSize'];
+  leftIcon?: React.ComponentType<any>;
+  rightIcon?: React.ComponentType<any>;
+}
+
+export const SccPrimaryButton = ({
+  text,
+  onPress,
+  isDisabled = false,
+  elementName,
+  logParams,
+  style,
+  width,
+  height = 56,
+  fontSize = 18,
+  leftIcon,
+  rightIcon,
+}: SccPrimaryButtonProps) => {
+  return (
+    <SccButton
+      text={text}
+      onPress={onPress}
+      isDisabled={isDisabled}
+      elementName={elementName}
+      logParams={logParams}
+      buttonColor="brandColor"
+      textColor="white"
+      fontFamily={font.pretendardSemibold}
+      fontSize={fontSize}
+      width={width}
+      height={height}
+      leftIcon={leftIcon}
+      rightIcon={rightIcon}
+      style={{borderRadius: 8, ...style}}
+    />
+  );
+};

--- a/src/components/atoms/SccSecondaryButton.tsx
+++ b/src/components/atoms/SccSecondaryButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {TextStyle, ViewStyle} from 'react-native';
+
+import {font} from '@/constant/font';
+
+import {SccButton} from './SccButton';
+
+interface SccSecondaryButtonProps {
+  text: string;
+  onPress?: () => void;
+  isDisabled?: boolean;
+  elementName: string;
+  logParams?: Record<string, any>;
+  style?: ViewStyle;
+  width?: ViewStyle['width'];
+  height?: ViewStyle['height'];
+  fontSize?: TextStyle['fontSize'];
+  leftIcon?: React.ComponentType<any>;
+  rightIcon?: React.ComponentType<any>;
+}
+
+export const SccSecondaryButton = ({
+  text,
+  onPress,
+  isDisabled = false,
+  elementName,
+  logParams,
+  style,
+  width,
+  height = 56,
+  fontSize = 18,
+  leftIcon,
+  rightIcon,
+}: SccSecondaryButtonProps) => {
+  return (
+    <SccButton
+      text={text}
+      onPress={onPress}
+      isDisabled={isDisabled}
+      elementName={elementName}
+      logParams={logParams}
+      buttonColor="gray20"
+      textColor="gray90"
+      fontFamily={font.pretendardSemibold}
+      fontSize={fontSize}
+      width={width}
+      height={height}
+      leftIcon={leftIcon}
+      rightIcon={rightIcon}
+      style={{borderRadius: 8, ...style}}
+    />
+  );
+};

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,2 +1,4 @@
 export * from './SccButton';
 export * from './SccInput';
+export * from './SccPrimaryButton';
+export * from './SccSecondaryButton';

--- a/src/constant/options.ts
+++ b/src/constant/options.ts
@@ -11,7 +11,7 @@ export const doorTypeMap = {
   [EntranceDoorType.Sliding]: '미닫이문',
   [EntranceDoorType.Automatic]: '자동문',
   [EntranceDoorType.Revolving]: '회전문',
-  [EntranceDoorType.Etc]: '기타',
+  [EntranceDoorType.Etc]: '기타 문',
   [EntranceDoorType.None]: '문 없음',
 } as const;
 

--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -4,7 +4,11 @@ import styled from 'styled-components/native';
 
 import {match} from 'ts-pattern';
 
-import {SccButton} from '@/components/atoms';
+import {
+  SccButton,
+  SccPrimaryButton,
+  SccSecondaryButton,
+} from '@/components/atoms';
 import TextArea from '@/components/form/TextArea';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
@@ -91,9 +95,6 @@ function getCategoryLabel(
       const doorTypes = snapshot?.entranceDoorTypes;
       if (doorTypes && doorTypes.length > 0 && doorTypes.length <= 2) {
         const label = doorTypes.map(d => doorTypeMap[d]).join(', ');
-        if (label === '기타') {
-          return '출입문 유형이 잘못됐어요';
-        }
         return `${label}이 아니에요`;
       }
       return '출입문 종류가 잘못됐어요';
@@ -320,9 +321,12 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
                       .with('CLOSED', () => '폐점/이전된 곳이에요')
                       .with('BAD_USER', () => '이 정복자를 차단할래요')
                       .exhaustive()}
-                    textColor={isSelected ? 'brandColor' : 'gray70'}
-                    buttonColor="white"
-                    borderColor={isSelected ? 'blue50' : 'gray30'}
+                    textColor={isSelected ? 'brand50' : 'gray80v2'}
+                    buttonColor={isSelected ? 'brand5' : 'white'}
+                    borderColor={isSelected ? 'brand40' : 'gray20v2'}
+                    fontFamily={font.pretendardMedium}
+                    fontSize={16}
+                    style={{borderRadius: 14}}
                     onPress={() => {
                       setSelectedReason(reason);
                     }}
@@ -401,9 +405,12 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
                     {index > 0 && <SpaceBetweenOptions />}
                     <SccButton
                       text={item.label}
-                      textColor={isSelected ? 'brandColor' : 'gray70'}
-                      buttonColor="white"
-                      borderColor={isSelected ? 'blue50' : 'gray30'}
+                      textColor={isSelected ? 'brand50' : 'gray80v2'}
+                      buttonColor={isSelected ? 'brand5' : 'white'}
+                      borderColor={isSelected ? 'brand40' : 'gray20v2'}
+                      fontFamily={font.pretendardMedium}
+                      fontSize={16}
+                      style={{borderRadius: 14}}
                       onPress={() => {
                         setSelectedCategory(item.category);
                         setSelectedElevatorTarget(item.elevatorTarget ?? null);
@@ -431,9 +438,12 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
                     {index > 0 && <SpaceBetweenOptions />}
                     <SccButton
                       text={CLOSED_SUB_TYPE_LABELS[subType]}
-                      textColor={isSelected ? 'brandColor' : 'gray70'}
-                      buttonColor="white"
-                      borderColor={isSelected ? 'blue50' : 'gray30'}
+                      textColor={isSelected ? 'brand50' : 'gray80v2'}
+                      buttonColor={isSelected ? 'brand5' : 'white'}
+                      borderColor={isSelected ? 'brand40' : 'gray20v2'}
+                      fontFamily={font.pretendardMedium}
+                      fontSize={16}
+                      style={{borderRadius: 14}}
                       onPress={() => {
                         setSelectedClosedSubType(subType);
                       }}
@@ -479,9 +489,6 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
         <ButtonContainer>
           <CloseButton
             text={step === 'reason' ? '닫기' : '이전'}
-            textColor="black"
-            buttonColor="gray10"
-            fontFamily={font.pretendardBold}
             onPress={step === 'reason' ? handleClose : handleBack}
             elementName={
               step === 'reason' ? 'place_feedback_close' : 'place_feedback_back'
@@ -490,9 +497,6 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
           <SpaceBetweenButtons />
           <SubmitButton
             text={getSubmitButtonText()}
-            textColor="white"
-            buttonColor="brandColor"
-            fontFamily={font.pretendardBold}
             isDisabled={isSubmitDisabled()}
             onPress={handleSubmit}
             elementName="place_feedback_submit"
@@ -537,11 +541,11 @@ const SpaceBetweenButtons = styled.View`
   width: 10px;
 `;
 
-const CloseButton = styled(SccButton)`
+const CloseButton = styled(SccSecondaryButton)`
   flex: 1;
 `;
 
-const SubmitButton = styled(SccButton)`
+const SubmitButton = styled(SccPrimaryButton)`
   flex: 2;
 `;
 

--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -314,19 +314,13 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
               return (
                 <View key={reason}>
                   {index > 0 && <SpaceBetweenOptions />}
-                  <SccButton
-                    key={reason}
+                  <FeedbackOptionButton
                     text={match(reason)
                       .with('INACCURATE_INFO', () => '틀린 정보가 있어요')
                       .with('CLOSED', () => '폐점/이전된 곳이에요')
                       .with('BAD_USER', () => '이 정복자를 차단할래요')
                       .exhaustive()}
-                    textColor={isSelected ? 'brand50' : 'gray80v2'}
-                    buttonColor={isSelected ? 'brand5' : 'white'}
-                    borderColor={isSelected ? 'brand40' : 'gray20v2'}
-                    fontFamily={font.pretendardMedium}
-                    fontSize={16}
-                    style={{borderRadius: 14}}
+                    isSelected={isSelected}
                     onPress={() => {
                       setSelectedReason(reason);
                     }}
@@ -403,14 +397,9 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
                 return (
                   <View key={item.key}>
                     {index > 0 && <SpaceBetweenOptions />}
-                    <SccButton
+                    <FeedbackOptionButton
                       text={item.label}
-                      textColor={isSelected ? 'brand50' : 'gray80v2'}
-                      buttonColor={isSelected ? 'brand5' : 'white'}
-                      borderColor={isSelected ? 'brand40' : 'gray20v2'}
-                      fontFamily={font.pretendardMedium}
-                      fontSize={16}
-                      style={{borderRadius: 14}}
+                      isSelected={isSelected}
                       onPress={() => {
                         setSelectedCategory(item.category);
                         setSelectedElevatorTarget(item.elevatorTarget ?? null);
@@ -436,14 +425,9 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
                 return (
                   <View key={subType}>
                     {index > 0 && <SpaceBetweenOptions />}
-                    <SccButton
+                    <FeedbackOptionButton
                       text={CLOSED_SUB_TYPE_LABELS[subType]}
-                      textColor={isSelected ? 'brand50' : 'gray80v2'}
-                      buttonColor={isSelected ? 'brand5' : 'white'}
-                      borderColor={isSelected ? 'brand40' : 'gray20v2'}
-                      fontFamily={font.pretendardMedium}
-                      fontSize={16}
-                      style={{borderRadius: 14}}
+                      isSelected={isSelected}
                       onPress={() => {
                         setSelectedClosedSubType(subType);
                       }}
@@ -508,6 +492,38 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
 };
 
 export default PlaceDetailNegativeFeedbackBottomSheet;
+
+/** Step 1/2에서 공통으로 쓰이는 선택 옵션 버튼. Figma 신고하기 633-7837 토큰. */
+interface FeedbackOptionButtonProps {
+  text: string;
+  isSelected: boolean;
+  onPress: () => void;
+  elementName: string;
+  logParams?: Record<string, unknown>;
+}
+
+function FeedbackOptionButton({
+  text,
+  isSelected,
+  onPress,
+  elementName,
+  logParams,
+}: FeedbackOptionButtonProps) {
+  return (
+    <SccButton
+      text={text}
+      textColor={isSelected ? 'brand50' : 'gray80v2'}
+      buttonColor={isSelected ? 'brand5' : 'white'}
+      borderColor={isSelected ? 'brand40' : 'gray20v2'}
+      fontFamily={font.pretendardMedium}
+      fontSize={16}
+      style={{borderRadius: 14}}
+      onPress={onPress}
+      elementName={elementName}
+      logParams={logParams}
+    />
+  );
+}
 
 const ContentsContainer = styled.View`
   flex-direction: column;

--- a/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
+++ b/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
@@ -3,11 +3,11 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {ActivityIndicator, ScrollView} from 'react-native';
 import styled from 'styled-components/native';
 
-import {SccButton} from '@/components/atoms';
-import TextArea from '@/components/form/TextArea';
+import {SccPrimaryButton} from '@/components/atoms';
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
+import TextAreaV2 from '@/screens/PlaceFormV2Screen/components/TextAreaV2';
 import {
   AccessibilityInfoV2Dto,
   AccessLevelCorrectionDto,
@@ -998,11 +998,6 @@ export default function ReportCorrectionFormScreen({
         return (
           <SectionContainer>
             <PlaceEntranceCorrectionSection
-              sectionTitle={
-                accessibilityData?.buildingAccessibility
-                  ? '장소 입구 정보'
-                  : undefined
-              }
               stairInfo={placeCorrection.stairInfo}
               stairHeightLevel={placeCorrection.stairHeightLevel}
               hasSlope={placeCorrection.hasSlope}
@@ -1257,35 +1252,35 @@ export default function ReportCorrectionFormScreen({
 
   return (
     <ScreenLayout isHeaderVisible={true} isKeyboardAvoidingView={true}>
-      <ScrollView
-        contentContainerStyle={{paddingHorizontal: 24, paddingBottom: 40}}>
-        <PageTitle>올바른 정보를 알려주세요</PageTitle>
-        <PageDescription>
-          선택한 항목에 대한 올바른 정보를 입력해주세요.
-        </PageDescription>
+      <ScrollView contentContainerStyle={{paddingBottom: 40}}>
+        <PageHeader>
+          <PageTitle>올바른 정보로 수정해주세요.</PageTitle>
+          <PageDescription>
+            잘못되었거나 수정이 필요한 정보를 알려주세요.
+          </PageDescription>
+        </PageHeader>
 
-        {renderSection()}
+        <FormBody>
+          {renderSection()}
 
-        <SectionContainer>
-          <SectionTitle>부연 설명 (선택)</SectionTitle>
-          <TextArea
-            placeholder="추가로 설명할 내용이 있다면 입력해주세요."
-            value={noteText}
-            onChangeText={setNoteText}
-          />
-        </SectionContainer>
+          <NoteSectionContainer>
+            <NoteLabel>부연 설명</NoteLabel>
+            <TextAreaV2
+              placeholder="추가로 설명할 내용이 있다면 알려주세요"
+              value={noteText}
+              onChangeText={setNoteText}
+            />
+          </NoteSectionContainer>
 
-        <SubmitButtonContainer>
-          <SccButton
-            text="제출하기"
-            textColor="white"
-            buttonColor="brandColor"
-            fontFamily={font.pretendardBold}
-            isDisabled={isSubmitDisabled}
-            onPress={() => submitMutation.mutate(undefined)}
-            elementName="report_correction_submit"
-          />
-        </SubmitButtonContainer>
+          <SubmitButtonContainer>
+            <SccPrimaryButton
+              text="제출하기"
+              isDisabled={isSubmitDisabled}
+              onPress={() => submitMutation.mutate(undefined)}
+              elementName="report_correction_submit"
+            />
+          </SubmitButtonContainer>
+        </FormBody>
       </ScrollView>
       <UploadProgressOverlay {...uploadProgress} />
     </ScreenLayout>
@@ -1298,32 +1293,45 @@ const LoadingContainer = styled.View`
   align-items: center;
 `;
 
+const PageHeader = styled.View`
+  background-color: ${color.gray10};
+  gap: 8px;
+  padding: 24px 20px;
+`;
+
 const PageTitle = styled.Text`
-  font-size: 22px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-top: 24px;
-  margin-bottom: 8px;
+  font-size: 20px;
+  line-height: 28px;
+  letter-spacing: -0.4px;
+  font-family: ${font.pretendardSemibold};
+  color: ${color.gray90v2};
 `;
 
 const PageDescription = styled.Text`
-  font-size: 14px;
+  font-size: 15px;
+  line-height: 22px;
+  letter-spacing: -0.3px;
   font-family: ${font.pretendardRegular};
-  color: ${color.gray50};
-  margin-bottom: 24px;
+  color: ${color.gray60v2};
 `;
 
-const SectionContainer = styled.View`
-  margin-bottom: 28px;
+const FormBody = styled.View`
+  padding: 30px 20px;
+  gap: 48px;
 `;
 
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 12px;
+const SectionContainer = styled.View``;
+
+const NoteSectionContainer = styled.View`
+  gap: 16px;
 `;
 
-const SubmitButtonContainer = styled.View`
-  margin-top: 12px;
+const NoteLabel = styled.Text`
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -0.36px;
+  font-family: ${font.pretendardSemibold};
+  color: ${color.gray80v2};
 `;
+
+const SubmitButtonContainer = styled.View``;

--- a/src/screens/ReportCorrectionFormScreen/sections/AccessLevelCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/AccessLevelCorrectionSection.tsx
@@ -5,14 +5,15 @@ import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 
 import OptionsV2 from '../../PlaceFormV2Screen/components/OptionsV2';
+import {SectionRoot, SubLabel} from './shared';
 
 const ACCESS_LEVEL_OPTIONS = [
-  {value: 0, label: '레벨 0 (계단/턱 없음)'},
-  {value: 1, label: '레벨 1 (계단 1칸, 엄지 반마디 이하)'},
-  {value: 2, label: '레벨 2 (계단 1칸, 엄지 한마디 정도)'},
-  {value: 3, label: '레벨 3 (계단 1칸, 엄지 한마디 이상)'},
-  {value: 4, label: '레벨 4 (계단 2~5칸)'},
-  {value: 5, label: '레벨 5 (계단 6칸 이상)'},
+  {value: 0, label: '접근레벨 0 (계단/턱 없음)'},
+  {value: 1, label: '접근레벨 1 (계단 1칸, 엄지 반마디 이하)'},
+  {value: 2, label: '접근레벨 2 (계단 1칸, 엄지 한마디 정도)'},
+  {value: 3, label: '접근레벨 3 (계단 1칸, 엄지 한마디 이상)'},
+  {value: 4, label: '접근레벨 4 (계단 2~5칸)'},
+  {value: 5, label: '접근레벨 5 (계단 6칸 이상)'},
 ];
 
 interface AccessLevelCorrectionSectionProps {
@@ -27,44 +28,38 @@ export default function AccessLevelCorrectionSection({
   onChangeLevel,
 }: AccessLevelCorrectionSectionProps) {
   return (
-    <Container>
-      <SectionTitle>접근레벨</SectionTitle>
-
-      {currentLevel !== undefined && (
-        <CurrentLevelText>현재: 레벨 {currentLevel}</CurrentLevelText>
-      )}
-
-      <SubLabel>실제 접근레벨은?</SubLabel>
-      <OptionsV2
-        options={ACCESS_LEVEL_OPTIONS}
-        value={selectedLevel}
-        columns={1}
-        onSelect={onChangeLevel}
-      />
-    </Container>
+    <SectionRoot>
+      <Group>
+        <Header>
+          <SubLabel>실제 접근 레벨을 확인해주세요</SubLabel>
+          {currentLevel !== undefined && (
+            <CurrentLevelText>현재: 접근레벨 {currentLevel}</CurrentLevelText>
+          )}
+        </Header>
+        <OptionsV2
+          options={ACCESS_LEVEL_OPTIONS}
+          value={selectedLevel}
+          columns={1}
+          onSelect={onChangeLevel}
+        />
+      </Group>
+    </SectionRoot>
   );
 }
 
-// Styled components
-const Container = styled.View``;
+const Group = styled.View`
+  gap: 16px;
+  padding-bottom: 12px;
+`;
 
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 12px;
+const Header = styled.View`
+  gap: 12px;
 `;
 
 const CurrentLevelText = styled.Text`
-  font-size: 14px;
+  font-size: 16px;
+  line-height: 24px;
+  letter-spacing: -0.32px;
   font-family: ${font.pretendardMedium};
   color: ${color.brandColor};
-  margin-bottom: 12px;
-`;
-
-const SubLabel = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardMedium};
-  color: ${color.gray60};
-  margin-bottom: 8px;
 `;

--- a/src/screens/ReportCorrectionFormScreen/sections/BuildingEntranceCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/BuildingEntranceCorrectionSection.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import styled from 'styled-components/native';
 
-import {color} from '@/constant/color';
-import {font} from '@/constant/font';
 import {StairInfo, StairHeightLevel} from '@/generated-sources/openapi';
 import ImageFile from '@/models/ImageFile';
 
 import OptionsV2 from '../../PlaceFormV2Screen/components/OptionsV2';
 import {ENTRANCE_OPTIONS} from '../../PlaceFormV2Screen/hooks';
 import PhotoEditSlots from './PhotoEditSlots';
+import {FormGroup, GuideLink, SectionRoot, SubLabel} from './shared';
 
 interface BuildingEntranceCorrectionSectionProps {
   entranceStairInfo?: StairInfo;
@@ -44,39 +42,50 @@ export default function BuildingEntranceCorrectionSection({
   const showStairHeight = entranceStairInfo === StairInfo.One;
 
   return (
-    <Container>
-      <SectionTitle>건물 입구 정보</SectionTitle>
-
-      <SubLabel>계단 수</SubLabel>
-      <OptionsV2
-        options={ENTRANCE_OPTIONS.stairInfoOptions}
-        value={entranceStairInfo}
-        columns={2}
-        onSelect={onChangeEntranceStairInfo}
-      />
+    <SectionRoot>
+      <FormGroup>
+        <SubLabel>계단 수를 확인해주세요</SubLabel>
+        <OptionsV2
+          options={ENTRANCE_OPTIONS.stairInfoOptions}
+          value={entranceStairInfo}
+          columns={2}
+          onSelect={onChangeEntranceStairInfo}
+        />
+        <GuideLink
+          type="stair"
+          elementName="report_correction_building_entrance_stair_guide"
+        />
+      </FormGroup>
 
       {showStairHeight && (
-        <>
-          <SubLabel>계단 높이</SubLabel>
+        <FormGroup>
+          <SubLabel>계단 높이를 확인해주세요</SubLabel>
           <OptionsV2
             options={ENTRANCE_OPTIONS.stairHeightOptions}
             value={entranceStairHeightLevel}
             columns={1}
             onSelect={onChangeEntranceStairHeightLevel}
           />
-        </>
+        </FormGroup>
       )}
 
-      <SubLabel>경사로</SubLabel>
-      <OptionsV2
-        options={ENTRANCE_OPTIONS.slopeOptions}
-        value={hasSlope}
-        columns={2}
-        onSelect={onChangeHasSlope}
-      />
+      <FormGroup>
+        <SubLabel>경사로 유무를 확인해주세요</SubLabel>
+        <OptionsV2
+          options={ENTRANCE_OPTIONS.slopeOptions}
+          value={hasSlope}
+          columns={2}
+          onSelect={onChangeHasSlope}
+        />
+        <GuideLink
+          type="slope"
+          elementName="report_correction_building_entrance_slope_guide"
+        />
+      </FormGroup>
 
-      <SubLabel>건물 입구 사진</SubLabel>
       <PhotoEditSlots
+        title="건물 입구 사진을 확인해주세요"
+        description="최대 3장까지 등록 가능해요"
         existingPhotoUrls={existingBaEntrancePhotoUrls}
         newPhotos={newBaEntrancePhotos}
         deletedExistingIndices={deletedBaEntrancePhotoIndices}
@@ -86,24 +95,6 @@ export default function BuildingEntranceCorrectionSection({
         onReplaceExisting={onReplaceExistingBaEntrancePhoto}
         onChangeNewPhotos={onChangeNewBaEntrancePhotos}
       />
-    </Container>
+    </SectionRoot>
   );
 }
-
-// Styled components
-const Container = styled.View``;
-
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 16px;
-`;
-
-const SubLabel = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardMedium};
-  color: ${color.gray60};
-  margin-bottom: 8px;
-  margin-top: 12px;
-`;

--- a/src/screens/ReportCorrectionFormScreen/sections/DoorTypeCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/DoorTypeCorrectionSection.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import styled from 'styled-components/native';
 
-import {color} from '@/constant/color';
-import {font} from '@/constant/font';
 import {makeDoorTypeOptions} from '@/constant/options';
 import {EntranceDoorType} from '@/generated-sources/openapi';
 
 import OptionsV2 from '../../PlaceFormV2Screen/components/OptionsV2';
+import {FormGroup, SectionRoot, SubLabel} from './shared';
 
 interface DoorTypeCorrectionSectionProps {
   entranceDoorTypes?: EntranceDoorType[];
@@ -20,25 +18,16 @@ export default function DoorTypeCorrectionSection({
   const options = makeDoorTypeOptions(entranceDoorTypes);
 
   return (
-    <Container>
-      <SectionTitle>입구 문이 어떤 유형인가요? (복수 선택 가능)</SectionTitle>
-
-      <OptionsV2.Multiple
-        options={options}
-        values={entranceDoorTypes}
-        columns={2}
-        onSelect={onChangeDoorTypes}
-      />
-    </Container>
+    <SectionRoot>
+      <FormGroup>
+        <SubLabel>출입문은 어떤 종류인가요?</SubLabel>
+        <OptionsV2.Multiple
+          options={options}
+          values={entranceDoorTypes}
+          columns={2}
+          onSelect={onChangeDoorTypes}
+        />
+      </FormGroup>
+    </SectionRoot>
   );
 }
-
-// Styled components
-const Container = styled.View``;
-
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 16px;
-`;

--- a/src/screens/ReportCorrectionFormScreen/sections/ElevatorCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/ElevatorCorrectionSection.tsx
@@ -1,8 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import styled from 'styled-components/native';
 
-import {color} from '@/constant/color';
-import {font} from '@/constant/font';
 import {
   ElevatorAccessibilityDto,
   StairInfo,
@@ -16,6 +13,7 @@ import {
   ELEVATOR_OPTIONS,
 } from '../../PlaceFormV2Screen/hooks';
 import PhotoEditSlots from './PhotoEditSlots';
+import {FormGroup, GuideLink, SectionRoot, SubLabel} from './shared';
 
 interface ElevatorCorrectionSectionProps {
   elevatorAccessibility?: ElevatorAccessibilityDto;
@@ -92,36 +90,43 @@ export default function ElevatorCorrectionSection({
   );
 
   return (
-    <Container>
-      <SectionTitle>엘리베이터가 있나요?</SectionTitle>
-
-      <OptionsV2
-        options={ELEVATOR_OPTIONS.hasElevatorOptions}
-        value={hasElevator}
-        columns={2}
-        onSelect={handleHasElevatorChange}
-      />
+    <SectionRoot>
+      <FormGroup>
+        <SubLabel>엘리베이터가 있는지 확인해주세요</SubLabel>
+        <OptionsV2
+          options={ELEVATOR_OPTIONS.hasElevatorOptions}
+          value={hasElevator}
+          columns={2}
+          onSelect={handleHasElevatorChange}
+        />
+      </FormGroup>
 
       {conditions.showElevatorDetails && (
         <>
-          <SubLabel>엘리베이터까지 계단</SubLabel>
-          <OptionsV2
-            options={ELEVATOR_OPTIONS.stairInfoOptions}
-            value={elevatorAccessibility?.stairInfo}
-            columns={2}
-            onSelect={(value: StairInfo) =>
-              update({
-                stairInfo: value,
-                ...(value !== StairInfo.One
-                  ? {stairHeightLevel: undefined}
-                  : {}),
-              })
-            }
-          />
+          <FormGroup>
+            <SubLabel>엘리베이터까지 계단을 확인해주세요</SubLabel>
+            <OptionsV2
+              options={ELEVATOR_OPTIONS.stairInfoOptions}
+              value={elevatorAccessibility?.stairInfo}
+              columns={2}
+              onSelect={(value: StairInfo) =>
+                update({
+                  stairInfo: value,
+                  ...(value !== StairInfo.One
+                    ? {stairHeightLevel: undefined}
+                    : {}),
+                })
+              }
+            />
+            <GuideLink
+              type="stair"
+              elementName="report_correction_elevator_stair_guide"
+            />
+          </FormGroup>
 
           {conditions.showStairHeight && (
-            <>
-              <SubLabel>계단 높이</SubLabel>
+            <FormGroup>
+              <SubLabel>계단 높이를 확인해주세요</SubLabel>
               <OptionsV2
                 options={ELEVATOR_OPTIONS.stairHeightOptions}
                 value={elevatorAccessibility?.stairHeightLevel}
@@ -130,19 +135,26 @@ export default function ElevatorCorrectionSection({
                   update({stairHeightLevel: value})
                 }
               />
-            </>
+            </FormGroup>
           )}
 
-          <SubLabel>엘리베이터 앞 경사로</SubLabel>
-          <OptionsV2
-            options={ELEVATOR_OPTIONS.slopeOptions}
-            value={elevatorAccessibility?.hasSlope}
-            columns={2}
-            onSelect={(value: boolean) => update({hasSlope: value})}
-          />
+          <FormGroup>
+            <SubLabel>엘리베이터 앞 경사로를 확인해주세요</SubLabel>
+            <OptionsV2
+              options={ELEVATOR_OPTIONS.slopeOptions}
+              value={elevatorAccessibility?.hasSlope}
+              columns={2}
+              onSelect={(value: boolean) => update({hasSlope: value})}
+            />
+            <GuideLink
+              type="slope"
+              elementName="report_correction_elevator_slope_guide"
+            />
+          </FormGroup>
 
-          <SubLabel>매장 엘리베이터 사진</SubLabel>
           <PhotoEditSlots
+            title="매장 엘리베이터 사진을 확인해주세요"
+            description="최대 3장까지 등록 가능해요"
             existingPhotoUrls={existingElevatorPhotoUrls}
             newPhotos={newElevatorPhotos}
             deletedExistingIndices={deletedElevatorPhotoIndices}
@@ -154,40 +166,21 @@ export default function ElevatorCorrectionSection({
           />
 
           {needsBaPhotos && (
-            <>
-              <SubLabel>건물 엘리베이터 사진</SubLabel>
-              <PhotoEditSlots
-                existingPhotoUrls={existingBaElevatorPhotoUrls}
-                newPhotos={newBaElevatorPhotos}
-                deletedExistingIndices={deletedBaElevatorPhotoIndices}
-                replacedPhotos={replacedBaElevatorPhotos}
-                maxPhotos={3}
-                onDeleteExisting={onDeleteExistingBaElevatorPhoto}
-                onReplaceExisting={onReplaceExistingBaElevatorPhoto}
-                onChangeNewPhotos={onChangeNewBaElevatorPhotos}
-              />
-            </>
+            <PhotoEditSlots
+              title="건물 엘리베이터 사진을 확인해주세요"
+              description="최대 3장까지 등록 가능해요"
+              existingPhotoUrls={existingBaElevatorPhotoUrls}
+              newPhotos={newBaElevatorPhotos}
+              deletedExistingIndices={deletedBaElevatorPhotoIndices}
+              replacedPhotos={replacedBaElevatorPhotos}
+              maxPhotos={3}
+              onDeleteExisting={onDeleteExistingBaElevatorPhoto}
+              onReplaceExisting={onReplaceExistingBaElevatorPhoto}
+              onChangeNewPhotos={onChangeNewBaElevatorPhotos}
+            />
           )}
         </>
       )}
-    </Container>
+    </SectionRoot>
   );
 }
-
-// Styled components
-const Container = styled.View``;
-
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 16px;
-`;
-
-const SubLabel = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardMedium};
-  color: ${color.gray60};
-  margin-bottom: 8px;
-  margin-top: 12px;
-`;

--- a/src/screens/ReportCorrectionFormScreen/sections/FloorCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/FloorCorrectionSection.tsx
@@ -1,8 +1,5 @@
 import React, {useCallback, useEffect, useMemo} from 'react';
-import styled from 'styled-components/native';
 
-import {color} from '@/constant/color';
-import {font} from '@/constant/font';
 import {
   FloorMovingMethodTypeDto,
   StairInfo,
@@ -23,6 +20,7 @@ import type {
   FloorOptionKey,
   StandaloneBuildingType,
 } from '../../PlaceFormV2Screen/types';
+import {FormGroup, GuideLink, SectionRoot, SubLabel} from './shared';
 
 export interface FloorFormState {
   floorOption: FloorOptionKey | null;
@@ -97,6 +95,17 @@ export default function FloorCorrectionSection({
     }
   }, [hasPlaceElevator, elevatorAccessibility, onChangeElevatorAccessibility]);
 
+  // 층간이동 질문이 더 이상 필요 없어지면 선택값도 초기화 (연쇄로 엘리베이터 정보도 초기화됨)
+  useEffect(() => {
+    if (!conditions.showFloorMovement && floorMovingMethodTypes.length > 0) {
+      onChangeFloorMovingMethodTypes([]);
+    }
+  }, [
+    conditions.showFloorMovement,
+    floorMovingMethodTypes,
+    onChangeFloorMovingMethodTypes,
+  ]);
+
   const handleOptionSelect = useCallback(
     (option: FloorOptionKey) => {
       setFloorOption(option);
@@ -135,24 +144,24 @@ export default function FloorCorrectionSection({
   );
 
   return (
-    <Container>
-      <SectionTitle>이 장소는 건물의 1층에 있나요?</SectionTitle>
-
-      <FloorQuestionUI
-        floorOption={floorOption}
-        selectedFloor={detailFloorValue}
-        standaloneType={standaloneType}
-        onChangeFloorOption={handleOptionSelect}
-        onChangeSelectedFloor={handleFloorChange}
-        onChangeStandaloneType={handleStandaloneTypeChange}
-      />
+    <SectionRoot>
+      <FormGroup>
+        <SubLabel>이 장소는 건물의 1층에 있나요?</SubLabel>
+        <FloorQuestionUI
+          floorOption={floorOption}
+          selectedFloor={detailFloorValue}
+          standaloneType={standaloneType}
+          onChangeFloorOption={handleOptionSelect}
+          onChangeSelectedFloor={handleFloorChange}
+          onChangeStandaloneType={handleStandaloneTypeChange}
+        />
+      </FormGroup>
 
       {conditions.showFloorMovement && (
-        <FloorMovementContainer>
-          <SubSectionTitle>
-            1층에서 다른층으로 이동가능한 방법을 모두 알려주세요
-          </SubSectionTitle>
-
+        <FormGroup>
+          <SubLabel>
+            1층에서 다른층으로 이동 가능한 방법을 확인해주세요
+          </SubLabel>
           <OptionsV2.Multiple
             columns={2}
             values={floorMovingMethodTypes}
@@ -162,31 +171,35 @@ export default function FloorCorrectionSection({
             )}
             onSelect={onChangeFloorMovingMethodTypes}
           />
-        </FloorMovementContainer>
+        </FormGroup>
       )}
 
       {hasPlaceElevator && (
-        <ElevatorInfoContainer>
-          <SubSectionTitle>엘리베이터 정보</SubSectionTitle>
-
-          <ElevatorSubLabel>엘리베이터까지 계단</ElevatorSubLabel>
-          <OptionsV2
-            options={ELEVATOR_OPTIONS.stairInfoOptions}
-            value={elevatorAccessibility?.stairInfo}
-            columns={2}
-            onSelect={(value: StairInfo) =>
-              updateElevatorField({
-                stairInfo: value,
-                ...(value !== StairInfo.One
-                  ? {stairHeightLevel: undefined}
-                  : {}),
-              })
-            }
-          />
+        <>
+          <FormGroup>
+            <SubLabel>엘리베이터까지 계단을 확인해주세요</SubLabel>
+            <OptionsV2
+              options={ELEVATOR_OPTIONS.stairInfoOptions}
+              value={elevatorAccessibility?.stairInfo}
+              columns={2}
+              onSelect={(value: StairInfo) =>
+                updateElevatorField({
+                  stairInfo: value,
+                  ...(value !== StairInfo.One
+                    ? {stairHeightLevel: undefined}
+                    : {}),
+                })
+              }
+            />
+            <GuideLink
+              type="stair"
+              elementName="report_correction_floor_elevator_stair_guide"
+            />
+          </FormGroup>
 
           {elevatorConditions.showStairHeight && (
-            <>
-              <ElevatorSubLabel>계단 높이</ElevatorSubLabel>
+            <FormGroup>
+              <SubLabel>계단 높이를 확인해주세요</SubLabel>
               <OptionsV2
                 options={ELEVATOR_OPTIONS.stairHeightOptions}
                 value={elevatorAccessibility?.stairHeightLevel}
@@ -195,53 +208,26 @@ export default function FloorCorrectionSection({
                   updateElevatorField({stairHeightLevel: value})
                 }
               />
-            </>
+            </FormGroup>
           )}
 
-          <ElevatorSubLabel>엘리베이터 앞 경사로</ElevatorSubLabel>
-          <OptionsV2
-            options={ELEVATOR_OPTIONS.slopeOptions}
-            value={elevatorAccessibility?.hasSlope}
-            columns={2}
-            onSelect={(value: boolean) =>
-              updateElevatorField({hasSlope: value})
-            }
-          />
-        </ElevatorInfoContainer>
+          <FormGroup>
+            <SubLabel>엘리베이터 앞 경사로를 확인해주세요</SubLabel>
+            <OptionsV2
+              options={ELEVATOR_OPTIONS.slopeOptions}
+              value={elevatorAccessibility?.hasSlope}
+              columns={2}
+              onSelect={(value: boolean) =>
+                updateElevatorField({hasSlope: value})
+              }
+            />
+            <GuideLink
+              type="slope"
+              elementName="report_correction_floor_elevator_slope_guide"
+            />
+          </FormGroup>
+        </>
       )}
-    </Container>
+    </SectionRoot>
   );
 }
-
-// Styled components
-const Container = styled.View``;
-
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 16px;
-`;
-
-const FloorMovementContainer = styled.View`
-  margin-top: 24px;
-`;
-
-const ElevatorInfoContainer = styled.View`
-  margin-top: 24px;
-`;
-
-const SubSectionTitle = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardSemibold};
-  color: ${color.black};
-  margin-bottom: 12px;
-`;
-
-const ElevatorSubLabel = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardMedium};
-  color: ${color.gray60};
-  margin-bottom: 8px;
-  margin-top: 12px;
-`;

--- a/src/screens/ReportCorrectionFormScreen/sections/PhotoCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/PhotoCorrectionSection.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import styled from 'styled-components/native';
 
-import {color} from '@/constant/color';
-import {font} from '@/constant/font';
 import ImageFile from '@/models/ImageFile';
 
 import PhotoEditSlots from './PhotoEditSlots';
+import {SectionRoot} from './shared';
 
 interface PhotoCorrectionSectionProps {
   entranceImageUrls: string[];
@@ -77,12 +75,11 @@ export default function PhotoCorrectionSection({
   onChangeNewBaElevatorPhotos,
 }: PhotoCorrectionSectionProps) {
   return (
-    <Container>
-      <SectionTitle>사진을 수정해주세요</SectionTitle>
-
+    <SectionRoot>
       {/* 장소 입구 사진 — PA exists이면 항상 표시 */}
-      <PhotoSectionLabel>장소 입구 사진</PhotoSectionLabel>
       <PhotoEditSlots
+        title="장소 입구 사진을 확인해주세요"
+        description="최대 3장까지 등록 가능해요"
         existingPhotoUrls={entranceImageUrls}
         newPhotos={newEntrancePhotos}
         deletedExistingIndices={deletedEntrancePhotoIndices}
@@ -95,72 +92,51 @@ export default function PhotoCorrectionSection({
 
       {/* 매장 엘리베이터 사진 — PA floorMovingMethodTypes에 PLACE_ELEVATOR 포함 시 */}
       {showPlaceElevatorPhotos && (
-        <>
-          <PhotoSectionLabel>매장 엘리베이터 사진</PhotoSectionLabel>
-          <PhotoEditSlots
-            existingPhotoUrls={elevatorImageUrls}
-            newPhotos={newElevatorPhotos}
-            deletedExistingIndices={deletedElevatorPhotoIndices}
-            replacedPhotos={replacedElevatorPhotos}
-            maxPhotos={3}
-            onDeleteExisting={onDeleteExistingElevatorPhoto}
-            onReplaceExisting={onReplaceExistingElevatorPhoto}
-            onChangeNewPhotos={onChangeNewElevatorPhotos}
-          />
-        </>
+        <PhotoEditSlots
+          title="매장 엘리베이터 사진을 확인해주세요"
+          description="최대 3장까지 등록 가능해요"
+          existingPhotoUrls={elevatorImageUrls}
+          newPhotos={newElevatorPhotos}
+          deletedExistingIndices={deletedElevatorPhotoIndices}
+          replacedPhotos={replacedElevatorPhotos}
+          maxPhotos={3}
+          onDeleteExisting={onDeleteExistingElevatorPhoto}
+          onReplaceExisting={onReplaceExistingElevatorPhoto}
+          onChangeNewPhotos={onChangeNewElevatorPhotos}
+        />
       )}
 
       {/* 건물 입구 사진 — PDP에 '건물 출입구' 섹션이 표시될 때 */}
       {showBaEntrancePhotos && (
-        <>
-          <PhotoSectionLabel>건물 입구 사진</PhotoSectionLabel>
-          <PhotoEditSlots
-            existingPhotoUrls={baEntranceImageUrls}
-            newPhotos={newBaEntrancePhotos}
-            deletedExistingIndices={deletedBaEntrancePhotoIndices}
-            replacedPhotos={replacedBaEntrancePhotos}
-            maxPhotos={3}
-            onDeleteExisting={onDeleteExistingBaEntrancePhoto}
-            onReplaceExisting={onReplaceExistingBaEntrancePhoto}
-            onChangeNewPhotos={onChangeNewBaEntrancePhotos}
-          />
-        </>
+        <PhotoEditSlots
+          title="건물 입구 사진을 확인해주세요"
+          description="최대 3장까지 등록 가능해요"
+          existingPhotoUrls={baEntranceImageUrls}
+          newPhotos={newBaEntrancePhotos}
+          deletedExistingIndices={deletedBaEntrancePhotoIndices}
+          replacedPhotos={replacedBaEntrancePhotos}
+          maxPhotos={3}
+          onDeleteExisting={onDeleteExistingBaEntrancePhoto}
+          onReplaceExisting={onReplaceExistingBaEntrancePhoto}
+          onChangeNewPhotos={onChangeNewBaEntrancePhotos}
+        />
       )}
 
       {/* 건물 엘리베이터 사진 — 건물 출입구 + BA.hasElevator일 때 */}
       {showBaElevatorPhotos && (
-        <>
-          <PhotoSectionLabel>건물 엘리베이터 사진</PhotoSectionLabel>
-          <PhotoEditSlots
-            existingPhotoUrls={baElevatorImageUrls}
-            newPhotos={newBaElevatorPhotos}
-            deletedExistingIndices={deletedBaElevatorPhotoIndices}
-            replacedPhotos={replacedBaElevatorPhotos}
-            maxPhotos={3}
-            onDeleteExisting={onDeleteExistingBaElevatorPhoto}
-            onReplaceExisting={onReplaceExistingBaElevatorPhoto}
-            onChangeNewPhotos={onChangeNewBaElevatorPhotos}
-          />
-        </>
+        <PhotoEditSlots
+          title="건물 엘리베이터 사진을 확인해주세요"
+          description="최대 3장까지 등록 가능해요"
+          existingPhotoUrls={baElevatorImageUrls}
+          newPhotos={newBaElevatorPhotos}
+          deletedExistingIndices={deletedBaElevatorPhotoIndices}
+          replacedPhotos={replacedBaElevatorPhotos}
+          maxPhotos={3}
+          onDeleteExisting={onDeleteExistingBaElevatorPhoto}
+          onReplaceExisting={onReplaceExistingBaElevatorPhoto}
+          onChangeNewPhotos={onChangeNewBaElevatorPhotos}
+        />
       )}
-    </Container>
+    </SectionRoot>
   );
 }
-
-// Styled components
-const Container = styled.View``;
-
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 16px;
-`;
-
-const PhotoSectionLabel = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardBold};
-  color: ${color.gray70};
-  margin-top: 16px;
-  margin-bottom: 8px;
-`;

--- a/src/screens/ReportCorrectionFormScreen/sections/PhotoEditSlots.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/PhotoEditSlots.tsx
@@ -11,6 +11,10 @@ import useNavigation from '@/navigation/useNavigation';
 import ImageFileUtils from '@/utils/ImageFileUtils';
 
 interface PhotoEditSlotsProps {
+  /** 섹션 타이틀 (존댓말, 예: "매장 입구 사진을 확인해주세요") */
+  title?: string;
+  /** 타이틀 아래 보조 설명 (예: "최대 3장까지 등록 가능해요") */
+  description?: string;
   /** 기존 원격 사진 URL */
   existingPhotoUrls: string[];
   /** 교체된 기존 사진 (원본 인덱스 -> 새 사진) */
@@ -34,6 +38,8 @@ interface PhotoEditSlotsProps {
  * - 최대 maxPhotos장
  */
 export default function PhotoEditSlots({
+  title,
+  description,
   existingPhotoUrls,
   replacedPhotos,
   newPhotos,
@@ -102,7 +108,14 @@ export default function PhotoEditSlots({
 
   return (
     <Container>
-      <Header>사진도 바뀌었나요? (선택)</Header>
+      {title !== undefined && (
+        <HeaderGroup>
+          <Title>{title}</Title>
+          {description !== undefined && (
+            <DescriptionText>{description}</DescriptionText>
+          )}
+        </HeaderGroup>
+      )}
       <SlotsRow>
         {/* 기존 사진 (교체된 사진 포함) */}
         {activeExistingPhotos.map((item, displayIndex) => {
@@ -210,14 +223,27 @@ export default function PhotoEditSlots({
 
 // Styled components
 const Container = styled.View`
-  margin-top: 8px;
+  gap: 16px;
 `;
 
-const Header = styled.Text`
+const HeaderGroup = styled.View`
+  gap: 2px;
+`;
+
+const Title = styled.Text`
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -0.36px;
+  font-family: ${font.pretendardSemibold};
+  color: ${color.gray80v2};
+`;
+
+const DescriptionText = styled.Text`
   font-size: 14px;
-  font-family: ${font.pretendardMedium};
-  color: ${color.gray60};
-  margin-bottom: 8px;
+  line-height: 20px;
+  letter-spacing: -0.28px;
+  font-family: ${font.pretendardRegular};
+  color: ${color.gray45};
 `;
 
 const SlotsRow = styled.View`

--- a/src/screens/ReportCorrectionFormScreen/sections/PlaceEntranceCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/PlaceEntranceCorrectionSection.tsx
@@ -3,7 +3,6 @@ import {Image} from 'react-native';
 import styled from 'styled-components/native';
 
 import {color} from '@/constant/color';
-import {font} from '@/constant/font';
 import {
   StairInfo,
   StairHeightLevel,
@@ -18,9 +17,9 @@ import {
   ENTRANCE_OPTIONS,
 } from '../../PlaceFormV2Screen/hooks';
 import PhotoEditSlots from './PhotoEditSlots';
+import {FormGroup, GuideLink, SectionRoot, SubLabel} from './shared';
 
 interface PlaceEntranceCorrectionSectionProps {
-  sectionTitle?: string;
   stairInfo?: StairInfo;
   stairHeightLevel?: StairHeightLevel;
   hasSlope?: boolean;
@@ -40,7 +39,6 @@ interface PlaceEntranceCorrectionSectionProps {
 }
 
 export default function PlaceEntranceCorrectionSection({
-  sectionTitle = '장소 입구 정보',
   stairInfo,
   stairHeightLevel,
   hasSlope,
@@ -64,12 +62,10 @@ export default function PlaceEntranceCorrectionSection({
   );
 
   return (
-    <Container>
-      <SectionTitle>{sectionTitle}</SectionTitle>
-
+    <SectionRoot>
       {conditions.showDoorDirection && (
-        <>
-          <SubLabel>매장 출입구 위치</SubLabel>
+        <FormGroup>
+          <SubLabel>매장 출입구 위치를 확인해주세요</SubLabel>
           <DoorDirectionContainer>
             <DoorDirectionOption>
               <DoorDirectionImageContainer
@@ -121,39 +117,52 @@ export default function PlaceEntranceCorrectionSection({
               />
             </DoorDirectionOption>
           </DoorDirectionContainer>
-        </>
+        </FormGroup>
       )}
 
-      <SubLabel>계단 수</SubLabel>
-      <OptionsV2
-        options={ENTRANCE_OPTIONS.stairInfoOptions}
-        value={stairInfo}
-        columns={2}
-        onSelect={onChangeStairInfo}
-      />
+      <FormGroup>
+        <SubLabel>계단 수를 확인해주세요</SubLabel>
+        <OptionsV2
+          options={ENTRANCE_OPTIONS.stairInfoOptions}
+          value={stairInfo}
+          columns={2}
+          onSelect={onChangeStairInfo}
+        />
+        <GuideLink
+          type="stair"
+          elementName="report_correction_place_entrance_stair_guide"
+        />
+      </FormGroup>
 
       {conditions.showStairHeight && (
-        <>
-          <SubLabel>계단 높이</SubLabel>
+        <FormGroup>
+          <SubLabel>계단 높이를 확인해주세요</SubLabel>
           <OptionsV2
             options={ENTRANCE_OPTIONS.stairHeightOptions}
             value={stairHeightLevel}
             columns={1}
             onSelect={onChangeStairHeightLevel}
           />
-        </>
+        </FormGroup>
       )}
 
-      <SubLabel>경사로</SubLabel>
-      <OptionsV2
-        options={ENTRANCE_OPTIONS.slopeOptions}
-        value={hasSlope}
-        columns={2}
-        onSelect={onChangeHasSlope}
-      />
+      <FormGroup>
+        <SubLabel>경사로 유무를 확인해주세요</SubLabel>
+        <OptionsV2
+          options={ENTRANCE_OPTIONS.slopeOptions}
+          value={hasSlope}
+          columns={2}
+          onSelect={onChangeHasSlope}
+        />
+        <GuideLink
+          type="slope"
+          elementName="report_correction_place_entrance_slope_guide"
+        />
+      </FormGroup>
 
-      <SubLabel>매장 입구 사진</SubLabel>
       <PhotoEditSlots
+        title="매장 입구 사진을 확인해주세요"
+        description="최대 3장까지 등록 가능해요"
         existingPhotoUrls={existingEntrancePhotoUrls}
         newPhotos={newEntrancePhotos}
         deletedExistingIndices={deletedEntrancePhotoIndices}
@@ -163,27 +172,9 @@ export default function PlaceEntranceCorrectionSection({
         onReplaceExisting={onReplaceExistingEntrancePhoto}
         onChangeNewPhotos={onChangeNewEntrancePhotos}
       />
-    </Container>
+    </SectionRoot>
   );
 }
-
-// Styled components
-const Container = styled.View``;
-
-const SectionTitle = styled.Text`
-  font-size: 16px;
-  font-family: ${font.pretendardBold};
-  color: ${color.black};
-  margin-bottom: 16px;
-`;
-
-const SubLabel = styled.Text`
-  font-size: 14px;
-  font-family: ${font.pretendardMedium};
-  color: ${color.gray60};
-  margin-bottom: 8px;
-  margin-top: 12px;
-`;
 
 const DoorDirectionContainer = styled.View`
   flex-direction: row;

--- a/src/screens/ReportCorrectionFormScreen/sections/shared.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/shared.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components/native';
+
+import {SccPressable} from '@/components/SccPressable';
+import {color} from '@/constant/color';
+import {font} from '@/constant/font';
+import useNavigation from '@/navigation/useNavigation';
+
+/** 각 input 섹션 타이틀 (존댓말, 18px SemiBold gray80v2) */
+export const SubLabel = styled.Text`
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -0.36px;
+  font-family: ${font.pretendardSemibold};
+  color: ${color.gray80v2};
+`;
+
+/** 사진 설명 등 보조 디스크립션 */
+export const Description = styled.Text`
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: -0.28px;
+  font-family: ${font.pretendardRegular};
+  color: ${color.gray45};
+`;
+
+/** 섹션 내부에서 라벨-입력(-가이드링크) 한 묶음을 감싸는 래퍼. gap 16 */
+export const FormGroup = styled.View`
+  gap: 16px;
+`;
+
+/** 각 카테고리 섹션의 최상위 컨테이너. 그룹 간 gap 48 */
+export const SectionRoot = styled.View`
+  gap: 48px;
+`;
+
+interface GuideLinkProps {
+  type: 'stair' | 'slope';
+  elementName: string;
+}
+
+const GUIDE_CONFIG: Record<
+  GuideLinkProps['type'],
+  {title: string; url: string; label: string}
+> = {
+  stair: {
+    title: '계단 기준 알아보기',
+    url: 'https://agnica.notion.site/8312cc653a8f4b9aa8bc920bbd668218',
+    label: '계단 기준 알아보기 >',
+  },
+  slope: {
+    title: '경사로 기준 알아보기',
+    url: 'https://agnica.notion.site/6f64035a062f41e28745faa4e7bd0770',
+    label: '경사로 기준 알아보기 >',
+  },
+};
+
+export function GuideLink({type, elementName}: GuideLinkProps) {
+  const navigation = useNavigation();
+  const config = GUIDE_CONFIG[type];
+
+  return (
+    <GuideLinkContainer>
+      <SccPressable
+        elementName={elementName}
+        onPress={() =>
+          navigation.navigate('Webview', {
+            fixedTitle: config.title,
+            url: config.url,
+          })
+        }>
+        <GuideLinkText>{config.label}</GuideLinkText>
+      </SccPressable>
+    </GuideLinkContainer>
+  );
+}
+
+const GuideLinkContainer = styled.View`
+  align-items: flex-end;
+`;
+
+const GuideLinkText = styled.Text`
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: -0.28px;
+  font-family: ${font.pretendardMedium};
+  color: ${color.brand40};
+`;


### PR DESCRIPTION
## Summary
- Figma `wV8P749QZBHIMa4u9wfFCr/신고하기` (루트 `2004-2386`) + `KQGNofQDa1zcq3wvy5Sgqa/건물정보구조변경` (`633-7837`) 기준으로 PDP 신고하기 플로우의 Step 1/2 바텀시트 및 Step 3 정보수정 폼 디자인을 전면 개편. 로직은 유지하고 디자인/문구만 변경.
- `SccPrimaryButton`, `SccSecondaryButton` 신설 (SccButton wrapper). 점진 마이그레이션 전제.
- Floor 섹션에서 층간이동 질문이 숨겨질 때 `floorMovingMethodTypes`가 초기화되지 않아 엘리베이터 input이 stale하게 남는 버그 수정.

## 주요 변경

**Step 1/2 바텀시트**
- `reason` / `inaccurateCategory` / `closedSubType` 3종 옵션 버튼을 Figma `633-7837` 토큰으로 교체: bg `brand5`/border `brand40`/text `brand50` (선택), bg white/border `gray20v2`/text `gray80v2` (미선택), Pretendard Medium 16, radius 14.

**Step 3 공통**
- PageHeader: `gray10` 배경 + padding `24px 20px` + gap `8px` (Figma `place_building` 2003-290).
- 섹션 레이아웃 재구성: `SectionRoot` (gap 48) / `FormGroup` (gap 16) flex-gap 기반. SubLabel의 margin-top/bottom 기반 gap 로직 제거.
- FormBody: `padding 30px 20px`, gap 48로 섹션-Note-Submit 간격 통일.
- 각 섹션 input 타이틀을 `'~를/을 확인해주세요'` 존댓말로 통일 (Figma 문구 기준).
- 사진 섹션: `PhotoEditSlots`에 `title`/`description` prop 추가 → `"XX 사진을 확인해주세요"` + `"최대 3장까지 등록 가능해요"`.
- 계단 수/경사로 섹션에 가이드 링크 (`계단 기준 알아보기 >` / `경사로 기준 알아보기 >`) 추가. `PlaceFormV2Screen`과 동일 URL 사용.
- 부연 설명: `TextArea` → `TextAreaV2` 교체, placeholder `"추가로 설명할 내용이 있다면 알려주세요"`.
- 제출하기: `SccButton` → `SccPrimaryButton` (radius 8, fontSize 18).

**섹션별 문구 조정 (Figma 반영)**
- Floor: `"이 장소는 건물의 1층에 있나요?"`
- DoorType: `"출입문은 어떤 종류인가요?"`
- AccessLevel: `"실제 접근 레벨을 확인해주세요"` + 현재값 `"현재: 접근레벨 N"` (16/24 Medium brand50), 옵션 라벨 `"레벨 N"` → `"접근레벨 N"`.

**기타**
- `EntranceDoorType.Etc` 라벨 `"기타"` → `"기타 문"`. Step 2에서 `"기타이 아니에요"`가 `"기타 문이 아니에요"`로 자연스럽게 표시됨. 관련 fallback(`label === '기타'`) 제거.

**버그 수정**
- `FloorCorrectionSection`: `conditions.showFloorMovement`가 false로 전환될 때 `floorMovingMethodTypes`를 초기화하는 effect 추가. 기존 `PLACE_ELEVATOR 해제 → elevatorAccessibility 초기화` effect와 연쇄해 엘리베이터 input이 자동으로 사라지도록 수정.

## Test plan
- [ ] PDP → 신고하기 → Step 1 (`reason`) 선택 UI가 Figma 토큰과 일치
- [ ] Step 2 (`inaccurateCategory`) 선택 UI가 Figma 토큰과 일치, `"기타 문이 아니에요"` 정상 표시
- [ ] Step 3 각 카테고리 렌더링 (PlaceEntrance / BuildingEntrance / Floor / DoorType / Elevator / AccessLevel / Photo) 시각 검증
- [ ] PageHeader 회색 배경 + 섹션 간 gap 48 일관성
- [ ] 계단/경사로 섹션에 가이드 링크 표시 + 탭 시 Webview 이동
- [ ] 부연 설명 placeholder / 제출 버튼 스타일
- [ ] Floor 버그: "1층 포함 여러층" + "매장 엘리베이터" 선택 → 엘리베이터 input 표시 → floorOption을 다른 것으로 변경 시 엘리베이터 input 완전히 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guide links for stair and slope information in correction forms
  * Introduced new primary and secondary button components with improved styling

* **Style**
  * Redesigned report correction form screens for better visual organization
  * Updated form labels with clearer guidance prompts throughout
  * Enhanced photo upload sections with descriptive titles and information
  * Fixed door type label display for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->