### PR TITLE
release-1.3.6: 음량 버튼 셔터 네이티브 모듈

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,59 @@ After any code changes or implementation work, **ALWAYS** run these validation c
 
 **No task is complete until both commands pass with zero issues.**
 
+## 네이티브 코드 변경 시 추가 검증 (MANDATORY)
+
+`ios/**/*.{mm,h,m,swift}`, `ios/**/project.pbxproj`, `android/**/*.{kt,java}` 중 어느 하나라도 변경됐다면 push 전에 **release configuration으로 compile-only 빌드**를 반드시 통과시킨다. JS lint/tsc는 네이티브 컴파일 에러를 잡지 못한다.
+
+### 왜 필요한가
+- Debug 빌드는 컴파일러 플래그가 느슨해서 `typeof` 같은 GCC 확장, 일부 deprecated API 호출 등이 경고로 다운그레이드되거나 통과됨
+- CI는 ReleaseSandbox(App Store 배포용)로 `-Werror` 동급의 strict flag로 빌드 → 같은 코드가 거기서 깨짐
+- Framework 링크 누락(예: `Undefined symbols for architecture arm64`) 같은 링커 에러도 Release 빌드에서야 노출됨
+
+### iOS 검증 명령
+```bash
+xcodebuild -workspace ios/sccReactNative.xcworkspace \
+  -configuration ReleaseSandbox \
+  -scheme StairCrusherClubSandbox \
+  -destination 'generic/platform=iOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+- `CODE_SIGNING_ALLOWED=NO`: match AppStore 프로필 없이 컴파일/링크만 수행
+- `generic/platform=iOS`: 특정 디바이스/시뮬레이터 안 잡고 빌드
+- 첫 빌드 10~15분, 이후 incremental 1~2분
+
+### Android 검증 명령
+```bash
+cd android && ./gradlew assembleSandboxRelease
+```
+
+### DerivedData 디스크 부족 시
+`~/Library/Developer/Xcode/DerivedData/` 가 수십GB까지 자라면 `rm -rf ~/Library/Developer/Xcode/DerivedData/*`로 비운다. 다음 빌드만 풀로 컴파일해서 한 번 느려질 뿐 안전하다.
+
+## 네이티브 모듈 작성 규칙 (RCTBridgeModule / ReactContextBaseJavaModule)
+
+새로운 네이티브 모듈을 만들거나 기존 모듈에 메서드를 추가할 때:
+
+### 양쪽 플랫폼 메서드 시그니처 일치 필수
+JS 측 wrapper의 반환 타입(`Promise<T>` vs `void`)이 iOS와 Android 양쪽의 native 메서드와 모두 일치해야 한다. 한쪽만 어긋나면 그 플랫폼에서 `TypeError: Cannot read properties of undefined` 같은 런타임 크래시가 발생한다.
+
+| JS wrapper 반환 | iOS (.mm) | Android (.kt) |
+|--------------|-----------|---------------|
+| `Promise<T>` | `RCT_EXPORT_METHOD(name:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)` | `@ReactMethod fun name(promise: Promise)` |
+| `void` | `RCT_EXPORT_METHOD(name)` | `@ReactMethod fun name()` |
+
+### Bridgeless(New Architecture) 주의사항
+이 프로젝트는 `isNewArchEnabled = true` + `bridgelessEnabled = YES`로 동작한다. `MainActivity`에서 `reactInstanceManager` 직접 접근은 throw를 일으킨다. 대신:
+```kotlin
+val reactContext = (application as? ReactApplication)?.reactHost?.currentReactContext
+val module = reactContext?.getNativeModule(MyModule::class.java)
+```
+그리고 module lookup이 어떤 이유로 실패해도 시스템 기본 동작이 막히지 않도록 `try/catch`로 감싼다 (예: `dispatchKeyEvent` 오버라이드).
+
+### NativeEventEmitter 이벤트 모듈
+이벤트를 emit하는 모듈(`RCTEventEmitter` / `DeviceEventManagerModule`)은 RN의 EventEmitter 계약 상 `addListener(eventName: String)`, `removeListeners(count: Int)` 메서드를 노출해야 한다. Android 쪽은 명시적으로 `@ReactMethod`로 두 메서드를 선언해두자 (no-op이어도 됨).
+
 ## Project Context
 
 - React Native application with TypeScript

--- a/android/app/src/main/java/club/staircrusher/MainActivity.kt
+++ b/android/app/src/main/java/club/staircrusher/MainActivity.kt
@@ -2,7 +2,9 @@ package club.staircrusher;
 
 import android.content.Intent
 import android.os.Bundle;
+import android.view.KeyEvent
 import co.ab180.airbridge.reactnative.AirbridgeReactNative
+import club.staircrusher.camerabuttons.SccCameraButtonsModule
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -38,5 +40,16 @@ class MainActivity : ReactActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (event.keyCode == KeyEvent.KEYCODE_VOLUME_UP || event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+            val module = reactInstanceManager.currentReactContext
+                ?.getNativeModule(SccCameraButtonsModule::class.java)
+            if (module?.handleKeyEvent(event) == true) {
+                return true
+            }
+        }
+        return super.dispatchKeyEvent(event)
     }
 }

--- a/android/app/src/main/java/club/staircrusher/MainActivity.kt
+++ b/android/app/src/main/java/club/staircrusher/MainActivity.kt
@@ -7,6 +7,7 @@ import co.ab180.airbridge.reactnative.AirbridgeReactNative
 import club.staircrusher.camerabuttons.SccCameraButtonsModule
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactApplication
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 import org.devio.rn.splashscreen.SplashScreen;
@@ -44,10 +45,16 @@ class MainActivity : ReactActivity() {
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         if (event.keyCode == KeyEvent.KEYCODE_VOLUME_UP || event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
-            val module = reactInstanceManager.currentReactContext
-                ?.getNativeModule(SccCameraButtonsModule::class.java)
-            if (module?.handleKeyEvent(event) == true) {
-                return true
+            try {
+                // 우리 앱은 bridgeless(new architecture)라 reactInstanceManager 직접 접근은
+                // throw를 일으킨다. application.reactHost.currentReactContext 경유로 안전하게 조회.
+                val reactContext = (application as? ReactApplication)?.reactHost?.currentReactContext
+                val module = reactContext?.getNativeModule(SccCameraButtonsModule::class.java)
+                if (module?.handleKeyEvent(event) == true) {
+                    return true
+                }
+            } catch (e: Throwable) {
+                // 어떤 이유로든 module lookup이 실패하면 시스템 기본 동작으로 넘긴다.
             }
         }
         return super.dispatchKeyEvent(event)

--- a/android/app/src/main/java/club/staircrusher/MainActivity.kt
+++ b/android/app/src/main/java/club/staircrusher/MainActivity.kt
@@ -2,12 +2,12 @@ package club.staircrusher;
 
 import android.content.Intent
 import android.os.Bundle;
+import android.util.Log
 import android.view.KeyEvent
 import co.ab180.airbridge.reactnative.AirbridgeReactNative
 import club.staircrusher.camerabuttons.SccCameraButtonsModule
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactApplication
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 import org.devio.rn.splashscreen.SplashScreen;
@@ -45,16 +45,14 @@ class MainActivity : ReactActivity() {
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         if (event.keyCode == KeyEvent.KEYCODE_VOLUME_UP || event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) {
+            // bridgeless 모드에서 ReactContext.getNativeModule 이 legacy package 모듈을 못 찾는
+            // 케이스가 있어, 모듈이 자신을 static 슬롯에 등록하고 그 슬롯을 거쳐 호출한다.
             try {
-                // 우리 앱은 bridgeless(new architecture)라 reactInstanceManager 직접 접근은
-                // throw를 일으킨다. application.reactHost.currentReactContext 경유로 안전하게 조회.
-                val reactContext = (application as? ReactApplication)?.reactHost?.currentReactContext
-                val module = reactContext?.getNativeModule(SccCameraButtonsModule::class.java)
-                if (module?.handleKeyEvent(event) == true) {
+                if (SccCameraButtonsModule.dispatchKeyEventToActiveInstance(event)) {
                     return true
                 }
             } catch (e: Throwable) {
-                // 어떤 이유로든 module lookup이 실패하면 시스템 기본 동작으로 넘긴다.
+                Log.e("SccCameraButtons", "dispatchKeyEvent failed", e)
             }
         }
         return super.dispatchKeyEvent(event)

--- a/android/app/src/main/java/club/staircrusher/MainApplication.kt
+++ b/android/app/src/main/java/club/staircrusher/MainApplication.kt
@@ -16,6 +16,7 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.uimanager.ReactShadowNode
 import com.facebook.react.uimanager.ViewManager
 import co.ab180.airbridge.reactnative.AirbridgeReactNative
+import club.staircrusher.camerabuttons.SccCameraButtonsPackage
 import com.hotupdater.HotUpdater
 import java.io.File
 
@@ -25,6 +26,7 @@ class MainApplication : Application(), ReactApplication {
         object : DefaultReactNativeHost(this) {
             override fun getPackages(): List<ReactPackage> =
                 PackageList(this).packages.apply {
+                    add(SccCameraButtonsPackage())
                     // Packages that cannot be autolinked yet can be added manually here, for example:
                     add(object : ReactPackage, ViewManagerOnDemandReactPackage {
                         override fun getViewManagerNames(reactContext: ReactApplicationContext) =

--- a/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsModule.kt
+++ b/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsModule.kt
@@ -1,5 +1,6 @@
 package club.staircrusher.camerabuttons
 
+import android.util.Log
 import android.view.KeyEvent
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -14,17 +15,30 @@ class SccCameraButtonsModule(
     @Volatile
     private var attached: Boolean = false
 
+    init {
+        activeInstance = this
+    }
+
+    override fun invalidate() {
+        super.invalidate()
+        if (activeInstance === this) {
+            activeInstance = null
+        }
+    }
+
     override fun getName(): String = NAME
 
     @ReactMethod
     fun attach(promise: Promise) {
         attached = true
+        Log.d(TAG, "attach() -> attached=true")
         promise.resolve(true)
     }
 
     @ReactMethod
     fun detach(promise: Promise) {
         attached = false
+        Log.d(TAG, "detach() -> attached=false")
         promise.resolve(true)
     }
 
@@ -43,6 +57,7 @@ class SccCameraButtonsModule(
      * Called from MainActivity.dispatchKeyEvent. Returns true if the event was consumed.
      */
     fun handleKeyEvent(event: KeyEvent): Boolean {
+        Log.d(TAG, "handleKeyEvent attached=$attached action=${event.action} keyCode=${event.keyCode} repeat=${event.repeatCount}")
         if (!attached) return false
         if (event.action != KeyEvent.ACTION_DOWN) return false
         if (event.keyCode != KeyEvent.KEYCODE_VOLUME_UP && event.keyCode != KeyEvent.KEYCODE_VOLUME_DOWN) {
@@ -51,14 +66,30 @@ class SccCameraButtonsModule(
         // Ignore key repeats so holding the button doesn't fire continuously.
         if (event.repeatCount > 0) return true
 
-        reactContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-            .emit(EVENT_CAPTURE_PRESS, null)
+        // bridgeless-safe emit. ReactContext.emitDeviceEvent는 내부에서 getJSModule null 체크를 한다.
+        try {
+            reactContext.emitDeviceEvent(EVENT_CAPTURE_PRESS, null)
+            Log.d(TAG, "emitted $EVENT_CAPTURE_PRESS")
+        } catch (e: Throwable) {
+            Log.e(TAG, "emit failed", e)
+        }
         return true
     }
 
     companion object {
         const val NAME = "SccCameraButtons"
         const val EVENT_CAPTURE_PRESS = "SccCameraButtonsCapturePress"
+        const val TAG = "SccCameraButtons"
+
+        // bridgeless 모드에서 ReactContext.getNativeModule(...) 이 legacy ReactPackage로 등록된
+        // 모듈을 찾지 못하는 케이스가 있어, MainActivity가 lookup 없이 직접 호출할 수 있도록
+        // 활성 인스턴스를 static 슬롯에 보관한다.
+        @Volatile
+        private var activeInstance: SccCameraButtonsModule? = null
+
+        @JvmStatic
+        fun dispatchKeyEventToActiveInstance(event: KeyEvent): Boolean {
+            return activeInstance?.handleKeyEvent(event) ?: false
+        }
     }
 }

--- a/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsModule.kt
+++ b/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsModule.kt
@@ -1,6 +1,7 @@
 package club.staircrusher.camerabuttons
 
 import android.view.KeyEvent
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
@@ -16,13 +17,15 @@ class SccCameraButtonsModule(
     override fun getName(): String = NAME
 
     @ReactMethod
-    fun attach() {
+    fun attach(promise: Promise) {
         attached = true
+        promise.resolve(true)
     }
 
     @ReactMethod
-    fun detach() {
+    fun detach(promise: Promise) {
         attached = false
+        promise.resolve(true)
     }
 
     // RN built-in EventEmitter API. JS side calls these to add/remove listener counts.

--- a/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsModule.kt
+++ b/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsModule.kt
@@ -1,0 +1,61 @@
+package club.staircrusher.camerabuttons
+
+import android.view.KeyEvent
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.modules.core.DeviceEventManagerModule
+
+class SccCameraButtonsModule(
+    private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+
+    @Volatile
+    private var attached: Boolean = false
+
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun attach() {
+        attached = true
+    }
+
+    @ReactMethod
+    fun detach() {
+        attached = false
+    }
+
+    // RN built-in EventEmitter API. JS side calls these to add/remove listener counts.
+    @ReactMethod
+    fun addListener(eventName: String) {
+        // no-op
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+        // no-op
+    }
+
+    /**
+     * Called from MainActivity.dispatchKeyEvent. Returns true if the event was consumed.
+     */
+    fun handleKeyEvent(event: KeyEvent): Boolean {
+        if (!attached) return false
+        if (event.action != KeyEvent.ACTION_DOWN) return false
+        if (event.keyCode != KeyEvent.KEYCODE_VOLUME_UP && event.keyCode != KeyEvent.KEYCODE_VOLUME_DOWN) {
+            return false
+        }
+        // Ignore key repeats so holding the button doesn't fire continuously.
+        if (event.repeatCount > 0) return true
+
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit(EVENT_CAPTURE_PRESS, null)
+        return true
+    }
+
+    companion object {
+        const val NAME = "SccCameraButtons"
+        const val EVENT_CAPTURE_PRESS = "SccCameraButtonsCapturePress"
+    }
+}

--- a/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsPackage.kt
+++ b/android/app/src/main/java/club/staircrusher/camerabuttons/SccCameraButtonsPackage.kt
@@ -1,0 +1,14 @@
+package club.staircrusher.camerabuttons
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class SccCameraButtonsPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+        listOf(SccCameraButtonsModule(reactContext))
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+}

--- a/android/app/version.properties
+++ b/android/app/version.properties
@@ -1,1 +1,1 @@
-version=1.3.5
+version=1.3.6

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -245,7 +245,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Mute (0.6.1)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2141,9 +2140,6 @@ PODS:
     - React-Core
   - react-native-tracking-transparency (0.1.2):
     - React
-  - react-native-volume-manager (2.0.8):
-    - Mute
-    - React-Core
   - react-native-webview (13.15.0):
     - boost
     - DoubleConversion
@@ -3177,7 +3173,6 @@ DEPENDENCIES:
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
   - react-native-tracking-transparency (from `../node_modules/react-native-tracking-transparency`)
-  - react-native-volume-manager (from `../node_modules/react-native-volume-manager`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -3254,7 +3249,6 @@ SPEC REPOS:
     - libdav1d
     - libwebp
     - lottie-ios
-    - Mute
     - nanopb
     - NMapsGeometry
     - NMapsMap
@@ -3376,8 +3370,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-splash-screen"
   react-native-tracking-transparency:
     :path: "../node_modules/react-native-tracking-transparency"
-  react-native-volume-manager:
-    :path: "../node_modules/react-native-volume-manager"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-NativeModulesApple:
@@ -3510,7 +3502,6 @@ SPEC CHECKSUMS:
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 29078ab5b3fd60b35793d708afaa9b0b01d97be4
-  Mute: 20135a96076f140cc82bfc8b810e2d6150d8ec7e
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
   NMapsMap: 09552eb050059e13b4c8fc294055760713cfdad8
@@ -3558,7 +3549,6 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 3bae4f8474c13ab141c40ed6c5c33f6177778d71
   react-native-splash-screen: 95994222cc95c236bd3cdc59fe45ed5f27969594
   react-native-tracking-transparency: 15eb319f2b982070eb9831582af27d87badfa624
-  react-native-volume-manager: cdd3c3857158c1df7b9fbea071a9946395cee06c
   react-native-webview: 9a8ea59197aa76145b8ce72aa3eea69f1e89dd38
   React-NativeModulesApple: e16d5c133019987285f001fbf1461a861e40426f
   React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -665,7 +665,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 164;
+				CURRENT_PROJECT_VERSION = 166;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -703,7 +703,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 164;
+				CURRENT_PROJECT_VERSION = 166;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -817,7 +817,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 164;
+				CURRENT_PROJECT_VERSION = 166;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -952,7 +952,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 164;
+				CURRENT_PROJECT_VERSION = 166;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		6132EF182BDFF13200BBE14D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		89B86B8879E417A56F32F316 /* libPods-sccReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4ECE3E814901418FC26F6DBA /* libPods-sccReactNative.a */; };
+		8A6A039BA7E33064C0C58694 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75688A217AAD3DBF51038FD8 /* AVKit.framework */; };
+		A2C8A2C7A737590D1707FF2C /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CDDDC8775B20FB298A0F377 /* MediaPlayer.framework */; };
 		D37EE964BE80BC6FEEEDA497 /* SccCameraButtons.mm in Sources */ = {isa = PBXBuildFile; fileRef = C2E6AC38FC31CD0188A67E64 /* SccCameraButtons.mm */; };
 		F113F2C4DFB2AA6F111C7E69 /* libPods-sccReactNative-sccReactNativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5010FAB64AC4B204FBF2657D /* libPods-sccReactNative-sccReactNativeTests.a */; };
 		F850682B2CF32E060002762A /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F85068262CF32E060002762A /* Pretendard-Light.ttf */; };
@@ -61,7 +63,9 @@
 		5010FAB64AC4B204FBF2657D /* libPods-sccReactNative-sccReactNativeTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-sccReactNative-sccReactNativeTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6002185BD33DA0C9D12E3914 /* Pods-sccReactNative-sccReactNativeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sccReactNative-sccReactNativeTests.debug.xcconfig"; path = "Target Support Files/Pods-sccReactNative-sccReactNativeTests/Pods-sccReactNative-sccReactNativeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = sccReactNative/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		75688A217AAD3DBF51038FD8 /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = sccReactNative/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		8CDDDC8775B20FB298A0F377 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		9CD56FF44FF27BF1ED301175 /* SccCameraButtons.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SccCameraButtons.h; path = sccReactNative/SccCameraButtons.h; sourceTree = "<group>"; };
 		A70675EF7CDECE2F83D8B811 /* Pods-sccReactNative.releasesandbox.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sccReactNative.releasesandbox.xcconfig"; path = "Target Support Files/Pods-sccReactNative/Pods-sccReactNative.releasesandbox.xcconfig"; sourceTree = "<group>"; };
 		C2E6AC38FC31CD0188A67E64 /* SccCameraButtons.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = SccCameraButtons.mm; path = sccReactNative/SccCameraButtons.mm; sourceTree = "<group>"; };
@@ -107,6 +111,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				89B86B8879E417A56F32F316 /* libPods-sccReactNative.a in Frameworks */,
+				8A6A039BA7E33064C0C58694 /* AVKit.framework in Frameworks */,
+				A2C8A2C7A737590D1707FF2C /* MediaPlayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -164,6 +170,8 @@
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				4ECE3E814901418FC26F6DBA /* libPods-sccReactNative.a */,
 				5010FAB64AC4B204FBF2657D /* libPods-sccReactNative-sccReactNativeTests.a */,
+				75688A217AAD3DBF51038FD8 /* AVKit.framework */,
+				8CDDDC8775B20FB298A0F377 /* MediaPlayer.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -665,7 +665,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 160;
+				CURRENT_PROJECT_VERSION = 162;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -703,7 +703,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 160;
+				CURRENT_PROJECT_VERSION = 162;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -817,7 +817,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 160;
+				CURRENT_PROJECT_VERSION = 162;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -952,7 +952,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 160;
+				CURRENT_PROJECT_VERSION = 162;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -657,7 +657,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 160;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -695,7 +695,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 160;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -809,7 +809,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 160;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -944,7 +944,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 158;
+				CURRENT_PROJECT_VERSION = 160;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6132EF182BDFF13200BBE14D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		89B86B8879E417A56F32F316 /* libPods-sccReactNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4ECE3E814901418FC26F6DBA /* libPods-sccReactNative.a */; };
+		D37EE964BE80BC6FEEEDA497 /* SccCameraButtons.mm in Sources */ = {isa = PBXBuildFile; fileRef = C2E6AC38FC31CD0188A67E64 /* SccCameraButtons.mm */; };
 		F113F2C4DFB2AA6F111C7E69 /* libPods-sccReactNative-sccReactNativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5010FAB64AC4B204FBF2657D /* libPods-sccReactNative-sccReactNativeTests.a */; };
 		F850682B2CF32E060002762A /* Pretendard-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F85068262CF32E060002762A /* Pretendard-Light.ttf */; };
 		F850682C2CF32E060002762A /* Pretendard-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F85068292CF32E060002762A /* Pretendard-SemiBold.ttf */; };
@@ -61,7 +62,9 @@
 		6002185BD33DA0C9D12E3914 /* Pods-sccReactNative-sccReactNativeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sccReactNative-sccReactNativeTests.debug.xcconfig"; path = "Target Support Files/Pods-sccReactNative-sccReactNativeTests/Pods-sccReactNative-sccReactNativeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = sccReactNative/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = sccReactNative/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		9CD56FF44FF27BF1ED301175 /* SccCameraButtons.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SccCameraButtons.h; path = sccReactNative/SccCameraButtons.h; sourceTree = "<group>"; };
 		A70675EF7CDECE2F83D8B811 /* Pods-sccReactNative.releasesandbox.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sccReactNative.releasesandbox.xcconfig"; path = "Target Support Files/Pods-sccReactNative/Pods-sccReactNative.releasesandbox.xcconfig"; sourceTree = "<group>"; };
+		C2E6AC38FC31CD0188A67E64 /* SccCameraButtons.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = SccCameraButtons.mm; path = sccReactNative/SccCameraButtons.mm; sourceTree = "<group>"; };
 		C61C13B7B0F0C29ED2D6F3A1 /* Pods-sccReactNative.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-sccReactNative.release.xcconfig"; path = "Target Support Files/Pods-sccReactNative/Pods-sccReactNative.release.xcconfig"; sourceTree = "<group>"; };
 		D83FB7472A9B57CC00136989 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		D87B9BD72AC8370F00FB5C91 /* sccReactNative.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = sccReactNative.entitlements; path = sccReactNative/sccReactNative.entitlements; sourceTree = "<group>"; };
@@ -149,6 +152,8 @@
 				F8E0E5F52E2550EE006AFA3F /* RNTSccRectangleOverlayData.mm */,
 				F8AB00622E28BF7E00CFCA09 /* RNTSccMarkerImageService.m */,
 				F8AB00642E28BF9100CFCA09 /* RNTSccMarkerImageService.h */,
+				9CD56FF44FF27BF1ED301175 /* SccCameraButtons.h */,
+				C2E6AC38FC31CD0188A67E64 /* SccCameraButtons.mm */,
 			);
 			name = sccReactNative;
 			sourceTree = "<group>";
@@ -576,6 +581,7 @@
 				F8E0E5F62E2550EE006AFA3F /* RNTSccRectangleOverlayData.mm in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				D37EE964BE80BC6FEEEDA497 /* SccCameraButtons.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -665,7 +665,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 162;
+				CURRENT_PROJECT_VERSION = 164;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -703,7 +703,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 162;
+				CURRENT_PROJECT_VERSION = 164;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -817,7 +817,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 162;
+				CURRENT_PROJECT_VERSION = 164;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -952,7 +952,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 162;
+				CURRENT_PROJECT_VERSION = 164;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -657,7 +657,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -695,7 +695,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -809,7 +809,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -944,7 +944,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 156;
+				CURRENT_PROJECT_VERSION = 158;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.5</string>
+	<string>1.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>156</string>
+	<string>158</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>162</string>
+	<string>164</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>160</string>
+	<string>162</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>164</string>
+	<string>166</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>158</string>
+	<string>160</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/SccCameraButtons.h
+++ b/ios/sccReactNative/SccCameraButtons.h
@@ -1,0 +1,6 @@
+#import <React/RCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
+
+@interface SccCameraButtons : RCTEventEmitter <RCTBridgeModule>
+
+@end

--- a/ios/sccReactNative/SccCameraButtons.mm
+++ b/ios/sccReactNative/SccCameraButtons.mm
@@ -1,0 +1,232 @@
+#import "SccCameraButtons.h"
+
+#import <AVFoundation/AVFoundation.h>
+#import <AVKit/AVKit.h>
+#import <MediaPlayer/MediaPlayer.h>
+#import <UIKit/UIKit.h>
+
+static NSString *const kEventCapturePress = @"SccCameraButtonsCapturePress";
+
+@interface SccCameraButtons ()
+
+@property (nonatomic, assign) BOOL attached;
+@property (nonatomic, assign) BOOL hasListeners;
+
+// iOS 17.2+ path
+@property (nonatomic, strong) id captureInteraction; // AVCaptureEventInteraction *
+@property (nonatomic, weak) UIView *interactionHostView;
+
+// iOS < 17.2 fallback path
+@property (nonatomic, assign) BOOL volumeObserverInstalled;
+@property (nonatomic, assign) float lastObservedVolume;
+@property (nonatomic, strong) MPVolumeView *hiddenVolumeView;
+
+@end
+
+@implementation SccCameraButtons
+
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[kEventCapturePress];
+}
+
+- (void)startObserving {
+  self.hasListeners = YES;
+}
+
+- (void)stopObserving {
+  self.hasListeners = NO;
+}
+
+#pragma mark - JS exposed
+
+RCT_EXPORT_METHOD(attach:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  if (self.attached) {
+    resolve(@(YES));
+    return;
+  }
+  self.attached = YES;
+
+  if (@available(iOS 17.2, *)) {
+    [self installCaptureInteraction];
+  } else {
+    [self installVolumeObserver];
+  }
+  resolve(@(YES));
+}
+
+RCT_EXPORT_METHOD(detach:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  if (!self.attached) {
+    resolve(@(YES));
+    return;
+  }
+  self.attached = NO;
+
+  if (@available(iOS 17.2, *)) {
+    [self uninstallCaptureInteraction];
+  }
+  [self uninstallVolumeObserver];
+  resolve(@(YES));
+}
+
+#pragma mark - iOS 17.2+ AVCaptureEventInteraction
+
+- (void)installCaptureInteraction API_AVAILABLE(ios(17.2)) {
+  UIView *host = [self keyWindowRootView];
+  if (host == nil) {
+    // Window not ready yet (rare). Retry on next run loop.
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      typeof(self) strongSelf = weakSelf;
+      if (strongSelf == nil || !strongSelf.attached) {
+        return;
+      }
+      if (@available(iOS 17.2, *)) {
+        [strongSelf installCaptureInteraction];
+      }
+    });
+    return;
+  }
+
+  __weak typeof(self) weakSelf = self;
+  AVCaptureEventInteraction *interaction = [[AVCaptureEventInteraction alloc] initWithHandler:^(AVCaptureEvent * _Nonnull event) {
+    if (event.phase != AVCaptureEventPhaseBegan) {
+      return;
+    }
+    typeof(self) strongSelf = weakSelf;
+    if (strongSelf == nil || !strongSelf.attached || !strongSelf.hasListeners) {
+      return;
+    }
+    [strongSelf sendEventWithName:kEventCapturePress body:nil];
+  }];
+  interaction.enabled = YES;
+  [host addInteraction:interaction];
+  self.captureInteraction = interaction;
+  self.interactionHostView = host;
+}
+
+- (void)uninstallCaptureInteraction API_AVAILABLE(ios(17.2)) {
+  UIView *host = self.interactionHostView;
+  id interaction = self.captureInteraction;
+  if (host != nil && interaction != nil && [interaction conformsToProtocol:@protocol(UIInteraction)]) {
+    [host removeInteraction:(id<UIInteraction>)interaction];
+  }
+  self.captureInteraction = nil;
+  self.interactionHostView = nil;
+}
+
+- (UIView *)keyWindowRootView {
+  UIWindow *keyWindow = nil;
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    for (UIWindow *window in windowScene.windows) {
+      if (window.isKeyWindow) {
+        keyWindow = window;
+        break;
+      }
+    }
+    if (keyWindow != nil) break;
+  }
+  return keyWindow.rootViewController.view;
+}
+
+#pragma mark - iOS < 17.2 fallback (AVAudioSession KVO)
+
+- (void)installVolumeObserver {
+  if (self.volumeObserverInstalled) {
+    return;
+  }
+  [self installHiddenVolumeView];
+
+  NSError *error = nil;
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  [session setCategory:AVAudioSessionCategoryPlayback
+           withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                 error:&error];
+  [session setActive:YES error:&error];
+
+  self.lastObservedVolume = session.outputVolume;
+  [session addObserver:self
+            forKeyPath:@"outputVolume"
+               options:NSKeyValueObservingOptionNew
+               context:nil];
+  self.volumeObserverInstalled = YES;
+}
+
+- (void)uninstallVolumeObserver {
+  if (!self.volumeObserverInstalled) {
+    return;
+  }
+  @try {
+    [[AVAudioSession sharedInstance] removeObserver:self forKeyPath:@"outputVolume"];
+  } @catch (NSException *exception) {
+    // ignore
+  }
+  self.volumeObserverInstalled = NO;
+  [self uninstallHiddenVolumeView];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+  if (![keyPath isEqualToString:@"outputVolume"]) {
+    return;
+  }
+  if (!self.attached || !self.hasListeners) {
+    return;
+  }
+  NSNumber *newValue = change[NSKeyValueChangeNewKey];
+  if (newValue == nil) {
+    return;
+  }
+  float newVolume = newValue.floatValue;
+  if (fabsf(newVolume - self.lastObservedVolume) < 0.0001f) {
+    return;
+  }
+  self.lastObservedVolume = newVolume;
+  [self sendEventWithName:kEventCapturePress body:nil];
+}
+
+- (void)installHiddenVolumeView {
+  if (self.hiddenVolumeView != nil) return;
+  // Place an off-screen MPVolumeView to suppress the system volume HUD while
+  // we still observe outputVolume changes.
+  MPVolumeView *view = [[MPVolumeView alloc] initWithFrame:CGRectMake(-1000, -1000, 1, 1)];
+  view.showsRouteButton = NO;
+  view.alpha = 0.01;
+  self.hiddenVolumeView = view;
+  UIView *host = [self keyWindowRootView];
+  if (host != nil) {
+    [host addSubview:view];
+  }
+}
+
+- (void)uninstallHiddenVolumeView {
+  [self.hiddenVolumeView removeFromSuperview];
+  self.hiddenVolumeView = nil;
+}
+
+- (void)dealloc {
+  if (self.volumeObserverInstalled) {
+    @try {
+      [[AVAudioSession sharedInstance] removeObserver:self forKeyPath:@"outputVolume"];
+    } @catch (NSException *exception) {
+      // ignore
+    }
+  }
+}
+
+@end

--- a/ios/sccReactNative/SccCameraButtons.mm
+++ b/ios/sccReactNative/SccCameraButtons.mm
@@ -86,9 +86,9 @@ RCT_EXPORT_METHOD(detach:(RCTPromiseResolveBlock)resolve
   UIView *host = [self keyWindowRootView];
   if (host == nil) {
     // Window not ready yet (rare). Retry on next run loop.
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
-      typeof(self) strongSelf = weakSelf;
+      __typeof(self) strongSelf = weakSelf;
       if (strongSelf == nil || !strongSelf.attached) {
         return;
       }
@@ -99,12 +99,12 @@ RCT_EXPORT_METHOD(detach:(RCTPromiseResolveBlock)resolve
     return;
   }
 
-  __weak typeof(self) weakSelf = self;
-  AVCaptureEventInteraction *interaction = [[AVCaptureEventInteraction alloc] initWithHandler:^(AVCaptureEvent * _Nonnull event) {
+  __weak __typeof(self) weakSelf = self;
+  AVCaptureEventInteraction *interaction = [[AVCaptureEventInteraction alloc] initWithEventHandler:^(AVCaptureEvent * _Nonnull event) {
     if (event.phase != AVCaptureEventPhaseBegan) {
       return;
     }
-    typeof(self) strongSelf = weakSelf;
+    __typeof(self) strongSelf = weakSelf;
     if (strongSelf == nil || !strongSelf.attached || !strongSelf.hasListeners) {
       return;
     }

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>158</string>
+	<string>160</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>164</string>
+	<string>166</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>160</string>
+	<string>162</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>162</string>
+	<string>164</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.5</string>
+	<string>1.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>156</string>
+	<string>158</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "react-native-tracking-transparency": "^0.1.2",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-vision-camera": "^4.7.0",
-    "react-native-volume-manager": "^2.0.8",
     "react-native-webview": "^13.15.0",
     "react-native-worklets": "^0.7.2",
     "styled-components": "^6.1.18",

--- a/src/native-modules/SccCameraButtons.ts
+++ b/src/native-modules/SccCameraButtons.ts
@@ -1,0 +1,62 @@
+import {NativeEventEmitter, NativeModules} from 'react-native';
+
+const EVENT_CAPTURE_PRESS = 'SccCameraButtonsCapturePress';
+
+interface SccCameraButtonsNativeModule {
+  attach(): Promise<boolean>;
+  detach(): Promise<boolean>;
+  // RN built-in EventEmitter API
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
+}
+
+const nativeModule = NativeModules.SccCameraButtons as
+  | SccCameraButtonsNativeModule
+  | undefined;
+
+const emitter = nativeModule
+  ? new NativeEventEmitter(nativeModule as unknown as never)
+  : null;
+
+export interface CaptureButtonSubscription {
+  remove(): void;
+}
+
+/**
+ * 카메라 화면에서 음량 버튼을 셔터로 사용하기 위한 네이티브 모듈 래퍼.
+ *
+ * - iOS 17.2+: AVCaptureEventInteraction (시스템이 볼륨 버튼 이벤트를 가로채 앱으로
+ *   전달, 시스템 볼륨/HUD 변화 없음, edge case 정상 동작)
+ * - iOS 15.1~17.1: AVAudioSession.outputVolume KVO + 숨겨진 MPVolumeView로 HUD 억제
+ *   (볼륨 0/1.0 edge case에서는 동작 안 함)
+ * - Android: MainActivity.dispatchKeyEvent에서 KEYCODE_VOLUME_UP/DOWN을 가로채서 emit
+ */
+export const SccCameraButtons = {
+  isAvailable: nativeModule != null,
+
+  attach(): Promise<boolean> {
+    if (!nativeModule) {
+      return Promise.resolve(false);
+    }
+    return nativeModule.attach();
+  },
+
+  detach(): Promise<boolean> {
+    if (!nativeModule) {
+      return Promise.resolve(false);
+    }
+    return nativeModule.detach();
+  },
+
+  addCapturePressListener(callback: () => void): CaptureButtonSubscription {
+    if (!emitter) {
+      return {remove() {}};
+    }
+    const sub = emitter.addListener(EVENT_CAPTURE_PRESS, callback);
+    return {
+      remove() {
+        sub.remove();
+      },
+    };
+  },
+};

--- a/src/screens/CameraScreen/CameraScreen.tsx
+++ b/src/screens/CameraScreen/CameraScreen.tsx
@@ -9,7 +9,6 @@ import {
   MediaType,
 } from 'react-native-image-picker';
 import {CameraCaptureError, PhotoFile} from 'react-native-vision-camera';
-import {VolumeManager} from 'react-native-volume-manager';
 
 import AlbumIcon from '@/assets/icon/ic_album.svg';
 import CircleCloseIcon from '@/assets/icon/ic_circle_close.svg';
@@ -28,6 +27,7 @@ import {MAX_NUMBER_OF_TAKEN_PHOTOS} from '@/constant/constant';
 import Logger from '@/logging/Logger';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
+import {SccCameraButtons} from '@/native-modules/SccCameraButtons';
 import ImageFileUtils from '@/utils/ImageFileUtils';
 import ToastUtils from '@/utils/ToastUtils';
 
@@ -242,16 +242,18 @@ export default function CameraScreen({
     let lastTriggerTime = 0;
     let isMounted = true;
 
-    VolumeManager.showNativeVolumeUI({enabled: false});
+    SccCameraButtons.attach().catch(() => {
+      // ignore — fallback path may not be available
+    });
 
-    const subscription = VolumeManager.addVolumeListener(() => {
+    const subscription = SccCameraButtons.addCapturePressListener(() => {
       if (!isMounted) {
         return;
       }
-      // 볼륨 변화 자체를 촬영 트리거로 본다. 볼륨 원복은 시도해도
-      // 기기/플랫폼에 따라 안정적이지 않아 코드만 복잡해지므로 생략.
+      // 빠른 연타 방어용 짧은 쿨다운. 네이티브 단에서 이미 정상화된
+      // discrete press 이벤트지만 안전 마진으로 둔다.
       const now = Date.now();
-      if (now - lastTriggerTime < 500) {
+      if (now - lastTriggerTime < 300) {
         return;
       }
       lastTriggerTime = now;
@@ -261,7 +263,7 @@ export default function CameraScreen({
     return () => {
       isMounted = false;
       subscription.remove();
-      VolumeManager.showNativeVolumeUI({enabled: true});
+      SccCameraButtons.detach().catch(() => {});
     };
   }, []);
 
@@ -365,6 +367,8 @@ export default function CameraScreen({
         {photoFiles.length === 0 && (
           <S.NoPhotosTaken>
             최대 {photoLimit}장까지 촬영할 수 있어요
+            {'\n'}
+            음량 조절 버튼으로도 촬영이 가능해요
           </S.NoPhotosTaken>
         )}
         {photoFiles.length > 0 && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -16247,16 +16247,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-volume-manager@npm:^2.0.8":
-  version: 2.0.8
-  resolution: "react-native-volume-manager@npm:2.0.8"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10c0/e4ea8d6c1ec1601f1910742c1111f1658740fdfff201455bd043730543071832d37e690ad2b2b1d3d30836243aa8e9418e561f2ca6a3b3210ce382b079b201d0
-  languageName: node
-  linkType: hard
-
 "react-native-web@npm:^0.21.1":
   version: 0.21.1
   resolution: "react-native-web@npm:0.21.1"
@@ -17039,7 +17029,6 @@ __metadata:
     react-native-tracking-transparency: "npm:^0.1.2"
     react-native-url-polyfill: "npm:^2.0.0"
     react-native-vision-camera: "npm:^4.7.0"
-    react-native-volume-manager: "npm:^2.0.8"
     react-native-web: "npm:^0.21.1"
     react-native-webview: "npm:^13.15.0"
     react-native-worklets: "npm:^0.7.2"


### PR DESCRIPTION
## Summary
음량 버튼으로 사진 촬영을 트리거하는 기능을 `react-native-volume-manager` 의존 방식에서 직접 작성한 네이티브 모듈(`SccCameraButtons`)로 교체.

기존의 볼륨 변화 감지 기반 방식은 (1) 볼륨 0/최대 edge case에서 동작 안 함, (2) 시스템 볼륨이 매번 변경됨 문제가 있어, OS 레벨에서 키 이벤트를 직접 가로채는 방식으로 변경.

## 변경 사항

### iOS
- **iOS 17.2+**: `AVCaptureEventInteraction` (Apple 공식 API)로 카메라 view에 attach. 시스템이 볼륨 버튼 이벤트를 가로채 앱으로 전달 → 시스템 볼륨/HUD 변화 없고 edge case 정상 동작
- **iOS 15.1~17.1**: `AVAudioSession.outputVolume` KVO + 숨김 `MPVolumeView`로 HUD 억제 (fallback, edge case는 한계 있음)
- AVKit, MediaPlayer 프레임워크 링크 추가

### Android
- `MainActivity.dispatchKeyEvent`에서 `KEYCODE_VOLUME_UP/DOWN` 가로채서 RN으로 emit, 시스템 볼륨 변경 차단
- bridgeless(new arch) 모드에서 `ReactContext.getNativeModule()`이 legacy 모듈을 못 찾는 문제 우회 — 모듈 자신을 static `activeInstance` 슬롯에 등록하고 그 슬롯을 거쳐 호출
- `getJSModule(RCTDeviceEventEmitter).emit` → `ReactContext.emitDeviceEvent`로 교체 (bridgeless 호환성)

### JS
- `src/native-modules/SccCameraButtons.ts` — 통합 wrapper. 플랫폼/버전 신경 안 쓰고 `attach()` / `detach()` / `addCapturePressListener()` 하나로 사용
- `CameraScreen.tsx`에서 기존 `VolumeManager` 코드 제거하고 새 wrapper로 교체
- `react-native-volume-manager` 의존성 제거

### 컨벤션 보강
- `CLAUDE.md`에 "네이티브 코드 변경 시 push 전 ReleaseSandbox compile-only 빌드" 와 "네이티브 모듈 작성 규칙(양쪽 플랫폼 시그니처 일치, bridgeless 주의사항)" 추가

## Test plan
- [x] iOS sandbox native build CI 통과
- [x] Android sandbox native build CI 통과
- [x] Android USB 실기기 (Galaxy SM-S906N) 로컬 빌드/설치 후 카메라 화면에서 볼륨 버튼으로 촬영 트리거 확인
- [ ] iOS 실기기 TestFlight로 검증 (음량 0/최대 edge case 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added volume button support for camera photo capture on both iOS and Android.

* **Documentation**
  * Enhanced native code contribution guidelines with validation procedures, module writing rules, and verification workflows.

* **Chores**
  * Bumped app version to 1.3.6.
  * Removed native volume control dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-app/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->