### PR TITLE
feat: SccContentFloatingBar 노출 element_view 계측 추가 (저장 퍼널 분석용)

### DIFF
--- a/src/screens/WebViewScreen/components/SccContentFloatingBar.tsx
+++ b/src/screens/WebViewScreen/components/SccContentFloatingBar.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import {Share, View} from 'react-native';
 import {keepPreviousData, useQuery} from '@tanstack/react-query';
 import styled from 'styled-components/native';
@@ -14,6 +14,7 @@ import {SccButton} from '@/components/atoms/SccButton';
 import {SccPressable} from '@/components/SccPressable';
 import {useUpvoteToggle} from '@/hooks/useUpvoteToggle';
 import {useSaveContent} from '@/hooks/useSaveContent';
+import {useLogger} from '@/logging/useLogger';
 import ShareUtils from '@/utils/ShareUtils';
 import ToastUtils from '@/utils/ToastUtils';
 import useAppComponents from '@/hooks/useAppComponents';
@@ -54,6 +55,17 @@ export default function SccContentFloatingBar({
 }: SccContentFloatingBarProps) {
   const {api} = useAppComponents();
   const insets = useSafeAreaInsets();
+
+  const logger = useLogger();
+  const loggerRef = useRef(logger);
+  loggerRef.current = logger;
+
+  // floating bar 는 SCC 컨텐츠 도메인에서만 마운트되므로, 이 view 이벤트가
+  // "저장 가능한 웹페이지 컨텐츠를 봤다"의 기준 계측이 된다 (퍼널 분석용).
+  // 웹뷰 안에서 다른 컨텐츠로 이동하면 url 이 바뀌므로 url 단위로 1회씩 남긴다.
+  useEffect(() => {
+    loggerRef.current.logElementView('scc-content-floating-bar', {url});
+  }, [url]);
 
   // 저장(SccContent) 상태 + 좋아요 요약 통합 조회.
   // 웹뷰 진입 시 라운드트립 1회로 isSaved + sccContentId + upvoteSummary 를 모두 받는다.


### PR DESCRIPTION
## 배경

웹페이지 저장하기 기능(userSavedContent)의 퍼널 분석에서 "웹페이지 컨텐츠를 본 세션"을 측정할 이벤트가 없음:
- `screen_view(Webview)`는 공지/폼 등 비컨텐츠 웹뷰 포함 (route param 허용 목록에 url 없음)
- 컨텐츠 진입 클릭은 `content_id`만 남기고 url을 안 남김
- 컨텐츠 URL이 param으로 남는 이벤트는 `scc-content-save` 클릭뿐

## 변경

`SccContentFloatingBar` 마운트/URL 변경 시 `element_view` 로깅 추가:
- element_name: `scc-content-floating-bar`, params: `{url}`
- floating bar는 SCC 컨텐츠 도메인(con.staircrusher.club / staircrusherclub.notion.site)에서만 마운트되므로 "저장 가능한 컨텐츠 노출"의 기준 계측이 됨
- 웹뷰 내 컨텐츠 간 이동 시 url 단위로 1회씩 기록

## 검증

- `yarn lint` / `yarn tsc --noEmit` 0 error
- 렌더 출력 무변경 (계측 추가만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal event tracking for the floating content bar component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->