### PR TITLE
fix: 관심 주제 선택 바텀시트 칩이 일부 기기에서 1-column으로 깨지는 문제 수정

### DIFF
--- a/src/screens/InterestedRegionAndThemesFormScreen/components/ThemeSelectBottomSheet.tsx
+++ b/src/screens/InterestedRegionAndThemesFormScreen/components/ThemeSelectBottomSheet.tsx
@@ -153,11 +153,18 @@ const ThemeGrid = styled.View`
 `;
 
 const ThemeChip = styled(SccPressable)<{selected: boolean}>`
-  /* 고정 width(169px) 는 좁은 폰에서 2칸이 한 줄에 안 들어가 1-column 으로 깨진다.
-     flex-basis 40% + flex-grow 1 로 화면 폭과 무관하게 항상 2-column 이 되도록 한다
-     (3번째는 120% 라 자동 줄바꿈, 같은 줄 2칸은 grow 로 남은 폭을 채움). */
+  /* width 40% + flex-grow 1 로 화면 폭과 무관하게 항상 2-column 을 유지한다
+     (3번째는 120% 라 자동 줄바꿈, 같은 줄 2칸은 grow 로 남은 폭을 채움).
+
+     주의: flex-basis(%) 는 컨테이너의 "확정된(definite)" main size 기준으로만
+     해석된다. BottomSheet 의 Container 는 명시적 width 없이 align-items: stretch
+     체인으로만 폭이 정해지므로, 일부 기기(갤럭시 플립6·S23 울트라 등)에서는
+     Yoga 가 이 폭을 indefinite 로 보고 flex-basis(%) 를 content size 로 대체한다.
+     그 결과 flex-grow 가 각 칩을 한 줄 전체로 늘려 1-column 으로 깨졌다.
+     width(%) 는 부모의 resolved width 기준으로 안정적으로 해석되므로
+     Options.style.ts 의 검증된 2-column 패턴과 동일하게 width 40% 를 사용한다. */
   flex-grow: 1;
-  flex-basis: 40%;
+  width: 40%;
   padding: 14px 8px;
   border-radius: 14px;
   border-width: 1.2px;


### PR DESCRIPTION
## 문제

"관심 주제를 모두 선택해주세요" 바텀시트(`ThemeSelectBottomSheet`)의 주제 칩이 원래 **2-column grid**로 나와야 하는데, 일부 기기(**갤럭시 플립6, S23 울트라** 등)에서 **1-column**으로 깨져서 표시됨.

## 원인

기존 코드는 칩 폭을 `flex-basis: 40%` + `flex-grow: 1`로 지정하고 있었음.

```css
flex-grow: 1;
flex-basis: 40%;
```

`flex-basis(%)`는 CSS Flexbox 스펙(§9.2.3)상 **컨테이너의 확정된(definite) main size 기준으로만** 해석된다. 그런데 `BottomSheet`의 `Container`는 명시적 `width` 없이 `align-items: stretch` 체인으로만 폭이 정해진다(`DimmedBackground` → `Container` → `SafeAreaView` → `ContentsContainer` → `ThemeGrid` 어디에도 명시적 width 없음).

이 경우 일부 기기에서 Yoga가 컨테이너 폭을 **indefinite**로 판단 → `flex-basis(%)`를 **content size로 대체** → `flex-grow: 1`이 각 칩을 한 줄 전체로 늘려 → **1-column**으로 깨짐.

> 참고: [`Options.style.ts`](https://github.com/Stair-Crusher-Club/scc-app/blob/main/src/components/form/Options.style.ts)의 검증된 2-column 패턴은 `width: '40%'` + `flexGrow: 1`을 사용한다. 직전 수정([`0358222`](https://github.com/Stair-Crusher-Club/scc-app/commit/0358222))에서 "Options.style.ts 패턴과 동일"하게 바꿨다고 했으나, 실제로는 `width` 대신 `flex-basis`를 써서 동일하지 않았던 것이 원인.

## 수정

`flex-basis: 40%` → `width: 40%`로 변경. `width(%)`는 부모의 resolved width 기준으로 안정적으로 해석되므로 기기/밀도와 무관하게 항상 2-column이 유지된다 (`Options.style.ts`와 동일한 검증된 패턴).

```diff
  flex-grow: 1;
- flex-basis: 40%;
+ width: 40%;
```

## 테스트

- [ ] 갤럭시 플립6 / S23 울트라 등 보고된 기기에서 2-column 정상 표시 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)