### PR TITLE
feat: B2B 챌린지 폼 필수 필드 라벨에 빨간 별표 표시

### DIFF
--- a/src/components/molecules/FormFieldRenderer/index.tsx
+++ b/src/components/molecules/FormFieldRenderer/index.tsx
@@ -6,6 +6,8 @@ import type {FormField} from '@/types/b2bForm';
 import {getInputType, formatPlaceholder} from '@/types/b2bForm';
 import Input from '@/screens/ChallengeDetailScreen/components/ChallengeDetailCompanyModal/Input';
 import FormFieldOptionSelector from '@/components/molecules/FormFieldOptionSelector';
+import {color} from '@/constant/color';
+import {font} from '@/constant/font';
 
 interface FormFieldRendererProps {
   field: FormField;
@@ -33,10 +35,18 @@ export default function FormFieldRenderer({
 
   const inputType = getInputType(field);
 
+  const labelNode = (
+    <LabelWrapper>
+      <LabelText>{field.displayName}</LabelText>
+      {field.isRequired && <RequiredMark>{' *'}</RequiredMark>}
+    </LabelWrapper>
+  );
+
   // Text input (주관식)
   if (inputType === 'text') {
     return (
       <FieldContainer>
+        {labelNode}
         <Input
           value={value}
           onChangeText={onChange}
@@ -51,6 +61,7 @@ export default function FormFieldRenderer({
   // Select input (객관식)
   return (
     <FieldContainer>
+      {labelNode}
       <Input
         value={value}
         placeholder={formatPlaceholder(field.displayName)}
@@ -73,4 +84,23 @@ export default function FormFieldRenderer({
   );
 }
 
-const FieldContainer = styled.View``;
+const FieldContainer = styled.View`
+  gap: 8px;
+`;
+
+const LabelWrapper = styled.View`
+  flex-direction: row;
+  align-items: center;
+`;
+
+const LabelText = styled.Text`
+  font-family: ${font.pretendardMedium};
+  font-size: 13px;
+  color: ${color.black};
+`;
+
+const RequiredMark = styled.Text`
+  font-family: ${font.pretendardMedium};
+  font-size: 13px;
+  color: ${color.red};
+`;

--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -1038,6 +1038,12 @@ export interface ChallengeB2bFormAvailableFieldDto {
      * @memberof ChallengeB2bFormAvailableFieldDto
      */
     'options'?: Array<string> | null;
+    /**
+     * 필수 입력 여부 (true면 빈 값으로 제출 시 검증 실패)
+     * @type {boolean}
+     * @memberof ChallengeB2bFormAvailableFieldDto
+     */
+    'isRequired': boolean;
 }
 /**
  * 

--- a/src/types/b2bForm.ts
+++ b/src/types/b2bForm.ts
@@ -20,6 +20,7 @@ export interface FormField {
   name: ChallengeB2bFormAvailableFieldNameTypeDto | null;
   displayName: string;
   options: string[] | null;
+  isRequired: boolean;
 }
 
 /**
@@ -39,6 +40,7 @@ export function toFormField(dto: ChallengeB2bFormAvailableFieldDto): FormField {
     name: dto.name ?? null,
     displayName: dto.displayName,
     options: dto.options ?? null,
+    isRequired: dto.isRequired ?? true,
   };
 }
 
@@ -171,7 +173,9 @@ export function validateForm(
   formState: FormState,
   fields: FormField[],
 ): {isValid: boolean; errorMessage?: string} {
-  const emptyFields = fields.filter(field => !formState[field.key]?.trim());
+  const emptyFields = fields
+    .filter(field => field.isRequired)
+    .filter(field => !formState[field.key]?.trim());
 
   if (emptyFields.length > 0) {
     const displayName = emptyFields[0].displayName;


### PR DESCRIPTION
## Summary
- `FormField`에 `isRequired: boolean` 추가, `toFormField`에서 `dto.isRequired ?? true`
- `validateForm`은 `isRequired=true` 필드만 빈 값 검증 → 옵셔널 필드는 비어있어도 제출 가능
- `FormFieldRenderer`가 각 Input 위에 displayName 라벨을 렌더링, 필수 필드에만 빨간색 `*` (color.red `#DB0B24`)

## Why
운영자가 정의한 옵셔널 필드는 사용자도 비워둘 수 있어야 하고, 필수 필드는 시각적으로 명확히 구분되어야 함.

## Dependencies
- scc-api PR: https://github.com/Stair-Crusher-Club/scc-api/pull/106
- scc-server PR: https://github.com/Stair-Crusher-Club/scc-server/pull/941
- 서브모듈 포인터: `feat/b2b-form-schema-required` (`85a5d9a`)

## Test plan
- [x] `yarn tsc --noEmit` 통과
- [x] `yarn lint` 통과
- [ ] B2B 챌린지 참가 모달 진입 시 필수 필드 라벨에만 빨간 `*` 표시 확인 (수동)
- [ ] 옵셔널 필드 비운 채 제출 → 성공 (수동)
- [ ] 필수 필드 비운 채 제출 시도 → 확인 버튼 비활성 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)