### PR TITLE
fix: iOS 26 HEIC 이미지 업로드 실패 회피 (JPEG 강제)

### DIFF
--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -131,6 +131,8 @@ const Logger = {
     imageCount: number;
     retryCount: number;
     errorMessage: string;
+    imageMime?: string;
+    imageSizeMb?: number;
   }) {
     logDebug('logUploadImageFailed', params, currUserPropertiesForDebugging);
     const eventParams = {
@@ -141,6 +143,10 @@ const Logger = {
       image_count: params.imageCount,
       retry_count: params.retryCount,
       error_message: params.errorMessage,
+      ...(params.imageMime !== undefined && {image_mime: params.imageMime}),
+      ...(params.imageSizeMb !== undefined && {
+        image_size_mb: params.imageSizeMb,
+      }),
     };
     trackEvent('upload_image_failed', eventParams);
     getAnalytics().logEvent('upload_image_failed', eventParams);

--- a/src/screens/CameraScreen/CameraScreen.tsx
+++ b/src/screens/CameraScreen/CameraScreen.tsx
@@ -171,6 +171,9 @@ export default function CameraScreen({
       maxHeight: 2000,
       maxWidth: 2000,
       selectionLimit: photoLimit,
+      // iOS에서 HEIC/HEIF를 JPEG로 변환해서 내려받는다.
+      // iOS 26에서 HEIC 일부가 후속 압축/업로드 단계에서 실패하는 사례 회피.
+      assetRepresentationMode: 'compatible' as const,
     };
 
     const loadingTimer = setTimeout(() => setIsLoadingAlbum(true), 1000);
@@ -359,6 +362,8 @@ async function cropToRect(taken: PhotoFile) {
     {
       offset: {x: offset.x, y: offset.y},
       size: {width: size, height: size},
+      // iOS 26에서 HEIC 입력이 후속 단계에서 실패하는 케이스가 있어 JPEG로 강제.
+      format: 'jpeg',
     },
   );
   return {cropped, size};

--- a/src/utils/ImageFileUtils.ts
+++ b/src/utils/ImageFileUtils.ts
@@ -45,8 +45,28 @@ function classifyError(error: unknown): {
   return {errorType: 'unknown'};
 }
 
+interface ImageDebugInfo {
+  imageMime?: string;
+  imageSizeMb?: number;
+}
+
+function attachDebugInfo<E extends Error>(error: E, info: ImageDebugInfo): E {
+  Object.assign(error, info);
+  return error;
+}
+
+function extractDebugInfo(error: unknown): ImageDebugInfo {
+  if (error && typeof error === 'object') {
+    const e = error as ImageDebugInfo;
+    return {imageMime: e.imageMime, imageSizeMb: e.imageSizeMb};
+  }
+  return {};
+}
+
 class UploadHttpError extends Error {
   httpStatus: number;
+  imageMime?: string;
+  imageSizeMb?: number;
   constructor(message: string, httpStatus: number) {
     super(message);
     this.name = 'UploadHttpError';
@@ -74,6 +94,11 @@ async function uploadToPresignedUrl(
       }
     };
 
+    const debugInfo: ImageDebugInfo = {
+      imageMime: imageBody.type,
+      imageSizeMb: floor(imageBody.size / (1024 * 1024), 3),
+    };
+
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
         resolve({
@@ -82,9 +107,12 @@ async function uploadToPresignedUrl(
         });
       } else {
         reject(
-          new UploadHttpError(
-            `Upload image to ${url.href} is failed. cause: ${xhr.responseText}`,
-            xhr.status,
+          attachDebugInfo(
+            new UploadHttpError(
+              `Upload image to ${url.href} is failed. cause: ${xhr.responseText}`,
+              xhr.status,
+            ),
+            debugInfo,
           ),
         );
       }
@@ -92,12 +120,19 @@ async function uploadToPresignedUrl(
 
     xhr.ontimeout = () => {
       reject(
-        new Error(`Image upload timed out after ${UPLOAD_TIMEOUT_MS / 1000}s`),
+        attachDebugInfo(
+          new Error(
+            `Image upload timed out after ${UPLOAD_TIMEOUT_MS / 1000}s`,
+          ),
+          debugInfo,
+        ),
       );
     };
 
     xhr.onerror = () => {
-      reject(new TypeError('Network request failed'));
+      reject(
+        attachDebugInfo(new TypeError('Network request failed'), debugInfo),
+      );
     };
 
     xhr.open('PUT', url.href);
@@ -207,6 +242,8 @@ const ImageFileUtils = {
             maxWidth: 2560,
             maxHeight: 2560,
             quality: 0.7,
+            // HEIC 입력이라도 JPEG로 출력 강제. iOS 26 호환성.
+            output: 'jpg',
           });
         } catch (compressError) {
           Logger.logError(
@@ -261,12 +298,15 @@ const ImageFileUtils = {
       return uploadedUrls;
     } catch (error) {
       const {errorType, httpStatus} = classifyError(error);
+      const {imageMime, imageSizeMb} = extractDebugInfo(error);
       await Logger.logUploadImageFailed({
         errorType,
         httpStatus,
         imageCount: images.length,
         retryCount: 1,
         errorMessage: error instanceof Error ? error.message : String(error),
+        imageMime,
+        imageSizeMb,
       });
       Logger.logError(
         error instanceof Error ? error : new Error(String(error)),


### PR DESCRIPTION
## 배경

place form에서 PA 등록 시 일부 사용자가 이미지 업로드 단계에서 실패한다는 제보. BigQuery `upload_image_failed` 이벤트를 분석한 결과, **iOS 26에서만 1~2.6% 실패율** (iOS 17/18은 거의 0%) 패턴이 명확.

| 날짜 | iOS 17 | iOS 18 | iOS 26 |
|------|--------|--------|--------|
| 4/18 토 | 0/53 | 1/311 (0.3%) | **16/821 (1.91%)** |
| 4/19 일 | - | 0/72 | **10/581 (1.69%)** |
| 4/24 금 | - | 0/8 | **2/74 (2.63%)** |
| 4/25 토 | 0/28 | 1/199 (0.5%) | **10/896 (1.10%)** |

실패 케이스는 모두 `network` (TypeError) 또는 `timeout` (30s 초과). HTTP 4xx/5xx 0건이므로 서버/인프라 광역 장애 아님.

한 사용자가 "iOS 설정 > 카메라 > 포맷 = 높은 호환성"으로 변경 후 정상 작동 보고 → HEIC variant가 후속 압축/업로드 단계 어딘가에서 깨지는 호환성 이슈로 판단.

자세한 분석: `analysis_notes/20260425_pa_image_upload_failure.md`

## Summary

defense-in-depth 3 layer로 카메라/앨범 입력을 항상 JPEG로 정규화한다. 어느 한 단계라도 JPEG로 정리되면 그 후 흐름은 안전하다.

| 위치 | 변경 | 효과 |
|------|------|------|
| `CameraScreen.tsx` `selectFromAlbum` | `assetRepresentationMode: 'compatible'` 추가 | iOS native가 HEIC/HEIF를 JPEG로 변환해서 내려줌 |
| `CameraScreen.tsx` `cropToRect` | `cropImage` 옵션 `format: 'jpeg'` | 카메라 경로의 첫 변환 단계에서 JPEG 강제 |
| `ImageFileUtils.ts` `ImageCompressor.compress` | `output: 'jpg'` | 압축 단계 출력 JPEG 강제 |
| `ImageFileUtils.ts` xhr handlers | reject error에 `imageMime`/`imageSizeMb` attach | 실패 시 blob mime/size 캡처 |
| `Logger.ts` `logUploadImageFailed` | `imageMime`, `imageSizeMb` 옵셔널 필드 추가 | BQ에 추가 컬럼 기록 → 재발/패턴 분석 |

## 왜 vision-camera takePhoto에 photoCodec 안 넣었나

vision-camera v4가 archived 상태고 v4.7에서 `photoCodec: 'jpeg'`가 정확히 valid한지 docs로 확신 어려움. cropImage가 JPEG로 강제하면 그 후 흐름이 다 JPEG가 되므로 root cause는 이미 커버됨. 만약 cropImage 단계에서 HEIC 처리 자체가 깨지면 v5 업그레이드를 별도로 검토.

## Test plan
- [x] `yarn tsc --noEmit` 통과
- [x] `yarn lint` 통과
- [ ] iOS 26 시뮬레이터/실기기에서 카메라 촬영 → PA 등록 정상 동작 확인 (포맷 = 높은 효율성 설정 상태에서)
- [ ] iOS 26에서 앨범 (HEIC 사진 포함)에서 선택 → PA 등록 정상 동작 확인
- [ ] Android에서 PA 등록 회귀 없음 확인
- [ ] 배포 후 BigQuery `upload_image_failed` 이벤트 추이 확인 (iOS 26 실패율 ~0% 수렴 예상)
- [ ] 실패가 발생하면 새 컬럼 `image_mime`, `image_size_mb`로 원인 추적

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error diagnostics now capture image metadata (MIME type and file size) for improved upload troubleshooting.

* **Bug Fixes**
  * Improved iOS device compatibility when selecting images from the device album.
  * Standardized all image processing to output JPEG format for consistent handling across different devices and image types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->