### PR TITLE
fix: 신고하기 step 2 옵션이 PDP에 노출된 정보만 반영하도록 수정

### DIFF
--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -35,13 +35,13 @@ interface PlaceAccessibilitySnapshot {
 interface PlaceDetailNegativeFeedbackBottomSheetProps {
   isVisible: boolean;
   placeId: string;
-  /** BA 실데이터 존재 여부. true이면 PDP에 BuildingEntranceSection이 렌더된 상태. */
+  /** BA 실데이터 존재 여부. true이면 PDP에 BuildingEntranceSection이 렌더된 상태. 기본값 false — 미전달 시 옵션 숨김. */
   hasBuildingAccessibility?: boolean;
-  /** PA 실데이터 존재 여부. 매장 출입구 카테고리 노출 여부와 라벨 결정에 사용. */
+  /** PA 실데이터 존재 여부. 매장 출입구 카테고리 노출 여부와 라벨 결정에 사용. 기본값 false — 미전달 시 옵션 숨김. */
   hasPlaceAccessibility?: boolean;
-  /** PDP 홈탭의 PhotoRow들(매장/건물/층간이동) 중 하나라도 렌더되는지. */
+  /** PDP 홈탭의 PhotoRow들(매장/건물/층간이동) 중 하나라도 렌더되는지. 기본값 false — 미전달 시 옵션 숨김. */
   hasPhoto?: boolean;
-  /** PA.entranceDoorTypes가 하나라도 있는지. BA 출입문 종류는 건물 입구 신고에 포함되므로 제외. */
+  /** PA.entranceDoorTypes가 하나라도 있는지. BA 출입문 종류는 건물 입구 신고에 포함되므로 제외. 기본값 false — 미전달 시 옵션 숨김. */
   hasDoorType?: boolean;
   elevatorTargets?: ElevatorCorrectionTargetDto[];
   placeAccessibilitySnapshot?: PlaceAccessibilitySnapshot;
@@ -136,9 +136,9 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
   isVisible,
   placeId,
   hasBuildingAccessibility = false,
-  hasPlaceAccessibility = true,
-  hasPhoto = true,
-  hasDoorType = true,
+  hasPlaceAccessibility = false,
+  hasPhoto = false,
+  hasDoorType = false,
   elevatorTargets = [],
   placeAccessibilitySnapshot,
   onPressCloseButton,

--- a/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
+++ b/src/screens/PlaceDetailScreen/modals/PlaceDetailNegativeFeedbackBottomSheet.tsx
@@ -35,7 +35,14 @@ interface PlaceAccessibilitySnapshot {
 interface PlaceDetailNegativeFeedbackBottomSheetProps {
   isVisible: boolean;
   placeId: string;
+  /** BA 실데이터 존재 여부. true이면 PDP에 BuildingEntranceSection이 렌더된 상태. */
   hasBuildingAccessibility?: boolean;
+  /** PA 실데이터 존재 여부. 매장 출입구 카테고리 노출 여부와 라벨 결정에 사용. */
+  hasPlaceAccessibility?: boolean;
+  /** PDP 홈탭의 PhotoRow들(매장/건물/층간이동) 중 하나라도 렌더되는지. */
+  hasPhoto?: boolean;
+  /** PA.entranceDoorTypes가 하나라도 있는지. BA 출입문 종류는 건물 입구 신고에 포함되므로 제외. */
+  hasDoorType?: boolean;
   elevatorTargets?: ElevatorCorrectionTargetDto[];
   placeAccessibilitySnapshot?: PlaceAccessibilitySnapshot;
   onPressCloseButton: () => void;
@@ -129,6 +136,9 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
   isVisible,
   placeId,
   hasBuildingAccessibility = false,
+  hasPlaceAccessibility = true,
+  hasPhoto = true,
+  hasDoorType = true,
   elevatorTargets = [],
   placeAccessibilitySnapshot,
   onPressCloseButton,
@@ -355,6 +365,22 @@ const PlaceDetailNegativeFeedbackBottomSheet = ({
                 InaccurateInfoCategoryDto.Other,
               ];
               CATEGORY_ORDER.forEach(cat => {
+                // PDP 홈탭 노출 조건과 1:1 대응하여 실제로 렌더되는 정보만 신고 옵션으로 제공.
+                if (
+                  cat === InaccurateInfoCategoryDto.PlaceEntrance &&
+                  !hasPlaceAccessibility
+                ) {
+                  return;
+                }
+                if (cat === InaccurateInfoCategoryDto.Photo && !hasPhoto) {
+                  return;
+                }
+                if (
+                  cat === InaccurateInfoCategoryDto.DoorType &&
+                  !hasDoorType
+                ) {
+                  return;
+                }
                 if (
                   cat === InaccurateInfoCategoryDto.BuildingEntrance &&
                   !hasBuildingAccessibility

--- a/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
+++ b/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
@@ -567,8 +567,21 @@ export default function PlaceDetailV2Screen({
 
   // 신고하기 step 2 옵션 필터링용 플래그 — PDP 홈탭에 실제로 렌더되는 정보에 1:1 대응.
   const negativeFeedbackFlags = useMemo(() => {
-    const pa = accessibilityPost?.placeAccessibility;
-    const ba = accessibilityPost?.buildingAccessibility;
+    // V2HomeTab과 동일한 fallback 패턴: 다중 배열 우선, 단일 legacy 필드 fallback.
+    const placeAccessibilities =
+      accessibilityPost?.placeAccessibilities ??
+      (accessibilityPost?.placeAccessibility
+        ? [accessibilityPost.placeAccessibility]
+        : []);
+    const buildingAccessibilities =
+      accessibilityPost?.buildingAccessibilities ??
+      (accessibilityPost?.buildingAccessibility
+        ? [accessibilityPost.buildingAccessibility]
+        : []);
+
+    // V2HomeTab: PlaceEntranceSection/FloorMovementSection은 placeAccessibilities[0] 기준.
+    const pa = placeAccessibilities[0];
+    const hasAnyBa = buildingAccessibilities.length > 0;
     if (!pa) {
       return {
         hasPlaceAccessibility: false,
@@ -576,26 +589,37 @@ export default function PlaceDetailV2Screen({
         hasPhoto: false,
         hasDoorType: false,
         elevatorTargets: [] as ElevatorCorrectionTargetDto[],
+        placeAccessibilitySnapshot: undefined,
       };
     }
 
+    // 참고: hasBuildingAccessibility 인자는 getAccessibilitySections 내부에서 현재 사용되지 않음.
+    // 홈탭의 '건물 출입구' 섹션 포함 여부는 doorDir === InsideBuilding 등 구조적 조건으로만 결정된다.
+    // 시그니처 상 required이므로 값을 그대로 전달한다.
     const homeSections = getAccessibilitySections({
       isStandalone: pa.isStandaloneBuilding === true,
       doorDir: pa.doorDirectionType ?? undefined,
       isMultiFloor: (pa.floors?.length ?? 0) > 1,
       hasV2Fields:
         pa.isStandaloneBuilding != null && pa.doorDirectionType != null,
-      hasBuildingAccessibility: !!ba,
+      hasBuildingAccessibility: hasAnyBa,
     });
 
     // 건물 출입구 섹션이 PDP에 노출되고 + BA 실데이터가 있을 때만 (EmptySection일 땐 false)
     const hasBuildingAccessibility =
-      homeSections.includes('건물 출입구') && !!ba;
+      homeSections.includes('건물 출입구') && hasAnyBa;
 
-    // PDP 홈탭의 PhotoRow 3곳 중 하나라도 실제로 렌더되는가
+    // PDP 홈탭의 PhotoRow 3곳 중 하나라도 실제로 렌더되는가.
+    // V2HomeTab의 BuildingEntranceSection은 모든 BA를 렌더하므로 사진 수도 전체 합산.
     const placePhotoCount = pa.images?.length ?? 0;
     const buildingPhotoCount = hasBuildingAccessibility
-      ? (ba?.entranceImages?.length ?? 0) + (ba?.elevatorImages?.length ?? 0)
+      ? buildingAccessibilities.reduce(
+          (sum, ba) =>
+            sum +
+            (ba.entranceImages?.length ?? 0) +
+            (ba.elevatorImages?.length ?? 0),
+          0,
+        )
       : 0;
     const floorMovingPhotoCount = homeSections.includes('층간 이동 정보')
       ? (pa.floorMovingElevatorAccessibility?.imageUrls?.length ?? 0)
@@ -607,7 +631,11 @@ export default function PlaceDetailV2Screen({
     const hasDoorType = (pa.entranceDoorTypes?.length ?? 0) > 0;
 
     const elevatorTargets: ElevatorCorrectionTargetDto[] = [];
-    if (hasBuildingAccessibility && ba?.hasElevator) {
+    // V2HomeTab이 모든 BA를 렌더하므로 어떤 BA든 엘리베이터가 있으면 옵션 노출.
+    if (
+      hasBuildingAccessibility &&
+      buildingAccessibilities.some(ba => ba.hasElevator)
+    ) {
       elevatorTargets.push(ElevatorCorrectionTargetDto.Ba);
     }
     if (
@@ -625,8 +653,14 @@ export default function PlaceDetailV2Screen({
       hasPhoto,
       hasDoorType,
       elevatorTargets,
+      placeAccessibilitySnapshot: {
+        floors: pa.floors ?? undefined,
+        isStandaloneBuilding: pa.isStandaloneBuilding ?? undefined,
+        entranceDoorTypes: pa.entranceDoorTypes ?? undefined,
+        accessibilityScore: data?.accessibilityScore ?? undefined,
+      },
     };
-  }, [accessibilityPost]);
+  }, [accessibilityPost, data?.accessibilityScore]);
 
   const handleSectionLayout = useCallback((chipName: string, y: number) => {
     sectionLayoutsRef.current[chipName] = y;
@@ -1042,19 +1076,7 @@ export default function PlaceDetailV2Screen({
           hasDoorType={negativeFeedbackFlags.hasDoorType}
           elevatorTargets={negativeFeedbackFlags.elevatorTargets}
           placeAccessibilitySnapshot={
-            accessibilityPost?.placeAccessibility
-              ? {
-                  floors:
-                    accessibilityPost.placeAccessibility.floors ?? undefined,
-                  isStandaloneBuilding:
-                    accessibilityPost.placeAccessibility.isStandaloneBuilding ??
-                    undefined,
-                  entranceDoorTypes:
-                    accessibilityPost.placeAccessibility.entranceDoorTypes ??
-                    undefined,
-                  accessibilityScore: data?.accessibilityScore ?? undefined,
-                }
-              : undefined
+            negativeFeedbackFlags.placeAccessibilitySnapshot
           }
           onPressCloseButton={() => {
             setReportTargetType(null);

--- a/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
+++ b/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
@@ -565,6 +565,69 @@ export default function PlaceDetailV2Screen({
   );
   const showChipBar = currentTab === 'accessibility' && chips.length > 0;
 
+  // 신고하기 step 2 옵션 필터링용 플래그 — PDP 홈탭에 실제로 렌더되는 정보에 1:1 대응.
+  const negativeFeedbackFlags = useMemo(() => {
+    const pa = accessibilityPost?.placeAccessibility;
+    const ba = accessibilityPost?.buildingAccessibility;
+    if (!pa) {
+      return {
+        hasPlaceAccessibility: false,
+        hasBuildingAccessibility: false,
+        hasPhoto: false,
+        hasDoorType: false,
+        elevatorTargets: [] as ElevatorCorrectionTargetDto[],
+      };
+    }
+
+    const homeSections = getAccessibilitySections({
+      isStandalone: pa.isStandaloneBuilding === true,
+      doorDir: pa.doorDirectionType ?? undefined,
+      isMultiFloor: (pa.floors?.length ?? 0) > 1,
+      hasV2Fields:
+        pa.isStandaloneBuilding != null && pa.doorDirectionType != null,
+      hasBuildingAccessibility: !!ba,
+    });
+
+    // 건물 출입구 섹션이 PDP에 노출되고 + BA 실데이터가 있을 때만 (EmptySection일 땐 false)
+    const hasBuildingAccessibility =
+      homeSections.includes('건물 출입구') && !!ba;
+
+    // PDP 홈탭의 PhotoRow 3곳 중 하나라도 실제로 렌더되는가
+    const placePhotoCount = pa.images?.length ?? 0;
+    const buildingPhotoCount = hasBuildingAccessibility
+      ? (ba?.entranceImages?.length ?? 0) + (ba?.elevatorImages?.length ?? 0)
+      : 0;
+    const floorMovingPhotoCount = homeSections.includes('층간 이동 정보')
+      ? (pa.floorMovingElevatorAccessibility?.imageUrls?.length ?? 0)
+      : 0;
+    const hasPhoto =
+      placePhotoCount + buildingPhotoCount + floorMovingPhotoCount > 0;
+
+    // 출입문 종류는 PA만 검사. BA 출입문 종류 신고는 건물 입구 신고 플로우에 포함.
+    const hasDoorType = (pa.entranceDoorTypes?.length ?? 0) > 0;
+
+    const elevatorTargets: ElevatorCorrectionTargetDto[] = [];
+    if (hasBuildingAccessibility && ba?.hasElevator) {
+      elevatorTargets.push(ElevatorCorrectionTargetDto.Ba);
+    }
+    if (
+      homeSections.includes('층간 이동 정보') &&
+      pa.floorMovingMethodTypes?.includes(
+        FloorMovingMethodTypeDto.PlaceElevator,
+      )
+    ) {
+      elevatorTargets.push(ElevatorCorrectionTargetDto.Pa);
+    }
+
+    return {
+      hasPlaceAccessibility: true,
+      hasBuildingAccessibility,
+      hasPhoto,
+      hasDoorType,
+      elevatorTargets,
+    };
+  }, [accessibilityPost]);
+
   const handleSectionLayout = useCallback((chipName: string, y: number) => {
     sectionLayoutsRef.current[chipName] = y;
   }, []);
@@ -971,52 +1034,13 @@ export default function PlaceDetailV2Screen({
           key={negativeFeedbackKey}
           isVisible={reportTargetType !== null}
           placeId={place.id}
+          hasPlaceAccessibility={negativeFeedbackFlags.hasPlaceAccessibility}
           hasBuildingAccessibility={
-            // PDP 홈탭의 getAccessibilitySections와 동일 로직 재사용
-            (() => {
-              const pa = accessibilityPost?.placeAccessibility;
-              if (!pa) return false;
-              const homeSections = getAccessibilitySections({
-                isStandalone: pa.isStandaloneBuilding === true,
-                doorDir: pa.doorDirectionType ?? undefined,
-                isMultiFloor: (pa.floors?.length ?? 0) > 1,
-                hasV2Fields:
-                  pa.isStandaloneBuilding != null &&
-                  pa.doorDirectionType != null,
-                hasBuildingAccessibility:
-                  !!accessibilityPost?.buildingAccessibility,
-              });
-              return homeSections.includes('건물 출입구');
-            })()
+            negativeFeedbackFlags.hasBuildingAccessibility
           }
-          elevatorTargets={(() => {
-            const pa = accessibilityPost?.placeAccessibility;
-            const ba = accessibilityPost?.buildingAccessibility;
-            if (!pa) return [];
-            const homeSections = getAccessibilitySections({
-              isStandalone: pa.isStandaloneBuilding === true,
-              doorDir: pa.doorDirectionType ?? undefined,
-              isMultiFloor: (pa.floors?.length ?? 0) > 1,
-              hasV2Fields:
-                pa.isStandaloneBuilding != null && pa.doorDirectionType != null,
-              hasBuildingAccessibility: !!ba,
-            });
-            const targets: ElevatorCorrectionTargetDto[] = [];
-            // BA 엘리베이터: 건물 출입구 섹션이 있고 BA에 엘리베이터가 있으면
-            if (homeSections.includes('건물 출입구') && ba?.hasElevator) {
-              targets.push(ElevatorCorrectionTargetDto.Ba);
-            }
-            // PA 엘리베이터: 층간 이동 정보 섹션이 있고 PA floorMovingMethodTypes에 PlaceElevator가 있으면
-            if (
-              homeSections.includes('층간 이동 정보') &&
-              pa.floorMovingMethodTypes?.includes(
-                FloorMovingMethodTypeDto.PlaceElevator,
-              )
-            ) {
-              targets.push(ElevatorCorrectionTargetDto.Pa);
-            }
-            return targets;
-          })()}
+          hasPhoto={negativeFeedbackFlags.hasPhoto}
+          hasDoorType={negativeFeedbackFlags.hasDoorType}
+          elevatorTargets={negativeFeedbackFlags.elevatorTargets}
           placeAccessibilitySnapshot={
             accessibilityPost?.placeAccessibility
               ? {


### PR DESCRIPTION
## Summary

PDP 홈탭 **신고하기 → 2단계 "어떤 정보가 틀렸나요?"** 옵션 목록이 **PDP에 렌더된 섹션만** 기준으로 결정되던 버그 수정. 섹션이 노출돼도 내용물이 비어있으면(EmptyStateCard / null row) 옵션에서 제외되도록 PDP 실렌더 조건과 1:1 대응시킨다.

**유저 예시 (수정 전 버그):** PA `doorDirectionType = INSIDE_BUILDING`이면 PDP에 "건물 출입구" 섹션이 노출되지만, BA가 등록되지 않은 경우 실제로는 `BuildingEntranceEmptySection`("아직 등록된 건물 정보가 없어요")만 보임. 그런데 신고 옵션에는 "건물 입구 계단 / 경사로 / 문이 잘못됐어요" 항목이 뜨고 있었음.

## Changes

**옵션별 노출 조건 재정의:**

| 옵션 | 수정 전 | 수정 후 (PDP 실렌더 조건) |
|---|---|---|
| 매장 출입구 | 항상 | PA 데이터 존재 시 |
| 층 정보 | 항상 | 항상 (FloorInfoRow는 PA 있으면 항상 렌더) |
| 사진 | 항상 | PhotoRow 3곳(매장 images / 건물 entrance+elevator images / 층간이동 imageUrls) 중 하나라도 있을 때 |
| 출입문 종류 | 항상 | PA.entranceDoorTypes 존재 시 (BA 출입문은 건물 입구 신고에 포함되므로 제외) |
| 건물 출입구 | 섹션 노출 여부만 | 섹션 노출 **AND** BA 실데이터 존재 |
| 엘리베이터 (BA) | 동일 | 동일 (이미 실데이터 기반) |
| 엘리베이터 (PA) | 동일 | 동일 (이미 실데이터 기반) |
| 접근 레벨 / 기타 | 항상 | 항상 |

**코드 구조:**
- `PlaceDetailNegativeFeedbackBottomSheet`에 `hasPlaceAccessibility`, `hasPhoto`, `hasDoorType` props 추가. `hasBuildingAccessibility`는 의미를 "섹션 노출"에서 "BA 실데이터 유무"로 변경.
- `PlaceDetailV2Screen`의 기존 인라인 IIFE 2개를 `useMemo(negativeFeedbackFlags)` 하나로 통합.

## Test plan

- [ ] **재현 케이스**: `doorDirectionType = INSIDE_BUILDING` + BA 없는 장소 → 시렌 → 틀린 정보 → **"건물 입구 계단 / 경사로 / 문이 잘못됐어요" 옵션 사라짐**
- [ ] **사진 없음 케이스**: PA/BA/층간이동 이미지 모두 없는 장소 → "사진이 잘못됐어요" 옵션 사라짐
- [ ] **출입문 없음 케이스**: PA.entranceDoorTypes 비어있는 장소 → "출입문 종류 / ~~이 아니에요" 옵션 사라짐
- [ ] **회귀 방지**: BA 데이터 있는 장소(doorDir=InsideBuilding) → 기존대로 "건물 입구" 옵션 정상, BA.hasElevator=true면 "건물 엘리베이터" 옵션 포함
- [ ] **라벨 회귀**: BA 있음 → "계단 / 경사로 / 문 방향이 잘못됐어요", BA 없음 → "입구 계단 / 경사로 / 문 방향이 잘못됐어요"
- [ ] `yarn tsc --noEmit`, `yarn lint` 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback system to ensure users only see report options for place details that are currently displayed, eliminating confusing options for unavailable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->