### PR TITLE
fix: 미션 1 완료 시 goBack + 미션 3 이미지 잘림 + 도움돼요 클릭 불가

### DIFF
--- a/src/screens/InterestedRegionAndThemesFormScreen/InterestedRegionAndThemesFormScreen.tsx
+++ b/src/screens/InterestedRegionAndThemesFormScreen/InterestedRegionAndThemesFormScreen.tsx
@@ -120,10 +120,14 @@ export default function InterestedRegionAndThemesFormScreen({
   ]);
 
   const handleCollectedClose = useCallback(() => {
-    // 팝업의 "확인" 은 닫기만 한다. 화면 이탈은 사용자가 직접 뒤로가기 버튼을 누를 때
-    // 발생하며, 그때 dirty check 를 우회한다 (이미 저장됨).
+    // 이 화면은 튜토리얼 미션 1 전용 (일반 flow 에서 진입하지 않는다). 미션 완료 팝업
+    // "확인" 시 화면을 닫아 TutorialMissionScreen 으로 돌아가는 것이 자연스러운 UX.
+    // navigation 책임은 호출 사이트에 두고 MissionCompletedOverlay 는 닫기 신호만 보낸다
+    // (다른 호출 사이트들 — 일반 저장리스트 / PDP — 에서는 goBack 하지 않도록).
     setShowCollected(false);
-  }, []);
+    formExitConfirm.bypass();
+    navigation.goBack();
+  }, [formExitConfirm, navigation]);
 
   const handleRegionConfirm = useCallback((nextSelectedIds: string[]) => {
     setSelectedRegionIds(nextSelectedIds);

--- a/src/screens/TutorialUpvoteAccessibilityMissionScreen/TutorialUpvoteAccessibilityMissionScreen.tsx
+++ b/src/screens/TutorialUpvoteAccessibilityMissionScreen/TutorialUpvoteAccessibilityMissionScreen.tsx
@@ -42,9 +42,11 @@ const PDP_BODY_BOTTOM_RENDER_HEIGHT =
   (SCREEN_WIDTH * PDP_BODY_BOTTOM_HEIGHT) / PDP_BODY_TOP_WIDTH;
 
 // figma 1648:41636 에서 "매장 출입구" 섹션은 body 시작점 기준 y=526dp (1648:41652 위치, app bar 빼고).
-// V2AppBar(50dp) 가 viewport 상단을 덮으므로 그만큼 덜 스크롤해서 섹션 header 가 viewport 에 보이게 한다.
 const V2_APP_BAR_HEIGHT = 50;
-const SCROLL_TARGET_Y = (526 * SCREEN_WIDTH) / 390 - V2_APP_BAR_HEIGHT;
+// ScrollView contentContainer 상단에 V2_APP_BAR_HEIGHT 만큼 padding 을 주어 (absolute 로
+// 띄워진 V2AppBar 가 body 이미지 최상단을 덮지 않게) — 따라서 섹션이 viewport 상단(=appbar 바로 아래)
+// 에 보이려면 scrollY = body offset (paddingTop 은 자연스럽게 보정됨).
+const SCROLL_TARGET_Y = (526 * SCREEN_WIDTH) / 390;
 // figma 1648:41483 frame 은 390 wide. 화면 폭이 다르더라도 디자인 비율을 그대로 유지.
 const INITIAL_DIM_SCALE = SCREEN_WIDTH / 390;
 
@@ -226,7 +228,8 @@ export default function TutorialUpvoteAccessibilityMissionScreen({
           onMomentumScrollEnd={handleMomentumScrollEnd}
           scrollEventThrottle={16}
           scrollEnabled={false}
-          showsVerticalScrollIndicator={false}>
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{paddingTop: V2_APP_BAR_HEIGHT}}>
           <Image
             source={require('@/assets/img/tutorial/tutorial_mission_3_pdp_body_top.png')}
             style={{
@@ -442,10 +445,16 @@ const TOOLTIP_ARROW_WIDTH = 32;
 const TOOLTIP_ARROW_HEIGHT = 18;
 /**
  * 도움돼요 버튼 위치만 비워두고 나머지를 dim 처리하는 spotlight.
- * 4개의 dim rect (위/아래/왼쪽/오른쪽) 로 hole 을 구성한다.
+ * SVG mask 로 dim rect 에 rounded rect hole 을 punch out (4-rect 방식과 달리 hole 모서리에
+ * border-radius 적용 가능).
  * 좌표는 window-absolute (measureInWindow 결과) 이며 SpotlightOverlay 가
  * full-screen Root 안에서 absolute positioning 되므로 그대로 사용한다.
- * pointerEvents="box-none" 으로 hole 영역의 터치는 아래(도움돼요 버튼)로 전달된다.
+ *
+ * pointerEvents="none" 으로 overlay 전체가 터치를 가로채지 않게 한다 — hole 영역의
+ * 도움돼요 버튼 탭이 정상 동작해야 한다. react-native-svg Svg 컴포넌트는 일부 Android 버전에서
+ * `pointerEvents="none"` 만 prop 으로 줘서는 native view 가 여전히 터치를 잡는 케이스가
+ * 있으므로, 부모 View 를 `pointerEvents="none"` 으로 잠가서 자식까지 전파시키는 것이 안전하다.
+ * (overlay 의 모든 자식 — dim svg, tooltip text/arrow — 은 시각 전용이라 터치 받을 일이 없음.)
  */
 function SpotlightOverlay({
   holeX,
@@ -458,10 +467,8 @@ function SpotlightOverlay({
   const hW = holeWidth + HOLE_PADDING * 2;
   const hH = holeHeight + HOLE_PADDING * 2;
   const {width: winW, height: winH} = Dimensions.get('window');
-  // SVG mask 로 dim rect 에 rounded rect hole 을 punch out. 4-rect 방식과 달리 hole 모서리에
-  // border-radius 적용 가능.
   return (
-    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
       <Svg
         width={winW}
         height={winH}


### PR DESCRIPTION
## Summary

NUX 미션 관련 추가 피드백 3건 픽스.

### 이슈 1: 미션 1 완료 팝업 '확인' → history back
- `InterestedRegionAndThemesFormScreen` 의 `handleCollectedClose` 에서 `navigation.goBack()` 재도입
- PR #164 에서 모든 미션 완료 팝업 호출 사이트의 `goBack` 을 제거했는데, 이 화면은 튜토리얼 전용이라 예외
- 다른 호출 사이트 (일반 저장리스트, 일반 PDP) 는 그대로 유지 — navigation 책임을 호출 사이트로 분리
- `MissionCompletedOverlay` 컴포넌트 자체는 변경 없음 (재사용 컴포넌트의 navigation 책임 X 유지)

### 이슈 2: 미션 3 페이지 이미지 최상단 잘림
- `TutorialUpvoteAccessibilityMissionScreen` 의 `ScrollView contentContainer` 에 `paddingTop: V2_APP_BAR_HEIGHT(50dp)` 추가
- V2AppBar 가 absolute 로 띄워져 있어 body 이미지 최상단을 덮던 문제 해결
- `SCROLL_TARGET_Y` 보정: paddingTop 추가로 자연스럽게 offset 되므로 기존 `-V2_APP_BAR_HEIGHT` 제거

### 이슈 3: 미션 3 페이지 '도움돼요' 버튼 클릭 불가
- `SpotlightOverlay` 의 outer View `pointerEvents` 를 `box-none` → `none` 으로 변경
- react-native-svg 의 `<Svg>` 컴포넌트가 일부 Android 버전에서 자체 `pointerEvents="none"` prop 만으로는 터치를 가로채는 케이스가 있어, 부모에서 전체 차단하는 게 안전
- overlay 의 모든 자식 (dim svg, tooltip text/arrow) 은 시각 전용이라 터치 받을 일이 없음 → `none` 으로 변경해도 안전

## Test plan

- [ ] 미션 1 (관심지역/관심테마) 입력 완료 → 외출템 수집 팝업 '확인' → TutorialMissionScreen 으로 자동 복귀
- [ ] 미션 3 (도움돼요) 진입 시 body 이미지 최상단이 V2AppBar 에 가려지지 않음
- [ ] 미션 3 의 INITIAL_DIM → AUTO_SCROLL → UPVOTE_DIM 전환 후 도움돼요 버튼 탭 가능 → 완료 팝업 노출
- [ ] 미션 2 (PublicPlaceListsScreen) / 일반 저장리스트 / 일반 PDP 에서는 기존처럼 미션 완료 팝업 '확인' 시 화면 이탈 발생하지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved mission completion overlay to enable proper navigation back without form exit confirmations
  * Refined tutorial screen scrolling behavior and improved overlay touch handling for better user interaction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-app/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->