### PR TITLE
fix: 홈 IntroPopup 완료자 재노출 + 관심지역/테마 수정 dirty check 버그

### DIFF
--- a/src/hooks/useFormExitConfirm.ts
+++ b/src/hooks/useFormExitConfirm.ts
@@ -1,5 +1,5 @@
 import {useIsFocused, usePreventRemove} from '@react-navigation/native';
-import {useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 
 /**
  * Form 화면에서 뒤로 가기 시 확인 modal을 띄우기 위한 hook.
@@ -7,6 +7,12 @@ import {useState} from 'react';
  * @param onConfirmExit 사용자가 modal에서 "나가기"를 확정했을 때 실행할 navigation action 처리 콜백.
  * @param options.enabled true일 때만 뒤로 가기 시 확인 modal을 trigger. 기본값 true.
  *   form이 dirty하지 않으면 false로 전달하여 사용자가 자유롭게 뒤로 갈 수 있도록 한다.
+ *
+ * 반환값의 `bypass`는 저장 완료 직후 등 dirty 상태이지만 확인 modal 없이 즉시
+ * 화면을 떠나야 할 때 사용한다. `bypass()` 호출 직후 navigation.goBack()을 부르면
+ * usePreventRemove 콜백에서 확인 modal을 건너뛴다.
+ * (단순히 `enabled=false`로 바꾸는 것은 React state 업데이트가 비동기라
+ * 같은 tick의 goBack에는 반영되지 않으므로 ref 기반 우회 경로가 필요하다.)
  */
 export function useFormExitConfirm(
   onConfirmExit: (
@@ -28,8 +34,16 @@ export function useFormExitConfirm(
     source?: string;
     target?: string;
   }> | null>(null);
+  const bypassRef = useRef(false);
 
   usePreventRemove(isFocused && enabled, ({data}) => {
+    if (bypassRef.current) {
+      // bypass 직후 발생한 remove 이벤트이므로 원본 action을 그대로 dispatch하고
+      // ref를 초기화한다. 확인 modal을 띄우지 않는다.
+      bypassRef.current = false;
+      onConfirmExit(data.action);
+      return;
+    }
     setPendingAction(data.action);
     setIsVisible(true);
   });
@@ -46,9 +60,14 @@ export function useFormExitConfirm(
     setPendingAction(null);
   };
 
+  const bypass = useCallback(() => {
+    bypassRef.current = true;
+  }, []);
+
   return {
     isVisible,
     onConfirm,
     onCancel,
+    bypass,
   };
 }

--- a/src/screens/EditInterestedRegionScreen/EditInterestedRegionScreen.tsx
+++ b/src/screens/EditInterestedRegionScreen/EditInterestedRegionScreen.tsx
@@ -65,12 +65,21 @@ export default function EditInterestedRegionScreen({
       {
         onSuccess: () => {
           setHasSubmitted(true);
+          // formExitConfirm.bypass(): setHasSubmitted은 비동기라 같은 tick의
+          // goBack 디스패치에는 반영되지 않으므로 ref 기반으로 즉시 우회한다.
+          formExitConfirm.bypass();
           ToastUtils.show('저장되었습니다.');
           navigation.goBack();
         },
       },
     );
-  }, [selectedRegionIds, interestedThemes, registerMutation, navigation]);
+  }, [
+    selectedRegionIds,
+    interestedThemes,
+    registerMutation,
+    formExitConfirm,
+    navigation,
+  ]);
 
   const handleSheetConfirm = useCallback((nextSelectedIds: string[]) => {
     setSelectedRegionIds(nextSelectedIds);

--- a/src/screens/EditInterestedThemesScreen/EditInterestedThemesScreen.tsx
+++ b/src/screens/EditInterestedThemesScreen/EditInterestedThemesScreen.tsx
@@ -64,12 +64,21 @@ export default function EditInterestedThemesScreen({
       {
         onSuccess: () => {
           setHasSubmitted(true);
+          // formExitConfirm.bypass(): setHasSubmitted은 비동기라 같은 tick의
+          // goBack 디스패치에는 반영되지 않으므로 ref 기반으로 즉시 우회한다.
+          formExitConfirm.bypass();
           ToastUtils.show('저장되었습니다.');
           navigation.goBack();
         },
       },
     );
-  }, [selectedThemes, interestedRegionIds, registerMutation, navigation]);
+  }, [
+    selectedThemes,
+    interestedRegionIds,
+    registerMutation,
+    formExitConfirm,
+    navigation,
+  ]);
 
   const handleSheetConfirm = useCallback(
     (nextSelectedThemes: UserInterestedThemeDto[]) => {

--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -38,9 +38,13 @@ import {
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {prefetchRemoteImage} from '@/components/SccRemoteImage';
 import {color} from '@/constant/color';
-import {GetClientVersionStatusResponseDtoStatusEnum} from '@/generated-sources/openapi';
+import {
+  GetClientVersionStatusResponseDtoStatusEnum,
+  TutorialMissionTypeDto,
+} from '@/generated-sources/openapi';
 import useAppComponents from '@/hooks/useAppComponents';
 import {useIsForeground} from '@/hooks/useIsForeground';
+import {useUserTutorialProgress} from '@/hooks/useUserTutorialProgress';
 import Logger from '@/logging/Logger';
 import AppUpgradeNeededBottomSheet from '@/modals/AppUpgradeNeededBottomSheet';
 import GeolocationPermissionBottomSheet, {
@@ -132,6 +136,26 @@ const HomeScreenV2 = ({navigation}: any) => {
   const __DEV_FORCE_INTRO_POPUP__: boolean = false;
   const [tutorialIntroPopupVisible, setTutorialIntroPopupVisible] =
     useState(false);
+
+  // 서버 progress 로 메인 미션 완료 여부 확인. 앱 삭제/재설치로 AsyncStorage
+  // 기반 atom 이 리셋되어도 서버 진행 상태로 "이미 완료자" 인지 판단해 팝업 재노출을 막는다.
+  const {data: tutorialProgress} = useUserTutorialProgress();
+  const allMainTutorialMissionsCompleted = useMemo(() => {
+    if (!tutorialProgress) {
+      return undefined;
+    }
+    const mainTypes: TutorialMissionTypeDto[] = [
+      TutorialMissionTypeDto.RegisterInterestedRegionsAndThemes,
+      TutorialMissionTypeDto.SavePlaceList,
+      TutorialMissionTypeDto.UpvoteAccessibility,
+    ];
+    return mainTypes.every(
+      type =>
+        tutorialProgress.missions.find(m => m.missionType === type)
+          ?.completedAt != null,
+    );
+  }, [tutorialProgress]);
+
   useEffect(() => {
     if (__DEV__ && __DEV_FORCE_INTRO_POPUP__) {
       const timer = setTimeout(() => setTutorialIntroPopupVisible(true), 500);
@@ -155,6 +179,17 @@ const HomeScreenV2 = ({navigation}: any) => {
     if (needsPlaceSearchTutorial) {
       return;
     }
+    // 서버 progress 가 아직 로딩 중이면 (undefined) 팝업 노출을 보류한다.
+    // 로딩 완료 후 메인 미션을 이미 모두 완료한 사용자에게는 팝업을 띄우지 않고,
+    // atom 도 true 로 설정해 일관성을 유지한다 (앱 삭제/재설치 후 AsyncStorage
+    // 리셋 시 다시 노출되지 않도록).
+    if (allMainTutorialMissionsCompleted === undefined) {
+      return;
+    }
+    if (allMainTutorialMissionsCompleted) {
+      setHasShownTutorialIntroPopup(true);
+      return;
+    }
     // 첫 진입 후 잠시 뒤에 노출 (홈 데이터 로딩 후)
     const timer = setTimeout(() => {
       setTutorialIntroPopupVisible(true);
@@ -167,6 +202,7 @@ const HomeScreenV2 = ({navigation}: any) => {
     featureFlags,
     hasShownTutorialIntroPopup,
     needsPlaceSearchTutorial,
+    allMainTutorialMissionsCompleted,
     setHasShownTutorialIntroPopup,
   ]);
 

--- a/src/screens/InterestedRegionAndThemesFormScreen/InterestedRegionAndThemesFormScreen.tsx
+++ b/src/screens/InterestedRegionAndThemesFormScreen/InterestedRegionAndThemesFormScreen.tsx
@@ -102,6 +102,9 @@ export default function InterestedRegionAndThemesFormScreen({
           if (!wasMissionAlreadyCompleted) {
             setShowCollected(true);
           } else {
+            // formExitConfirm.bypass(): setHasSubmitted은 비동기라 같은 tick의
+            // goBack 디스패치에는 반영되지 않으므로 ref 기반으로 즉시 우회한다.
+            formExitConfirm.bypass();
             navigation.goBack();
           }
         },
@@ -112,13 +115,16 @@ export default function InterestedRegionAndThemesFormScreen({
     selectedThemes,
     registerMutation,
     wasMissionAlreadyCompleted,
+    formExitConfirm,
     navigation,
   ]);
 
   const handleCollectedClose = useCallback(() => {
     setShowCollected(false);
+    // 수집 팝업을 닫고 화면을 떠나기 직전 dirty check를 우회한다 (이미 저장됨).
+    formExitConfirm.bypass();
     navigation.goBack();
-  }, [navigation]);
+  }, [formExitConfirm, navigation]);
 
   const handleRegionConfirm = useCallback((nextSelectedIds: string[]) => {
     setSelectedRegionIds(nextSelectedIds);


### PR DESCRIPTION
## Summary

USER_TUTORIAL (윌리의 외출 NUX) QA 에서 발견된 두 버그 수정.

### 1. 홈 IntroPopup 이 튜토리얼 완료자에게도 재노출 (앱 삭제/재설치 시)

- **원인**: `hasShownTutorialIntroPopupAtom` (AsyncStorage 기반) 만 검사 → 앱 삭제 시 같이 날아가 false 로 리셋 → 서버 progress 무시하고 다시 노출.
- **Fix**: `HomeScreenV2.tsx` 의 IntroPopup useEffect 에 서버 progress 기반 메인 미션 완료 검사를 추가했다. `useUserTutorialProgress` 로 progress 를 가져와 main 3개 미션 (`REGISTER_INTERESTED_REGIONS_AND_THEMES`, `SAVE_PLACE_LIST`, `UPVOTE_ACCESSIBILITY`) 의 `completedAt` 이 모두 채워져 있으면 팝업을 띄우지 않고 atom 도 true 로 설정해 일관성을 유지한다. progress 로딩 중에는 노출을 보류한다.

### 2. 관심 지역/관심 테마 수정 후 \"페이지를 나가시겠어요?\" 잘못 노출

- **원인**: `EditInterestedRegionScreen` / `EditInterestedThemesScreen` 의 저장 성공 핸들러가 `setHasSubmitted(true)` 후 같은 tick 에서 `navigation.goBack()` 을 호출. React state 업데이트는 비동기라 `usePreventRemove` 콜백이 stale `enabled=true` 로 동작 → dirty check 시트가 뜸.
- **Fix**: `useFormExitConfirm` 에 ref 기반 `bypass()` 메서드를 추가했다. 저장 성공 시 `bypass()` 호출 후 `goBack()` 하면 `usePreventRemove` 콜백이 ref 를 확인해 확인 시트를 건너뛰고 원본 action 을 그대로 dispatch 한다. 같은 패턴인 `InterestedRegionAndThemesFormScreen` 의 `wasMissionAlreadyCompleted` 경로와 `handleCollectedClose` 도 동일하게 수정했다.

## Test plan

- [ ] 홈 화면
  - [ ] 신규 유저: IntroPopup 정상 노출
  - [ ] 메인 3개 미션 완료 후 앱 데이터 초기화 → 재진입 시 IntroPopup 노출되지 않음
  - [ ] progress 응답이 도착하기 전에는 팝업 노출 보류 (flash 없음)
- [ ] 프로필 > 관심 지역 수정
  - [ ] 값 변경 → 확인 → 토스트 + 자동 goBack, dirty check 시트 미노출
  - [ ] 값 변경 후 헤더 뒤로가기 → dirty check 시트 정상 노출
  - [ ] 값 변경하지 않고 뒤로가기 → dirty check 시트 미노출
- [ ] 프로필 > 관심 테마 수정 — 위와 동일 시나리오 검증
- [ ] 튜토리얼 미션 1 (InterestedRegionAndThemesFormScreen) — 저장 → 외출템 수집 팝업 → 닫기 → dirty check 미노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)