### PR TITLE
feat: BUILDING_ENTRANCE 교정에 출입문 종류 input 포함

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -908,7 +908,7 @@ export type BuildingDoorDirectionTypeDto = typeof BuildingDoorDirectionTypeDto[k
 
 
 /**
- * 건물 입구 정보 교정 (계단, 경사로, 사진). 출입문 유형은 DOOR_TYPE 카테고리에서 별도 교정.
+ * 건물 입구 정보 교정 (계단, 경사로, 문 종류, 사진).
  * @export
  * @interface BuildingEntranceCorrectionDto
  */
@@ -931,6 +931,12 @@ export interface BuildingEntranceCorrectionDto {
      * @memberof BuildingEntranceCorrectionDto
      */
     'hasSlope'?: boolean;
+    /**
+     * 
+     * @type {Array<EntranceDoorType>}
+     * @memberof BuildingEntranceCorrectionDto
+     */
+    'entranceDoorTypes'?: Array<EntranceDoorType>;
     /**
      * 건물 입구 사진 URL 목록
      * @type {Array<string>}

--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -69,7 +69,7 @@ function getCategoryLabel(
         ? '계단 / 경사로 / 문 방향이 잘못됐어요'
         : '입구 계단 / 경사로 / 문 방향이 잘못됐어요';
     case InaccurateInfoCategoryDto.BuildingEntrance:
-      return '건물 입구 계단 / 경사로 / 문 종류가 잘못됐어요';
+      return '건물 입구 계단 / 경사로 / 문이 잘못됐어요';
     case InaccurateInfoCategoryDto.Floor: {
       // PDP의 getFloorAccessibility title과 일치시킨다
       const floors = snapshot?.floors;

--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -69,7 +69,7 @@ function getCategoryLabel(
         ? '계단 / 경사로 / 문 방향이 잘못됐어요'
         : '입구 계단 / 경사로 / 문 방향이 잘못됐어요';
     case InaccurateInfoCategoryDto.BuildingEntrance:
-      return '건물 입구 계단 / 경사로가 잘못됐어요';
+      return '건물 입구 계단 / 경사로 / 문 종류가 잘못됐어요';
     case InaccurateInfoCategoryDto.Floor: {
       // PDP의 getFloorAccessibility title과 일치시킨다
       const floors = snapshot?.floors;

--- a/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
+++ b/src/screens/ReportCorrectionFormScreen/ReportCorrectionFormScreen.tsx
@@ -99,6 +99,7 @@ function buildBuildingEntranceCorrection(
     entranceStairInfo: buildingCorrection.entranceStairInfo,
     entranceStairHeightLevel: buildingCorrection.entranceStairHeightLevel,
     hasSlope: buildingCorrection.hasSlope,
+    entranceDoorTypes: buildingCorrection.entranceDoorTypes,
     entranceImageUrls:
       finalBaEntranceUrls.length > 0 ? finalBaEntranceUrls : undefined,
   };
@@ -1075,6 +1076,7 @@ export default function ReportCorrectionFormScreen({
                 buildingCorrection.entranceStairHeightLevel
               }
               hasSlope={buildingCorrection.hasSlope}
+              entranceDoorTypes={buildingCorrection.entranceDoorTypes}
               existingBaEntrancePhotoUrls={baEntranceImageUrls}
               newBaEntrancePhotos={newBaEntrancePhotos}
               deletedBaEntrancePhotoIndices={deletedBaEntrancePhotoIndices}
@@ -1097,6 +1099,12 @@ export default function ReportCorrectionFormScreen({
               }
               onChangeHasSlope={value =>
                 setBuildingCorrection(prev => ({...prev, hasSlope: value}))
+              }
+              onChangeEntranceDoorTypes={value =>
+                setBuildingCorrection(prev => ({
+                  ...prev,
+                  entranceDoorTypes: value,
+                }))
               }
               onDeleteExistingBaEntrancePhoto={
                 handleDeleteExistingBaEntrancePhoto

--- a/src/screens/ReportCorrectionFormScreen/sections/BuildingEntranceCorrectionSection.tsx
+++ b/src/screens/ReportCorrectionFormScreen/sections/BuildingEntranceCorrectionSection.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 
-import {StairInfo, StairHeightLevel} from '@/generated-sources/openapi';
+import {makeDoorTypeOptions} from '@/constant/options';
+import {
+  EntranceDoorType,
+  StairInfo,
+  StairHeightLevel,
+} from '@/generated-sources/openapi';
 import ImageFile from '@/models/ImageFile';
 
 import OptionsV2 from '../../PlaceFormV2Screen/components/OptionsV2';
@@ -12,6 +17,7 @@ interface BuildingEntranceCorrectionSectionProps {
   entranceStairInfo?: StairInfo;
   entranceStairHeightLevel?: StairHeightLevel;
   hasSlope?: boolean;
+  entranceDoorTypes?: EntranceDoorType[];
   existingBaEntrancePhotoUrls: string[];
   newBaEntrancePhotos: ImageFile[];
   deletedBaEntrancePhotoIndices: number[];
@@ -19,6 +25,7 @@ interface BuildingEntranceCorrectionSectionProps {
   onChangeEntranceStairInfo: (value: StairInfo) => void;
   onChangeEntranceStairHeightLevel: (value: StairHeightLevel) => void;
   onChangeHasSlope: (value: boolean) => void;
+  onChangeEntranceDoorTypes: (value: EntranceDoorType[]) => void;
   onDeleteExistingBaEntrancePhoto: (index: number) => void;
   onReplaceExistingBaEntrancePhoto: (index: number, photo: ImageFile) => void;
   onChangeNewBaEntrancePhotos: (photos: ImageFile[]) => void;
@@ -28,6 +35,7 @@ export default function BuildingEntranceCorrectionSection({
   entranceStairInfo,
   entranceStairHeightLevel,
   hasSlope,
+  entranceDoorTypes,
   existingBaEntrancePhotoUrls,
   newBaEntrancePhotos,
   deletedBaEntrancePhotoIndices,
@@ -35,6 +43,7 @@ export default function BuildingEntranceCorrectionSection({
   onChangeEntranceStairInfo,
   onChangeEntranceStairHeightLevel,
   onChangeHasSlope,
+  onChangeEntranceDoorTypes,
   onDeleteExistingBaEntrancePhoto,
   onReplaceExistingBaEntrancePhoto,
   onChangeNewBaEntrancePhotos,
@@ -80,6 +89,16 @@ export default function BuildingEntranceCorrectionSection({
         <GuideLink
           type="slope"
           elementName="report_correction_building_entrance_slope_guide"
+        />
+      </FormGroup>
+
+      <FormGroup>
+        <SubLabel>출입문은 어떤 종류인가요?</SubLabel>
+        <OptionsV2.Multiple
+          options={makeDoorTypeOptions(entranceDoorTypes ?? [])}
+          values={entranceDoorTypes ?? []}
+          columns={2}
+          onSelect={onChangeEntranceDoorTypes}
         />
       </FormGroup>
 


### PR DESCRIPTION
## 배경

PR #151 이후 신고 교정 플로우에서 BA 출입문 종류를 고칠 경로가 사라져 PDP "출입문 유형" 이 틀려도 유저가 수정할 수 없던 dead end 를 해소한다.

BuildingEntrance 한 플로우에서 건물 입구 관련 모든 틀린 정보(계단/경사로/문 종류/사진)를 한 번에 교정할 수 있도록 UI를 확장.

## 변경

- **`BuildingEntranceCorrectionSection`**: 경사로 FormGroup 다음에 "출입문은 어떤 종류인가요?" FormGroup 신규 추가. `makeDoorTypeOptions` + `OptionsV2.Multiple` 기존 자산 재사용 (`DoorTypeCorrectionSection` 패턴 그대로 복제 — "문 없음" 배타 로직 포함).
- **`ReportCorrectionFormScreen`**:
  - \`buildBuildingEntranceCorrection\` 반환값에 \`entranceDoorTypes\` 포함
  - renderSection 의 BUILDING_ENTRANCE 분기에 \`entranceDoorTypes\` prop + \`onChangeEntranceDoorTypes\` 핸들러 전달
  - local BA 타입/프리필에는 이미 필드가 있어 추가 변경 없음
- **`PlaceDetailNegativeFeedbackBottomSheet`**: step 2 라벨 \`건물 입구 계단 / 경사로가 잘못됐어요\` → \`건물 입구 계단 / 경사로 / 문 종류가 잘못됐어요\` (PlaceEntrance 라벨과 톤 통일)
- scc-api submodule → feat/building-entrance-door-types (14d792d), \`yarn codegen\` 반영

## Related
- API spec: https://github.com/Stair-Crusher-Club/scc-api/pull/103
- Server: https://github.com/Stair-Crusher-Club/scc-server/pull/920

## 배포 순서
1. scc-api merge
2. scc-server merge → 배포
3. scc-app merge → OTA

(서버 미배포 상태에서 앱만 먼저 나가도 에러는 없고, 단지 \`entranceDoorTypes\` 가 무시됨)

## Test plan
- [x] \`yarn tsc --noEmit\` 0 error
- [x] \`yarn lint\` 0 warning
- [ ] 에뮬레이터 E2E: BA 있는 장소 PDP → 신고하기 → BUILDING_ENTRANCE → 문 종류 prefill/변경/제출/PDP 재조회 (리뷰/스테이징에서 확인 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entrance door type selection when reporting building entrance corrections, allowing users to specify what types of doors are present at entrances.
  * Updated feedback category labels to include door type information in building entrance corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->