### PR TITLE
fix: NUX 미션 저장 버튼 즉시 toggle + 완료 팝업 goBack 제거 + 재노출 방지

### DIFF
--- a/src/hooks/useSavePlaceList.ts
+++ b/src/hooks/useSavePlaceList.ts
@@ -13,6 +13,13 @@ interface UseSavePlaceListOptions {
   onSuccess?: (variables: {isSaved: boolean; placeListId: string}) => void;
 }
 
+/**
+ * onMutate에서 즉시 toggle 할 대상 query key prefix.
+ * 저장리스트가 크면 서버 응답 + invalidate 후 refetch 까지 수초 걸려서 "안 눌렸나?" 라고
+ * 헷갈리는 QA 이슈가 있었음. 캐시의 isSaved 만 우선 뒤집고 onError 시 revert.
+ */
+const PLACE_LIST_DETAIL_QUERY_KEY_PREFIX = 'PlaceListDetail';
+
 export function useSavePlaceList(options?: UseSavePlaceListOptions) {
   const {api} = useAppComponents();
   const queryClient = useQueryClient();
@@ -31,6 +38,43 @@ export function useSavePlaceList(options?: UseSavePlaceListOptions) {
         return await api.savePlaceList({placeListId});
       }
     },
+    // 서버 응답 + invalidate refetch 사이의 지연을 가리기 위해 캐시의 isSaved 만 즉시 toggle.
+    // PlaceListDetail 캐시는 filters 까지 포함한 키 (['PlaceListDetail', placeListId, filters]).
+    // 같은 placeListId 의 모든 filters 변형을 한 번에 뒤집기 위해 prefix match 로 순회한다.
+    onMutate: async ({isSaved, placeListId}) => {
+      await queryClient.cancelQueries({
+        queryKey: [PLACE_LIST_DETAIL_QUERY_KEY_PREFIX, placeListId],
+      });
+
+      type PlaceListDetailCache =
+        | {placeList?: {isSaved?: boolean} | null; [key: string]: unknown}
+        | undefined;
+      const snapshots: Array<{
+        queryKey: readonly unknown[];
+        data: PlaceListDetailCache;
+      }> = [];
+
+      queryClient
+        .getQueryCache()
+        .findAll({
+          queryKey: [PLACE_LIST_DETAIL_QUERY_KEY_PREFIX, placeListId],
+        })
+        .forEach(query => {
+          const prevData = query.state.data as PlaceListDetailCache;
+          snapshots.push({queryKey: query.queryKey, data: prevData});
+          if (prevData?.placeList) {
+            queryClient.setQueryData(query.queryKey, {
+              ...prevData,
+              placeList: {
+                ...prevData.placeList,
+                isSaved: !isSaved,
+              },
+            });
+          }
+        });
+
+      return {snapshots};
+    },
     onSuccess: (_data, variables) => {
       if (!variables.isSaved) {
         ToastUtils.show('리스트를 [메뉴 > 저장한 장소]에 저장했습니다.');
@@ -40,12 +84,16 @@ export function useSavePlaceList(options?: UseSavePlaceListOptions) {
 
       queryClient.invalidateQueries({queryKey: ['SavedPlaceLists']});
       queryClient.invalidateQueries({
-        queryKey: ['PlaceListDetail', variables.placeListId],
+        queryKey: [PLACE_LIST_DETAIL_QUERY_KEY_PREFIX, variables.placeListId],
       });
 
       options?.onSuccess?.(variables);
     },
-    onError: error => {
+    onError: (error, _variables, context) => {
+      // optimistic update revert.
+      context?.snapshots.forEach(({queryKey, data}) => {
+        queryClient.setQueryData(queryKey, data);
+      });
       ToastUtils.showOnApiError(error);
     },
   });

--- a/src/screens/InterestedRegionAndThemesFormScreen/InterestedRegionAndThemesFormScreen.tsx
+++ b/src/screens/InterestedRegionAndThemesFormScreen/InterestedRegionAndThemesFormScreen.tsx
@@ -120,11 +120,10 @@ export default function InterestedRegionAndThemesFormScreen({
   ]);
 
   const handleCollectedClose = useCallback(() => {
+    // 팝업의 "확인" 은 닫기만 한다. 화면 이탈은 사용자가 직접 뒤로가기 버튼을 누를 때
+    // 발생하며, 그때 dirty check 를 우회한다 (이미 저장됨).
     setShowCollected(false);
-    // 수집 팝업을 닫고 화면을 떠나기 직전 dirty check를 우회한다 (이미 저장됨).
-    formExitConfirm.bypass();
-    navigation.goBack();
-  }, [formExitConfirm, navigation]);
+  }, []);
 
   const handleRegionConfirm = useCallback((nextSelectedIds: string[]) => {
     setSelectedRegionIds(nextSelectedIds);

--- a/src/screens/PlaceListDetailScreen/PlaceListDetailScreen.tsx
+++ b/src/screens/PlaceListDetailScreen/PlaceListDetailScreen.tsx
@@ -68,29 +68,37 @@ const PlaceListDetailScreen = ({
   const [filters, setFilters] = useAtom(placeListFilterAtom);
   const [, setFilterModalState] = useAtom(placeListFilterModalStateAtom);
 
-  // SAVE_PLACE_LIST 미션이 현재 진행 중인 미션일 때만 저장 액션이 미션 완료 트리거가 된다.
-  // 마운트 시점에 캡처해두지 않으면 mutation 성공 후 progress가 invalidate되면서
-  // currentMissionType이 다음 미션(UPVOTE_ACCESSIBILITY)으로 바뀌어 overlay가 안 뜬다.
+  // SAVE_PLACE_LIST 미션이 "아직 미완료" 상태일 때만 저장 액션이 미션 완료 트리거가 된다.
+  // 기존엔 currentMissionType 으로 판단했는데, 미션 완료 후에도 useSavePlaceList 가
+  // USER_TUTORIAL_PROGRESS 캐시를 invalidate 하지 않아서 currentMissionType 이 SavePlaceList
+  // 로 stuck 되는 상황이 있었음 → 사용자가 같은 화면에서 저장 해제 → 다시 저장 시 완료 팝업이
+  // 또 떴다. mission.completedAt 으로 판단하면 서버가 한 번 set 한 시점부터 영원히 true 이므로
+  // 재노출이 원천 차단된다.
   const {data: tutorialProgress} = useUserTutorialProgress();
-  const wasOnSavePlaceListMissionRef = useRef<boolean>(false);
-  useEffect(() => {
-    if (
-      tutorialProgress?.currentMissionType ===
-      TutorialMissionTypeDto.SavePlaceList
-    ) {
-      wasOnSavePlaceListMissionRef.current = true;
-    }
-  }, [tutorialProgress?.currentMissionType]);
+  const isSavePlaceListMissionCompleted =
+    tutorialProgress?.missions.find(
+      m => m.missionType === TutorialMissionTypeDto.SavePlaceList,
+    )?.completedAt != null;
+  // 현재 세션에서 이미 한 번 팝업을 보여줬으면 같은 진입 동안 다시 띄우지 않는다.
+  const hasShownSaveMissionCompletedRef = useRef<boolean>(false);
   const [showSaveMissionCompleted, setShowSaveMissionCompleted] =
     useState(false);
 
   const toggleSave = useSavePlaceList({
     onSuccess: ({isSaved: prevIsSaved}) => {
       // 저장 → unsave가 아니라 저장 액션일 때만 미션 완료로 간주.
-      if (!prevIsSaved && wasOnSavePlaceListMissionRef.current) {
-        wasOnSavePlaceListMissionRef.current = false;
-        setShowSaveMissionCompleted(true);
+      // 이미 완료된 미션이면 노출 X. 같은 진입 안에서 두 번 띄우지도 않는다.
+      if (prevIsSaved) {
+        return;
       }
+      if (isSavePlaceListMissionCompleted) {
+        return;
+      }
+      if (hasShownSaveMissionCompletedRef.current) {
+        return;
+      }
+      hasShownSaveMissionCompletedRef.current = true;
+      setShowSaveMissionCompleted(true);
     },
   });
 
@@ -436,8 +444,9 @@ const PlaceListDetailScreen = ({
           }님이 찾은 지도로 접근성 좋은\n맛집, 카페를 확인할 수 있게 됐어요 👍`}
           confirmElementName="tutorial_mission_2_completed_confirm"
           onClose={() => {
+            // 팝업 닫기만 한다. 일반 저장리스트 화면에서 진입한 사용자가 history back
+            // 으로 튕겨나가는 어색한 UX 방지. 뒤로가기는 사용자가 직접 누르도록.
             setShowSaveMissionCompleted(false);
-            navigation.goBack();
           }}
         />
       )}

--- a/src/screens/TutorialUpvoteAccessibilityMissionScreen/TutorialUpvoteAccessibilityMissionScreen.tsx
+++ b/src/screens/TutorialUpvoteAccessibilityMissionScreen/TutorialUpvoteAccessibilityMissionScreen.tsx
@@ -89,6 +89,9 @@ export default function TutorialUpvoteAccessibilityMissionScreen({
     phaseRef.current = next;
     setPhaseState(next);
   }, []);
+  // 팝업 가시성을 phase 와 분리해 관리한다. 사용자가 "확인" 을 누르면 팝업만 사라지고
+  // phase 는 COMPLETED 로 유지 (재 mutation / spotlight 재노출 방지). history back 은 안 한다.
+  const [isCompletedPopupVisible, setIsCompletedPopupVisible] = useState(false);
 
   const [showAppBarTitle, setShowAppBarTitle] = useState(false);
   const bottomBarAnim = useRef(new Animated.Value(0)).current;
@@ -196,13 +199,16 @@ export default function TutorialUpvoteAccessibilityMissionScreen({
     completeMission.mutate(undefined, {
       onSuccess: () => {
         setPhase('COMPLETED');
+        setIsCompletedPopupVisible(true);
       },
     });
   }, [completeMission, setPhase]);
 
+  // 팝업 "확인" 은 닫기 동작만 한다. history back 으로 자동 튕기는 어색한 UX 방지.
+  // phase 는 COMPLETED 로 유지되어 spotlight/팝업이 사라진 PDP 시뮬레이션이 남는다.
   const handleClosePopup = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+    setIsCompletedPopupVisible(false);
+  }, []);
 
   const description = `돋보기 획득!\n꼼꼼하고 다정하게 정보를\n살펴봐주셔서 고마워요!`;
 
@@ -311,7 +317,7 @@ export default function TutorialUpvoteAccessibilityMissionScreen({
 
         {/* State 4: 미션 완료 팝업. */}
         <MissionCompletedOverlay
-          isVisible={phase === 'COMPLETED'}
+          isVisible={isCompletedPopupVisible}
           itemImage={require('@/assets/img/tutorial/mission_complete_img_magnifier.png')}
           description={description}
           confirmElementName="tutorial_mission_3_completed_confirm"


### PR DESCRIPTION
## Summary

QA 에서 보고된 NUX (윌리의 외출) 튜토리얼 미션 관련 3개 버그 픽스.

### 이슈 1: 미션 2 저장/해제 버튼 상태가 즉시 반영 안 됨
저장리스트가 커서 서버 응답 + invalidate refetch 가 느릴 때 사용자가 "안 눌렸나?" 헷갈리는 문제.
\`useSavePlaceList\` 의 \`onMutate\` 에 optimistic update 추가. \`PlaceListDetail\` 캐시의 \`isSaved\` 를 즉시 toggle 하고 \`onError\` 시 snapshot 으로 revert.

### 이슈 2: 미션 완료 팝업 "확인" 누르면 history back 되는 어색한 UX
\`MissionCompletedOverlay\` 의 \`onClose\` 콜백 4곳에서 \`navigation.goBack()\` 제거.
- \`PlaceListDetailScreen\` — 일반 저장리스트 화면에서 진입한 사용자가 튕겨나가지 않도록
- \`TutorialUpvoteAccessibilityMissionScreen\` — phase 와 팝업 가시성을 분리해 "확인" 누르면 팝업만 닫히고 PDP 시뮬레이션이 남도록
- \`InterestedRegionAndThemesFormScreen\` — 안전한 선택으로 팝업 닫기만. 사용자가 직접 뒤로가기를 누르면 dirty check 우회 (\`hasSubmitted\`) 로 정상 이탈

\`MissionCompletedOverlay.tsx\` 컴포넌트 자체는 손대지 않음 (별도 작업과의 충돌 방지).

### 이슈 3: 미션 2 완료 팝업이 저장 해제 → 재저장 시 다시 노출되던 버그
기존엔 \`currentMissionType === SavePlaceList\` 로 판단했는데, \`useSavePlaceList\` 가 \`USER_TUTORIAL_PROGRESS\` 캐시를 invalidate 하지 않아 \`currentMissionType\` 이 stuck 되는 케이스가 있었음.
\`mission.completedAt\` 으로 판단 + 같은 세션 1회 가드 ref 추가. 서버가 한 번 \`completedAt\` 을 set 한 후엔 영원히 true 이므로 재노출 원천 차단.
미션 3 도 \`isCompletedPopupVisible\` state 를 \`phase\` 와 분리해 같은 패턴 적용.

## Test plan
- [ ] 미션 2 화면에서 저장 버튼 탭 → 즉시 \"리스트 저장됨\" 으로 토글됨
- [ ] 미션 2 화면에서 해제 버튼 탭 → 즉시 \"리스트 저장하기\" 로 토글됨
- [ ] 네트워크 실패 시 버튼 상태 revert 확인
- [ ] 미션 1/2/3 완료 팝업의 \"확인\" 버튼 → 팝업만 닫히고 화면은 그대로 유지
- [ ] 미션 2 완료 후 저장 해제 → 다시 저장 시 완료 팝업 재노출 안 됨
- [ ] 미션 3 완료 후 같은 화면에서 도움돼요 버튼 재탭 시 mutation 재호출 안 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness and reliability when saving or unsaving place lists through better cache synchronization.
  * Fixed overlay dismissal behavior: closing mission completion and tutorial overlays no longer automatically navigates away from the current screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-app/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->