### PR TITLE
feat: WebView floating bar SccContent 일반화 + Notion 도메인 지원

### DIFF
--- a/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
+++ b/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
@@ -781,7 +781,7 @@ export default function PlaceDetailV2Screen({
     data?.specialAccessibility?.bbucleRoadData?.bbucleRoadUrl;
 
   // BbucleRoad: WebViewScreen으로 replace하여 코드 중복 제거.
-  // WebViewScreen이 이미 BbucleRoadFloatingBar, handleWebViewShouldStartLoad 등을 처리.
+  // WebViewScreen이 이미 SccContentFloatingBar, handleWebViewShouldStartLoad 등을 처리.
   const [didReplaceToBbucleRoad, setDidReplaceToBbucleRoad] = useState(false);
   useEffect(() => {
     if (bbucleRoadUrl && place && !didReplaceToBbucleRoad) {

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -13,7 +13,7 @@ import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 import {ScreenProps} from '@/navigation/Navigation.screens';
 import {handleWebViewShouldStartLoad} from '@/utils/webViewUtils';
-import BbucleRoadFloatingBar from './WebViewScreen/components/BbucleRoadFloatingBar';
+import SccContentFloatingBar from './WebViewScreen/components/SccContentFloatingBar';
 
 export interface WebViewScreenParams {
   headerVariant?: 'appbar' | 'navigation';
@@ -31,13 +31,15 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     fixedTitle || undefined,
   );
 
-  // URL에서 뿌클로드 ID 추출 (모든 route)
-  const bbucleRoadId = useMemo(() => {
+  // 뿌클로드 ID 추출 (con.staircrusher.club 경로에서만)
+  const sccContentId = useMemo(() => {
     const match = currentUrl.match(/con\.staircrusher\.club\/([^/?#]+)/);
     return match ? match[1] : null;
   }, [currentUrl]);
 
-  const shouldShowFloatingBar = bbucleRoadId !== null;
+  const shouldShowFloatingBar =
+    sccContentId !== null ||
+    currentUrl.startsWith('https://staircrusherclub.notion.site');
 
   const onTapCloseButton = useCallback(() => {
     Alert.alert('정말 페이지를 나가시겠어요?', '', [
@@ -113,8 +115,12 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
         }}
         contentInset={shouldShowFloatingBar ? {bottom: 80} : undefined}
       />
-      {shouldShowFloatingBar && bbucleRoadId && (
-        <BbucleRoadFloatingBar bbucleRoadId={bbucleRoadId} title={title} />
+      {shouldShowFloatingBar && (
+        <SccContentFloatingBar
+          url={currentUrl}
+          sccContentId={sccContentId}
+          title={title}
+        />
       )}
     </SafeAreaWrapper>
   );

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -31,15 +31,15 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     fixedTitle || undefined,
   );
 
-  // 뿌클로드 ID 추출 (con.staircrusher.club 경로에서만)
+  // 뿌클로드(con.staircrusher.club) / 계뿌클 Notion 양쪽에서 콘텐츠 ID 추출
   const sccContentId = useMemo(() => {
-    const match = currentUrl.match(/con\.staircrusher\.club\/([^/?#]+)/);
+    const match = currentUrl.match(
+      /(?:con\.staircrusher\.club|staircrusherclub\.notion\.site)\/([^/?#]+)/,
+    );
     return match ? match[1] : null;
   }, [currentUrl]);
 
-  const shouldShowFloatingBar =
-    sccContentId !== null ||
-    currentUrl.startsWith('https://staircrusherclub.notion.site');
+  const shouldShowFloatingBar = sccContentId !== null;
 
   const onTapCloseButton = useCallback(() => {
     Alert.alert('정말 페이지를 나가시겠어요?', '', [

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -39,7 +39,10 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     return match ? match[1] : null;
   }, [currentUrl]);
 
-  const shouldShowFloatingBar = sccContentId !== null;
+  // SCC 콘텐츠 도메인이면 ID 추출 실패해도 floating bar는 노출 (id 없으면 도움이돼요만 숨김)
+  const shouldShowFloatingBar =
+    currentUrl.startsWith('https://con.staircrusher.club') ||
+    currentUrl.startsWith('https://staircrusherclub.notion.site');
 
   const onTapCloseButton = useCallback(() => {
     Alert.alert('정말 페이지를 나가시겠어요?', '', [

--- a/src/screens/WebViewScreen/components/SccContentFloatingBar.tsx
+++ b/src/screens/WebViewScreen/components/SccContentFloatingBar.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {Linking, View} from 'react-native';
+import {Linking, Share, View} from 'react-native';
 import {useQuery} from '@tanstack/react-query';
 import styled from 'styled-components/native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -20,29 +20,31 @@ import ThumbsUpFillIcon from '@/assets/icon/ic_thumbs_up_fill.svg';
 import ShareIcon from '@/assets/icon/ic_share.svg';
 import {useCheckAuth} from '@/utils/checkAuth';
 
-interface BbucleRoadFloatingBarProps {
-  bbucleRoadId: string;
+interface SccContentFloatingBarProps {
+  url: string;
+  sccContentId: string | null;
   title?: string;
 }
 
-export default function BbucleRoadFloatingBar({
-  bbucleRoadId,
+export default function SccContentFloatingBar({
+  url,
+  sccContentId,
   title,
-}: BbucleRoadFloatingBarProps) {
+}: SccContentFloatingBarProps) {
   const {api} = useAppComponents();
   const insets = useSafeAreaInsets();
   const {userInfo} = useMe();
 
-  // Upvote 상태 조회
+  // Upvote 상태 조회 (sccContentId가 있을 때만)
   const {data: upvoteDetails} = useQuery({
-    queryKey: ['BbucleRoadUpvoteDetails', bbucleRoadId],
+    queryKey: ['SccContentUpvoteDetails', sccContentId],
     queryFn: async () => {
       return await api.getUpvoteDetailsPost({
         targetType: UpvoteTargetTypeDto.BbucleRoad,
-        id: bbucleRoadId,
+        id: sccContentId!,
       });
     },
-    enabled: !!bbucleRoadId,
+    enabled: !!sccContentId,
   });
 
   const upvotedUsers = upvoteDetails?.data?.upvotedUsers ?? [];
@@ -54,20 +56,28 @@ export default function BbucleRoadFloatingBar({
   const {isUpvoted, totalUpvoteCount, toggleUpvote} = useUpvoteToggle({
     initialIsUpvoted: hasUpvoted,
     initialTotalCount: totalCount,
-    targetId: bbucleRoadId,
+    targetId: sccContentId ?? undefined,
     targetType: UpvoteTargetTypeDto.BbucleRoad,
-    placeId: '', // 뿌클로드는 장소 ID가 없음
+    placeId: '',
   });
   const checkAuth = useCheckAuth();
 
   // 공유하기
   const handleShare = useCallback(async () => {
     try {
-      await ShareUtils.shareBbucleRoad(bbucleRoadId, title);
+      if (sccContentId) {
+        await ShareUtils.shareBbucleRoad(sccContentId, title);
+      } else {
+        await Share.share({
+          message: title
+            ? `[${title}]를 계단뿌셔클럽에서 확인해보세요!\n${url}`
+            : url,
+        });
+      }
     } catch (_error) {
       // Share 취소는 에러로 처리하지 않음
     }
-  }, [bbucleRoadId, title]);
+  }, [sccContentId, url, title]);
 
   // 정보 더 받아보기 (Tally 링크)
   const handleMoreInfo = useCallback(async () => {
@@ -82,24 +92,26 @@ export default function BbucleRoadFloatingBar({
   return (
     <Container style={{paddingBottom: insets.bottom}}>
       <ContentRow>
-        {/* 도움이 돼요 버튼 */}
-        <UpvoteButton
-          onPress={() => {
-            checkAuth(toggleUpvote, () =>
-              ToastUtils.show('로그인이 필요합니다'),
-            );
-          }}
-          elementName="bbucleroad-upvote"
-          logParams={{bbucleRoadId}}>
-          {isUpvoted ? (
-            <ThumbsUpFillIcon width={20} height={20} />
-          ) : (
-            <ThumbsUpIcon width={20} height={20} />
-          )}
-          {totalUpvoteCount !== undefined && totalUpvoteCount > 0 ? (
-            <UpvoteCount isActive={isUpvoted}>{totalUpvoteCount}</UpvoteCount>
-          ) : null}
-        </UpvoteButton>
+        {/* 도움이 돼요 버튼 (sccContentId 있을 때만) */}
+        {sccContentId !== null && (
+          <UpvoteButton
+            onPress={() => {
+              checkAuth(toggleUpvote, () =>
+                ToastUtils.show('로그인이 필요합니다'),
+              );
+            }}
+            elementName="scc-content-upvote"
+            logParams={{sccContentId}}>
+            {isUpvoted ? (
+              <ThumbsUpFillIcon width={20} height={20} />
+            ) : (
+              <ThumbsUpIcon width={20} height={20} />
+            )}
+            {totalUpvoteCount !== undefined && totalUpvoteCount > 0 ? (
+              <UpvoteCount isActive={isUpvoted}>{totalUpvoteCount}</UpvoteCount>
+            ) : null}
+          </UpvoteButton>
+        )}
 
         <Spacer />
 
@@ -117,8 +129,8 @@ export default function BbucleRoadFloatingBar({
           fontWeight={'500'}
           height={40}
           onPress={handleShare}
-          elementName="bbucleroad-share"
-          logParams={{bbucleRoadId}}
+          elementName="scc-content-share"
+          logParams={{sccContentId, url}}
         />
 
         {/* 정보 더 받아보기 버튼 */}
@@ -131,8 +143,8 @@ export default function BbucleRoadFloatingBar({
           fontWeight={'500'}
           height={40}
           onPress={handleMoreInfo}
-          elementName="bbucleroad-more-info"
-          logParams={{bbucleRoadId}}
+          elementName="scc-content-more-info"
+          logParams={{sccContentId, url}}
         />
       </ContentRow>
     </Container>


### PR DESCRIPTION
## Summary
- `BbucleRoadFloatingBar` → `SccContentFloatingBar`로 리네이밍, `bbucleRoadId` → `sccContentId` (optional)
- `sccContentId`가 없으면 도움이돼요 버튼은 숨기고, 공유는 현재 webview URL을 그대로 share
- WebView floating bar 노출 대상에 `https://staircrusherclub.notion.site` 시작 URL 추가
- WebView `contentInset`과 floating bar 렌더링이 동일한 `shouldShowFloatingBar` 단일 조건을 공유하도록 정리

## Test plan
- [ ] `con.staircrusher.club/{id}` 페이지: floating bar 노출 + 도움이돼요/공유/정보 더 받아보기 동작
- [ ] `https://staircrusherclub.notion.site/...` 페이지: floating bar 노출, 도움이돼요 버튼 미노출, 공유는 현재 URL share
- [ ] 그 외 일반 webview URL: floating bar 미노출, contentInset 80px도 적용 안 됨
- [ ] PDP에서 BbucleRoad replace 흐름 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced floating bar functionality to support Stairucrusher Club content from additional sources.
  * Updated sharing and upvoting capabilities for improved content interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->