### PR TITLE
fix: WebView floating bar 노출 판정 host 매칭으로 변경

### DIFF
--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -39,10 +39,11 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     return match ? match[1] : null;
   }, [currentUrl]);
 
-  // SCC 콘텐츠 도메인이면 ID 추출 실패해도 floating bar는 노출 (id 없으면 도움이돼요만 숨김)
+  // SCC 콘텐츠 도메인이면 ID 추출 실패해도 floating bar는 노출 (id 없으면 도움이돼요만 숨김).
+  // scheme(http/https)나 selector 차이에 robust하도록 host 매칭으로 판정.
   const shouldShowFloatingBar =
-    currentUrl.startsWith('https://con.staircrusher.club') ||
-    currentUrl.startsWith('https://staircrusherclub.notion.site');
+    /\bcon\.staircrusher\.club\b/.test(currentUrl) ||
+    /\bstaircrusherclub\.notion\.site\b/.test(currentUrl);
 
   const onTapCloseButton = useCallback(() => {
     Alert.alert('정말 페이지를 나가시겠어요?', '', [
@@ -114,7 +115,10 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
         onShouldStartLoadWithRequest={handleShouldStartLoad}
         onNavigationStateChange={navState => {
           setCanGoBack(navState.canGoBack);
-          setCurrentUrl(navState.url);
+          // navState.url이 빈 문자열로 들어오는 순간이 있어 currentUrl이 덮어써지지 않도록 가드
+          if (navState.url) {
+            setCurrentUrl(navState.url);
+          }
         }}
         contentInset={shouldShowFloatingBar ? {bottom: 80} : undefined}
       />


### PR DESCRIPTION
## Summary
- #156 머지 후 \`https://staircrusherclub.notion.site/...\` URL에서 floating bar가 안 뜬다는 리포트
- \`shouldShowFloatingBar\` 판정을 \`startsWith('https://...')\` → 호스트명 정규식 매칭으로 변경 (scheme이나 URL 형식 변형에 robust)
- \`onNavigationStateChange\`에서 \`navState.url\`이 빈 문자열로 들어오는 순간 currentUrl이 덮여 floating bar가 사라지지 않도록 가드

## Test plan
- [ ] \`https://staircrusherclub.notion.site/elec-wheelchair-airport-tip?pvs=149\` 진입 시 floating bar 노출
- [ ] \`https://con.staircrusher.club/{id}\` 페이지에서도 기존대로 floating bar 노출
- [ ] floating bar 미노출 대상(다른 외부 사이트)은 여전히 미노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)