### PR TITLE
fix: 등록 완료 후 PDP의 이전 스택이 Form으로 남는 문제

### DIFF
--- a/src/screens/RegistrationCompleteScreen/RegistrationCompleteScreen.tsx
+++ b/src/screens/RegistrationCompleteScreen/RegistrationCompleteScreen.tsx
@@ -1,3 +1,4 @@
+import {CommonActions} from '@react-navigation/native';
 import React, {useEffect} from 'react';
 import styled from 'styled-components/native';
 
@@ -48,10 +49,37 @@ export default function RegistrationCompleteScreen({
   }, [navigation]);
 
   const handleConfirm = () => {
-    // 단일 액션으로 RegistrationComplete + FormScreen을 pop하고 PDP를 재노출한다.
-    // pop() + pop() + navigate()로 분리하면 모달 dismiss 중 FormScreen이 먼저 unmount되어
-    // 네비게이터 배경이 투명하게 노출되는 중간 프레임이 생긴다.
-    navigation.popTo(pdpScreen, {placeInfo, event});
+    // 단일 dispatch로 RegistrationComplete + FormScreen을 pop하고 PDP를 최상단에 둔다.
+    // - pop()/navigate() 여러 번 호출 시 모달 dismiss 중 FormScreen이 먼저 unmount되어
+    //   네비게이터 배경이 투명하게 노출되는 중간 프레임이 생긴다.
+    // - popTo 하나만 쓰면 PDP가 스택에 없을 때(Search → FormV2 직행 플로우) FormScreen이
+    //   스택에 남아 PDP에서 뒤로가기 시 FormScreen이 뜬다.
+    navigation.dispatch(state => {
+      // 상위 두 스크린(RegistrationComplete, FormScreen) 제거
+      const remaining = state.routes.slice(0, -2);
+      const existingPdpIndex = remaining.findIndex(r => r.name === pdpScreen);
+
+      const newRoutes =
+        existingPdpIndex >= 0
+          ? [
+              ...remaining.slice(0, existingPdpIndex),
+              {
+                ...remaining[existingPdpIndex],
+                params: {
+                  ...remaining[existingPdpIndex].params,
+                  placeInfo,
+                  event,
+                },
+              },
+            ]
+          : [...remaining, {name: pdpScreen, params: {placeInfo, event}}];
+
+      return CommonActions.reset({
+        ...state,
+        index: newRoutes.length - 1,
+        routes: newRoutes,
+      });
+    });
   };
 
   if (target === 'building') {


### PR DESCRIPTION
## Summary

- #152 후속 버그 수정. 이전 PR에서 `pop() + pop() + navigate()`를 `navigation.popTo(pdpScreen, params)`로 바꿨는데, **PDP가 스택에 없는 플로우(예: Search → `PlaceFormV2` 직행)** 에선 `popTo`가 PDP를 push만 하고 `FormScreen`을 pop하지 않아서, 등록 완료 후 PDP에서 뒤로가기를 누르면 Form이 다시 뜨는 문제가 있었음.
- 단일 `dispatch` reducer로 바꿔서 두 케이스를 원자적으로 처리:
  - **PDP가 스택에 있으면** (PDP → Form → RegComplete): 그 위의 전부 pop. 기존 PDP 인스턴스 재사용하면서 `placeInfo` / `event` params만 병합.
  - **PDP가 스택에 없으면** (Search → Form → RegComplete): `Form` + `RegComplete` 제거 후 PDP push.
- `CommonActions.reset`을 `dispatch` 함수 안에서 한 번만 반환하므로 여러 액션 사이에 타이밍 간극이 생기지 않아 파란 플래시 재발도 없음.

## Test plan

- [x] `yarn tsc --noEmit` 통과
- [x] `yarn lint` 통과
- [ ] Android 에뮬레이터 E2E
  - [ ] Search → `PlaceFormV2` 직행 → 제출 → 완료 모달 "닫기" → PDP 진입 → 뒤로가기 → **Search로 돌아가는지** (기존 버그는 Form으로 돌아감)
  - [ ] PDP → `PlaceFormV2` → 제출 → 완료 모달 "닫기" → PDP → 뒤로가기 → PDP 이전 스택으로 정상 복귀
  - [ ] 파란 플래시가 재발하지 않는지 (#152의 개선 유지)
  - [ ] 건물 폼도 동일하게 동작하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)