### PR TITLE
fix: 크루 폐업 신고 시 '정복 안 된 곳' 목록 캐시에서 즉시 제거

### DIFF
--- a/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
+++ b/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
@@ -24,6 +24,7 @@ import {
   FloorMovingMethodTypeDto,
   Place,
   PlaceDoorDirectionTypeDto,
+  PlaceListItem,
   PlaceSpecialAccessibilityDto,
   ReportAccessibilityPostRequest,
   ReportTargetTypeDto,
@@ -124,6 +125,12 @@ export default function PlaceDetailV2Screen({
         ToastUtils.show('폐업 처리가 완료되었습니다.');
         queryClient.invalidateQueries({queryKey: ['searchPlaces']});
         queryClient.invalidateQueries({queryKey: ['PlaceDetailV2']});
+        // '정복 안 된 곳만 보기' 목록 캐시에서 폐업된 장소를 즉시 제거
+        // (invalidate 대신 setQueriesData로 직접 필터 — 재요청 없이 UX 즉시 반영)
+        queryClient.setQueriesData<PlaceListItem[]>(
+          {queryKey: ['SearchUnconqueredPlaces']},
+          old => old?.filter(item => item.place.id !== params.placeId),
+        );
         navigation.goBack();
       } else {
         const isAutoResolved = result.data?.isAutoResolved === true;


### PR DESCRIPTION
## Summary

- 크루가 PDP 에서 폐업 신고하면 서버는 `isClosed=true` 를 즉시 반영하지만, '정복 안 된 곳만 보기' 화면의 react query 캐시는 그대로라 뒤로가기 했을 때 폐업한 장소가 그대로 목록에 보였음.
- `reportAccessibilityMutation` 성공 분기(`isCrewClosure`)에서 `queryClient.setQueriesData` 로 `['SearchUnconqueredPlaces', *]` 캐시에서 해당 `placeId` 만 직접 필터해 제거. invalidate 가 아니라 부분 업데이트라 재요청 없이 UX 가 즉시 반영됨.
- 서버 쪽 폐업 필터 누락 fix 는 별도 PR: Stair-Crusher-Club/scc-server#TBD

## Test plan
- [ ] '정복 안 된 곳만 보기' 진입 → 임의 장소 PDP → 신고 → 폐업 → 뒤로가기. 해당 카드가 목록에서 사라지는지 확인 (크루 계정).
- [ ] 비크루 계정에서 폐업 신고하면 목록에는 그대로 남아있는지 확인 (즉시 반영 X).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closed places reported during accessibility review are now immediately removed from search results, ensuring they no longer appear in subsequent searches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-app/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->