### PR TITLE
fix: 2시간 장소 등록 활동 발열 완화 + 가시성 텔레메트리

### DIFF
--- a/src/components/maps/ItemMapView.tsx
+++ b/src/components/maps/ItemMapView.tsx
@@ -30,6 +30,7 @@ import {MarkerItem} from '@/components/maps/MarkerItem.ts';
 import {getRegionFromItems, Region} from '@/components/maps/Types.tsx';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
+import {useIsForeground} from '@/hooks/useIsForeground';
 import {usePlaceDetailScreenName} from '@/hooks/useFeatureFlags';
 import useNavigation from '@/navigation/useNavigation.ts';
 import {useLogger} from '@/logging/useLogger';
@@ -100,6 +101,8 @@ const FRefInputComp = <T extends MarkerItem>(
   // context 값이 0이 되어 추가 padding 없음.
   const tabBarHeight = useContext(BottomTabBarHeightContext) ?? 0;
   const isFocused = useIsFocused();
+  const isForeground = useIsForeground();
+  const isActive = isFocused && isForeground;
   const onMyLocationPress = () => {
     mapRef.current?.setPositionMode('direction');
     GeolocationUtils.getCurrentPosition().then(
@@ -124,11 +127,13 @@ const FRefInputComp = <T extends MarkerItem>(
     return () => clearTimeout(timer);
   }, []);
 
-  // 화면이 포커스된 동안에만 GPS watch. 다른 화면으로 push 되면 즉시 해제.
+  // 화면이 포커스 + 앱이 foreground 인 동안에만 GPS watch.
+  // - useIsFocused: navigation stack 의 다른 화면으로 push 되면 GPS 해제
+  // - useIsForeground: 앱이 백그라운드로 가면 GPS 해제 (isFocused 만으로는 안 됨)
   // 2시간 활동 발열 원인 1순위: enableHighAccuracy GPS가 navigation stack에
   // 깔린 모든 map 화면에서 동시에 돌고 있던 누수.
   useEffect(() => {
-    if (!isFocused) return;
+    if (!isActive) return;
     HeatTelemetry.start('gps_watch');
     const watchId = Geolocation.watchPosition(
       position => {
@@ -150,7 +155,7 @@ const FRefInputComp = <T extends MarkerItem>(
       Geolocation.clearWatch(watchId);
       HeatTelemetry.stop('gps_watch');
     };
-  }, [isFocused, setCurrentLocation]);
+  }, [isActive, setCurrentLocation]);
 
   useEffect(() => {
     HeatTelemetry.start('map_native_view');

--- a/src/components/maps/ItemMapView.tsx
+++ b/src/components/maps/ItemMapView.tsx
@@ -1,5 +1,6 @@
 import Geolocation from '@react-native-community/geolocation';
 import {BottomTabBarHeightContext} from '@react-navigation/bottom-tabs';
+import {useIsFocused} from '@react-navigation/native';
 import {useSetAtom} from 'jotai';
 import React, {
   ForwardedRef,
@@ -33,6 +34,7 @@ import {usePlaceDetailScreenName} from '@/hooks/useFeatureFlags';
 import useNavigation from '@/navigation/useNavigation.ts';
 import {useLogger} from '@/logging/useLogger';
 import GeolocationUtils from '@/utils/GeolocationUtils.ts';
+import HeatTelemetry from '@/utils/HeatTelemetry';
 
 // ItemMapList 카드 컨테이너 고정 높이 (242 + 28)
 const CARD_LIST_HEIGHT = 270;
@@ -97,6 +99,7 @@ const FRefInputComp = <T extends MarkerItem>(
   // 탭바가 숨김(`tabBarStyle: display:none`) 이거나 Bottom Tab 컨텍스트 밖이면
   // context 값이 0이 되어 추가 padding 없음.
   const tabBarHeight = useContext(BottomTabBarHeightContext) ?? 0;
+  const isFocused = useIsFocused();
   const onMyLocationPress = () => {
     mapRef.current?.setPositionMode('direction');
     GeolocationUtils.getCurrentPosition().then(
@@ -118,7 +121,15 @@ const FRefInputComp = <T extends MarkerItem>(
     const timer = setTimeout(() => {
       mapRef.current?.setPositionMode('direction');
     }, 100);
+    return () => clearTimeout(timer);
+  }, []);
 
+  // 화면이 포커스된 동안에만 GPS watch. 다른 화면으로 push 되면 즉시 해제.
+  // 2시간 활동 발열 원인 1순위: enableHighAccuracy GPS가 navigation stack에
+  // 깔린 모든 map 화면에서 동시에 돌고 있던 누수.
+  useEffect(() => {
+    if (!isFocused) return;
+    HeatTelemetry.start('gps_watch');
     const watchId = Geolocation.watchPosition(
       position => {
         setCurrentLocation({
@@ -132,13 +143,18 @@ const FRefInputComp = <T extends MarkerItem>(
       {
         enableHighAccuracy: true,
         maximumAge: 60000,
-        interval: 3000,
+        interval: 5000,
       },
     );
     return () => {
-      clearTimeout(timer);
       Geolocation.clearWatch(watchId);
+      HeatTelemetry.stop('gps_watch');
     };
+  }, [isFocused, setCurrentLocation]);
+
+  useEffect(() => {
+    HeatTelemetry.start('map_native_view');
+    return () => HeatTelemetry.stop('map_native_view');
   }, []);
 
   useImperativeHandle(ref, () => ({

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -182,6 +182,35 @@ const Logger = {
     crashlytics().recordError(error);
   },
 
+  async logHeatSample(params: {
+    sessionDurationMs: number;
+    foregroundDurationMs: number;
+    batteryLevel: number | null;
+    batteryDeltaSession: number | null;
+    gpsWatchMs: number;
+    mapNativeViewMs: number;
+    cameraActiveMs: number;
+    imageUploadMs: number;
+  }) {
+    logDebug('logHeatSample', params, currUserPropertiesForDebugging);
+    const eventParams = {
+      session_duration_ms: params.sessionDurationMs,
+      foreground_duration_ms: params.foregroundDurationMs,
+      ...(params.batteryLevel !== null && {
+        battery_level: params.batteryLevel,
+      }),
+      ...(params.batteryDeltaSession !== null && {
+        battery_delta_session: params.batteryDeltaSession,
+      }),
+      gps_watch_ms: params.gpsWatchMs,
+      map_native_view_ms: params.mapNativeViewMs,
+      camera_active_ms: params.cameraActiveMs,
+      image_upload_ms: params.imageUploadMs,
+    };
+    trackEvent('heat_sample', eventParams);
+    getAnalytics().logEvent('heat_sample', eventParams);
+  },
+
   async logAppPushOpen(params: AppPushOpenParams) {
     logDebug('logAppPushOpen', params, currUserPropertiesForDebugging);
     const eventParams = {

--- a/src/navigation/Navigation.screens.ts
+++ b/src/navigation/Navigation.screens.ts
@@ -154,7 +154,7 @@ export const MainNavigationScreens: {
     component: UpvoteAnalyticsScreen,
     options: {headerShown: true, headerTitle: '도움돼요'},
   },
-  {name: 'Camera', component: CameraScreen},
+  {name: 'Camera', component: CameraScreen, options: {freezeOnBlur: true}},
   {
     name: 'CrusherActivity',
     component: CrusherActivityScreen,
@@ -239,7 +239,7 @@ export const MainNavigationScreens: {
   {
     name: 'ToiletMap',
     component: ToiletMapScreen,
-    options: {headerShown: false},
+    options: {headerShown: false, freezeOnBlur: true},
   },
   {
     name: 'SavedPlaceLists',
@@ -254,18 +254,18 @@ export const MainNavigationScreens: {
   {
     name: 'PlaceListDetail',
     component: PlaceListDetailScreen,
-    options: {headerShown: false},
+    options: {headerShown: false, freezeOnBlur: true},
   },
   {
     // deep link 하위호환: place-group/:id → PlaceListDetail
     name: 'PlaceGroupMap',
     component: PlaceListDetailScreen,
-    options: {headerShown: false},
+    options: {headerShown: false, freezeOnBlur: true},
   },
   {
     name: 'SearchUnconqueredPlaces',
     component: SearchUnconqueredPlacesScreen,
-    options: {headerShown: false},
+    options: {headerShown: false, freezeOnBlur: true},
   },
   {
     name: 'ImageZoomViewer',

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -71,9 +71,6 @@ export const Navigation = () => {
       initialRouteName="Intro"
       screenOptions={() => ({
         headerShown: false,
-        // inactive 화면의 JS 실행을 동결. stack에 깔린 map/카메라 등 무거운 화면이
-        // 백그라운드에서 계속 GPU/CPU 자원을 쓰는 것을 막아 2시간 활동 발열을 완화.
-        freezeOnBlur: true,
         // native-stack screen 컨테이너 기본값이 투명이라, 화면 전환 중/후에
         // GestureHandlerRootView 등 상위 트리의 배경색이 leak된다. 모든 화면을
         // 흰 배경으로 강제해 leak 차단. (특정 화면이 투명 필요시 override)

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -71,6 +71,9 @@ export const Navigation = () => {
       initialRouteName="Intro"
       screenOptions={() => ({
         headerShown: false,
+        // inactive 화면의 JS 실행을 동결. stack에 깔린 map/카메라 등 무거운 화면이
+        // 백그라운드에서 계속 GPU/CPU 자원을 쓰는 것을 막아 2시간 활동 발열을 완화.
+        freezeOnBlur: true,
         // native-stack screen 컨테이너 기본값이 투명이라, 화면 전환 중/후에
         // GestureHandlerRootView 등 상위 트리의 배경색이 leak된다. 모든 화면을
         // 흰 배경으로 강제해 leak 차단. (특정 화면이 투명 필요시 override)

--- a/src/screens/CameraScreen/CameraScreen.tsx
+++ b/src/screens/CameraScreen/CameraScreen.tsx
@@ -28,6 +28,7 @@ import Logger from '@/logging/Logger';
 import ImageFile from '@/models/ImageFile';
 import {ScreenProps} from '@/navigation/Navigation.screens';
 import {SccCameraButtons} from '@/native-modules/SccCameraButtons';
+import HeatTelemetry from '@/utils/HeatTelemetry';
 import ImageFileUtils from '@/utils/ImageFileUtils';
 import ToastUtils from '@/utils/ToastUtils';
 
@@ -236,6 +237,11 @@ export default function CameraScreen({
         countdownTimeoutRef.current = null;
       }
     };
+  }, []);
+
+  useEffect(() => {
+    HeatTelemetry.start('camera_active');
+    return () => HeatTelemetry.stop('camera_active');
   }, []);
 
   useEffect(() => {

--- a/src/screens/MainScreen/MainScreen.tsx
+++ b/src/screens/MainScreen/MainScreen.tsx
@@ -113,6 +113,7 @@ export default function MainScreen({navigation}: ScreenProps<'Main'>) {
           title: '지도',
           headerShown: false,
           tabBarIcon: MapTabIcon,
+          freezeOnBlur: true,
         }}
       />
       <Tab.Screen

--- a/src/screens/RootScreen.tsx
+++ b/src/screens/RootScreen.tsx
@@ -23,6 +23,7 @@ import {
 import {dismissSplashOverlay} from '@/splash/SplashOverlay';
 import {logDebug} from '@/utils/DebugUtils';
 import {isAuthDeferred} from '@/utils/deepLinkUtils';
+import HeatTelemetry from '@/utils/HeatTelemetry';
 
 // 전체 화면 공용 로깅 규칙 정의
 const ROUTE_PARAMS_LOGGING_RULES: Record<string, string> = {
@@ -66,6 +67,7 @@ const RootScreen = () => {
           if (Platform.OS === 'ios') {
             requestTrackingPermission();
           }
+          HeatTelemetry.beginSession().catch(() => {});
           const currentScreenName =
             navigationRef.current?.getCurrentRoute()?.name;
           logDebug(`App starts at ${currentScreenName}`);

--- a/src/utils/HeatTelemetry.ts
+++ b/src/utils/HeatTelemetry.ts
@@ -1,0 +1,127 @@
+import {AppState, AppStateStatus} from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+
+import Logger from '@/logging/Logger';
+
+const SAMPLE_INTERVAL_MS = 60_000;
+
+export type HeatComponent =
+  | 'gps_watch'
+  | 'map_native_view'
+  | 'camera_active'
+  | 'image_upload';
+
+type ActiveStarts = {[K in HeatComponent]?: number};
+type Accumulated = {[K in HeatComponent]?: number};
+
+class HeatTelemetry {
+  private activeStarts: ActiveStarts = {};
+  private accumulated: Accumulated = {};
+  private sessionStartedAt: number = Date.now();
+  private sessionStartBattery: number | null = null;
+  private samplingTimer: ReturnType<typeof setInterval> | null = null;
+  private appStateSub: {remove: () => void} | null = null;
+  private foregroundElapsedMs = 0;
+  private lastForegroundStart: number | null = Date.now();
+
+  start = (component: HeatComponent) => {
+    if (this.activeStarts[component] != null) return;
+    this.activeStarts[component] = Date.now();
+  };
+
+  stop = (component: HeatComponent) => {
+    const startedAt = this.activeStarts[component];
+    if (startedAt == null) return;
+    this.accumulated[component] =
+      (this.accumulated[component] ?? 0) + (Date.now() - startedAt);
+    this.activeStarts[component] = undefined;
+  };
+
+  beginSession = async () => {
+    this.sessionStartedAt = Date.now();
+    this.accumulated = {};
+    this.activeStarts = {};
+    this.foregroundElapsedMs = 0;
+    this.lastForegroundStart = Date.now();
+    this.sessionStartBattery = await this.readBattery();
+
+    if (this.samplingTimer) {
+      clearInterval(this.samplingTimer);
+    }
+    this.samplingTimer = setInterval(() => {
+      this.flushSample().catch(() => {});
+    }, SAMPLE_INTERVAL_MS);
+
+    if (this.appStateSub) {
+      this.appStateSub.remove();
+    }
+    this.appStateSub = AppState.addEventListener(
+      'change',
+      this.handleAppStateChange,
+    );
+  };
+
+  private handleAppStateChange = (state: AppStateStatus) => {
+    const now = Date.now();
+    if (state === 'active') {
+      if (this.lastForegroundStart == null) {
+        this.lastForegroundStart = now;
+      }
+    } else {
+      if (this.lastForegroundStart != null) {
+        this.foregroundElapsedMs += now - this.lastForegroundStart;
+        this.lastForegroundStart = null;
+      }
+      this.flushSample().catch(() => {});
+    }
+  };
+
+  private async readBattery(): Promise<number | null> {
+    try {
+      const level = await DeviceInfo.getBatteryLevel();
+      // -1 indicates unavailable (emulator 등)
+      return level >= 0 ? level : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private snapshotActive(): Accumulated {
+    const now = Date.now();
+    const snapshot: Accumulated = {...this.accumulated};
+    (Object.keys(this.activeStarts) as HeatComponent[]).forEach(comp => {
+      const startedAt = this.activeStarts[comp];
+      if (startedAt != null) {
+        snapshot[comp] = (snapshot[comp] ?? 0) + (now - startedAt);
+      }
+    });
+    return snapshot;
+  }
+
+  private async flushSample() {
+    const now = Date.now();
+    const sessionDurationMs = now - this.sessionStartedAt;
+    const fgElapsed =
+      this.foregroundElapsedMs +
+      (this.lastForegroundStart != null ? now - this.lastForegroundStart : 0);
+    const activeNow = this.snapshotActive();
+    const currentBattery = await this.readBattery();
+    const batteryDelta =
+      this.sessionStartBattery != null && currentBattery != null
+        ? this.sessionStartBattery - currentBattery
+        : null;
+
+    Logger.logHeatSample({
+      sessionDurationMs,
+      foregroundDurationMs: fgElapsed,
+      batteryLevel: currentBattery,
+      batteryDeltaSession: batteryDelta,
+      gpsWatchMs: activeNow.gps_watch ?? 0,
+      mapNativeViewMs: activeNow.map_native_view ?? 0,
+      cameraActiveMs: activeNow.camera_active ?? 0,
+      imageUploadMs: activeNow.image_upload ?? 0,
+    });
+  }
+}
+
+export default new HeatTelemetry();


### PR DESCRIPTION
## Summary

2시간 오프라인 장소 등록 활동 시 휴대폰 발열 호소에 대응. 발열 핫스팟을 코드에서 직접 짚어 누수를 막고, "각 요소가 발열에 얼마나 기여하는지" 데이터로 검증할 수 있는 텔레메트리도 같이 추가.

### 변경 내용

**누수/부하 완화**
- `ItemMapView`: `useIsFocused`로 비포커스 시 `Geolocation.watchPosition` 즉시 해제. navigation stack에 깔린 map 화면들이 동시에 enableHighAccuracy GPS를 돌리던 누수 차단 (Search/PlaceListDetail/SearchUnconquered/ToiletMap 4개 화면).
- `ItemMapView`: watchPosition `interval` 3초 → 5초.
- `Navigation`: `Stack.Navigator`에 `freezeOnBlur: true`. inactive 화면의 JS 실행/타이머/맵 GPU 부하 동결.

**가시성 텔레메트리**
- `HeatTelemetry`: 컴포넌트별 active 시간(`gps_watch` / `map_native_view` / `camera_active`) 누적.
- 60초마다 + 백그라운드 진입 시 Firebase Analytics `heat_sample` 이벤트로 flush.
- 페이로드: `session_duration_ms`, `foreground_duration_ms`, `battery_level`, `battery_delta_session`, 각 컴포넌트 `*_ms`.
- 다수 세션 누적되면 BigQuery에서 `battery_delta_per_min ~ gps_frac + map_frac + camera_frac` 회귀로 각 요소의 분당 발열 기여도 산정 가능.

### 네이티브 변경 없음 — OTA 배포 가능

모두 JS/TS 변경. `freezeOnBlur`는 react-navigation v7 native-stack의 JS 옵션이고 `react-native-screens` 4.x가 이미 빌드돼 있음. `getBatteryLevel`은 이미 의존성에 있는 `react-native-device-info`가 노출하는 API.

### 의도적으로 안 한 것

- `enableHighAccuracy: false` (정확도 완화) — 위치점 표시는 wifi/network로 충분하지만 UX 영향 가능성 있어 보류. 텔레메트리 1~2주 데이터 보고 결정.
- iOS `thermalState` / Android `BatteryManager temperature` native module — 더 직접적인 신호지만 native 빌드 필요해 별 PR.
- image upload 측정 wiring — 업로드 burst는 짧고 누적 영향 적어 우선순위 낮음.

## Test plan

- [ ] Search/PlaceListDetail/SearchUnconquered 진입 → 다른 화면으로 push → logcat/Console에서 `clearWatch` 호출 확인
- [ ] Search → PDP → 뒤로가기 시 map 정상 표시되는지 확인 (freezeOnBlur 부수효과 점검)
- [ ] Home 화면 → 다른 화면으로 push → 돌아왔을 때 배너 auto-scroll이 다시 동작하는지
- [ ] Firebase DebugView에서 `heat_sample` 이벤트 60s마다 발생 확인
- [ ] BigQuery `heat_sample` 테이블에 데이터 들어오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry system now tracks session metrics including battery level, battery drain, and active duration of key components like GPS, camera, and map viewing
  * GPS tracking now activates only when the map screen is in focus, reducing unnecessary background location updates

* **Performance**
  * Inactive navigation screens now freeze to reduce background CPU and GPU usage, improving overall battery efficiency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-app/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->