### PR TITLE
fix: BlurView native unlinked — backdrop dim 으로 fallback

### DIFF
--- a/src/components/MissionCompletedOverlay/MissionCompletedOverlay.tsx
+++ b/src/components/MissionCompletedOverlay/MissionCompletedOverlay.tsx
@@ -1,6 +1,5 @@
-import {BlurView} from '@react-native-community/blur';
 import React from 'react';
-import {Dimensions, Image, Modal, StyleSheet} from 'react-native';
+import {Dimensions, Image, Modal, StyleSheet, View} from 'react-native';
 import styled from 'styled-components/native';
 
 import {SccButton} from '@/components/atoms';
@@ -51,11 +50,9 @@ export default function MissionCompletedOverlay({
       animationType="fade"
       statusBarTranslucent
       onRequestClose={onClose}>
-      <BlurView
-        style={StyleSheet.absoluteFill}
-        blurType="dark"
-        blurAmount={10}
-        reducedTransparencyFallbackColor={color.blacka70}
+      {/* BlurView native module unlinked 대응: dim fallback. */}
+      <View
+        style={[StyleSheet.absoluteFill, {backgroundColor: color.blacka70}]}
       />
       <DimContent>
         <Contents>

--- a/src/screens/TutorialMissionScreen/components/HiddenMissionCollectedPopup.tsx
+++ b/src/screens/TutorialMissionScreen/components/HiddenMissionCollectedPopup.tsx
@@ -1,6 +1,5 @@
-import {BlurView} from '@react-native-community/blur';
 import React from 'react';
-import {Dimensions, Image, Modal, StyleSheet} from 'react-native';
+import {Dimensions, Image, Modal, StyleSheet, View} from 'react-native';
 import styled from 'styled-components/native';
 
 import {SccPressable} from '@/components/SccPressable';
@@ -27,11 +26,9 @@ export default function HiddenMissionCollectedPopup({
       animationType="fade"
       statusBarTranslucent
       onRequestClose={onClose}>
-      <BlurView
-        style={StyleSheet.absoluteFill}
-        blurType="dark"
-        blurAmount={10}
-        reducedTransparencyFallbackColor={color.blacka70}
+      {/* BlurView native module unlinked 대응: dim fallback. */}
+      <View
+        style={[StyleSheet.absoluteFill, {backgroundColor: color.blacka70}]}
       />
       <DimRoot>
         <ContentsWrapper>

--- a/src/screens/TutorialMissionScreen/components/MissionCard.tsx
+++ b/src/screens/TutorialMissionScreen/components/MissionCard.tsx
@@ -1,6 +1,5 @@
-import {BlurView} from '@react-native-community/blur';
 import React from 'react';
-import {Image, View} from 'react-native';
+import {Image} from 'react-native';
 import styled from 'styled-components/native';
 
 import CheckBoldBlueIcon from '@/assets/icon/ic_check_bold_blue.svg';
@@ -64,14 +63,8 @@ export default function MissionCard({
       </CardBody>
 
       {isDimmed && (
-        <DimOverlay
-          blurType="light"
-          blurAmount={6}
-          reducedTransparencyFallbackColor="rgba(255,255,255,0.92)">
-          <View
-            style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
-            <DimText>{`🔒\n${dimText ?? '이전 미션을 먼저 완료해주세요!'}`}</DimText>
-          </View>
+        <DimOverlay>
+          <DimText>{`🔒\n${dimText ?? '이전 미션을 먼저 완료해주세요!'}`}</DimText>
         </DimOverlay>
       )}
     </CardContainer>
@@ -165,8 +158,10 @@ const StartButtonText = styled.Text`
   color: ${color.white};
 `;
 
-// Figma quest_card_dim: backdrop-blur 5.5px + bg rgba(255,255,255,0.5).
-const DimOverlay = styled(BlurView)`
+// BlurView native module unlinked 대응: dim fallback.
+// 원래는 backdrop-blur 5.5px + rgba(255,255,255,0.5)였으나
+// blur 없이 흰색 dim만으로 읽힘성 확보 (opacity 0.85).
+const DimOverlay = styled.View`
   position: absolute;
   top: 0;
   left: 0;
@@ -174,7 +169,7 @@ const DimOverlay = styled(BlurView)`
   bottom: 0;
   align-items: center;
   justify-content: center;
-  background-color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.85);
 `;
 
 const DimText = styled.Text`


### PR DESCRIPTION
## Summary
- dev 앱에서 `Unimplemented component: <BlurView>` 텍스트가 튜토리얼 미션 화면에 노출되는 문제 수정
- 원인: `@react-native-community/blur` 의 native module 이 현재 dev 빌드에 link 되어 있지 않음 (OTA 만 배포되고 native rebuild 가 안 된 상태)
- 대응: BlurView 사용 3 군데를 일반 View + 반투명 배경 dim 으로 교체. blur 효과는 사라지지만 텍스트 노출 없음 + 새 네이티브 빌드 없이 OTA 만으로 적용 가능

## 변경 파일
- `src/screens/TutorialMissionScreen/components/HiddenMissionCollectedPopup.tsx` — modal backdrop blur → `blacka70` dim
- `src/components/MissionCompletedOverlay/MissionCompletedOverlay.tsx` — modal backdrop blur → `blacka70` dim
- `src/screens/TutorialMissionScreen/components/MissionCard.tsx` — `DimOverlay` (styled(BlurView)) → `styled.View` + `rgba(255,255,255,0.85)` (가독성 위해 0.5 → 0.85 로 약간 진하게)

## 진단 결과 (Case C)
- 패키지는 정상 설치되어 있고 (`node_modules/@react-native-community/blur` 존재), package 의 `codegenConfig` 도 fabric/new-arch 지원
- `MainApplication.kt` 는 `PackageList(this).packages` 로 autolinking 사용 중 → 명시적 등록은 필요 없음
- 즉 native 차원에서는 잘 맞물려 있고, **현재 dev 앱이 native rebuild 없이 OTA 만 받은 상태** 라서 native side 에서 BlurView 가 없는 것
- 진짜 root cause 픽스는: `cd android && ./gradlew clean && yarn android:sandbox` 로 새 네이티브 빌드 → release 태그 → store 업데이트 (또는 EAS/CI 빌드 재실행)
- 본 PR 은 OTA 만으로도 즉시 텍스트 노출을 막기 위한 **fallback 픽스**. 추후 디자인이 blur 를 정말 원하면 native 빌드 + BlurView 재도입 (별도 PR)

## Test plan
- [ ] `yarn lint` 통과 (확인 완료, 0 errors)
- [ ] `yarn tsc --noEmit` 통과 (확인 완료, 0 errors)
- [ ] OTA 배포 후 튜토리얼 미션 화면에서 `Unimplemented component` 텍스트 노출 없음 확인
- [ ] 미션 완료 팝업 / 히든 미션 팝업 backdrop 이 어두운 dim 으로 보이는지 확인
- [ ] dimmed 상태 MissionCard 의 잠금 텍스트가 흰 dim 위에 잘 읽히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated mission overlay and modal backgrounds across tutorial screens to use semi-transparent dimming instead of blur effects.
  * Simplified overlay appearance for improved visual consistency throughout the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-app/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->