### PR TITLE
fix: 등록 완료 모달 닫기 시 파란 플래시 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,14 @@ export default function FormScreen() {
 
 ## Navigation Structure
 
+### 전환 중 flash/flicker 문제는 배경색이 아니라 타이밍을 고친다 (MANDATORY)
+
+네비게이션 전환 사이에 **중간 프레임(다른 색 화면이 잠깐 보임)** 이 생기는 문제를 발견했을 때, "루트 View나 Navigator의 `contentStyle` 배경색을 바꾸자"는 defensive fix를 제안하지 말 것.
+
+- **이유**: 중간 프레임이 노출된다는 사실 자체가 버그다. 파란색이 흰색으로 바뀌어도 "중간에 이상한 화면이 보인다"는 UX는 동일하다. 배경색 수정은 증상만 가리고 원인(비원자적 네비게이션 dispatch)을 남긴다.
+- **올바른 접근**: 여러 액션이 연속 dispatch되고 있는가부터 본다. 해결책은 **단일 액션으로 합치기** — 예: `pop() + pop() + navigate()` → `navigation.popTo(name, params)` (v7 native-stack 지원), 또는 `CommonActions.reset` / `StackActions.pop(n)` + params merge.
+- **예외**: splash → navigator 전환처럼 원래 다른 색이 보이는 게 자연스러운 컨텍스트는 배경색 유지.
+
 ### Adding New Screens
 
 1. **Create screen directory structure:**

--- a/src/screens/RegistrationCompleteScreen/RegistrationCompleteScreen.tsx
+++ b/src/screens/RegistrationCompleteScreen/RegistrationCompleteScreen.tsx
@@ -48,14 +48,10 @@ export default function RegistrationCompleteScreen({
   }, [navigation]);
 
   const handleConfirm = () => {
-    // FormScreen과 CompleteScreen 스택에서 제거
-    navigation.pop();
-    navigation.pop();
-    // PlaceDetail로 이동
-    navigation.navigate(pdpScreen, {
-      placeInfo,
-      event,
-    });
+    // 단일 액션으로 RegistrationComplete + FormScreen을 pop하고 PDP를 재노출한다.
+    // pop() + pop() + navigate()로 분리하면 모달 dismiss 중 FormScreen이 먼저 unmount되어
+    // 네비게이터 배경이 투명하게 노출되는 중간 프레임이 생긴다.
+    navigation.popTo(pdpScreen, {placeInfo, event});
   };
 
   if (target === 'building') {


### PR DESCRIPTION
## Summary

- 장소/건물 정보 등록 후 "정보를 등록해주셔서 감사합니다!" 모달에서 "닫기"를 누를 때 순간적으로 브랜드 블루(#1D85FF) 화면이 플래시된 후 PDP로 전환되던 버그 수정.
- 원인: `RegistrationCompleteScreen.handleConfirm`이 `pop() + pop() + navigate()` 3-step으로 분리되어 있어, 모달 dismiss 중 `FormScreen`이 먼저 unmount → Navigator 배경이 투명하게 노출 → `App.tsx`의 루트 `color.brand30`이 비쳐 보임.
- 해결: `navigation.popTo(pdpScreen, {placeInfo, event})` 단일 호출로 합쳐서 원자적으로 처리. `App.tsx`의 `brand30` 배경(스플래시용)은 그대로 유지.
- 재발 방지: `scc-app/CLAUDE.md` Navigation 섹션에 "flash/flicker 문제는 배경색이 아니라 타이밍을 고친다" 가이드 추가.

## 관련 레포

- 변경 없음 (단일 레포 수정, API 스펙/서버 영향 없음).

## Test plan

- [x] `yarn tsc --noEmit` 통과
- [x] `yarn lint` 통과
- [ ] Android 에뮬레이터 E2E
  - [ ] PlaceFormV2 → 제출 → 완료 모달 "닫기" → 중간 프레임 없이 PDP로 전환 확인
  - [ ] BuildingFormV2 → 동일 플로우 확인
  - [ ] 회귀: PlaceReviewForm / ToiletReviewForm / AddCommentScreen 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized navigation flow during registration completion to reduce transition delays and improve responsiveness.

* **Documentation**
  * Added guidance on handling visual artifacts during navigation transitions and best practices for managing sequential navigation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->