### PR TITLE
feat(toilet): 화장실 상세 리뷰 등록자/시점 표시 + 안내 텍스트

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -6738,6 +6738,18 @@ export interface ToiletAccessibilityDto {
      * @memberof ToiletAccessibilityDto
      */
     'referenceTargetId'?: string | null;
+    /**
+     * 유저 리뷰 작성자 닉네임. 익명이거나 공공데이터 소스면 null. (유저 리뷰 소스)
+     * @type {string}
+     * @memberof ToiletAccessibilityDto
+     */
+    'registeredUserName'?: string | null;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof ToiletAccessibilityDto
+     */
+    'createdAt'?: EpochMillisTimestamp;
 }
 /**
  * 통합 Toilet + 병합된 소스별 접근성 정보 리스트. PDP(Place + PlaceAccessibility[]) 패턴. Toilet 레벨 식별/표시 정보 + 소스별 ToiletAccessibilityDto 배열로 구성된다. 

--- a/src/screens/PlaceDetailV2Screen/tabs/V2HomeTab.tsx
+++ b/src/screens/PlaceDetailV2Screen/tabs/V2HomeTab.tsx
@@ -396,7 +396,7 @@ export default function V2HomeTab({
           </ToiletReviewList>
         ) : (
           <EmptyStateCard
-            title={'아직 등록된 화장실 정보가 없어요🥲'}
+            title={'아직 등록된 장애인 화장실 정보가 없어요🥲'}
             description={
               '장애인 화장실이 있었나요?\n정보를 등록해주시면 필요한 분들에게 큰 도움이 돼요.'
             }

--- a/src/screens/PlaceDetailV2Screen/tabs/V2RestroomTab.tsx
+++ b/src/screens/PlaceDetailV2Screen/tabs/V2RestroomTab.tsx
@@ -56,7 +56,7 @@ export default function V2RestroomTab({
     return (
       <EmptyStateWrapper>
         <EmptyStateCard
-          title={'아직 등록된 화장실 정보가 없어요🥲'}
+          title={'아직 등록된 장애인 화장실 정보가 없어요🥲'}
           description={
             '장애인 화장실이 있었나요?\n정보를 등록해주시면 필요한 분들에게 큰 도움이 돼요.'
           }

--- a/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
+++ b/src/screens/PlaceReviewFormScreen/sections/ToiletSection.tsx
@@ -48,6 +48,10 @@ export default function ToiletSection({onSave}: {onSave: () => void}) {
 
         <View className="gap-3">
           <Question required>장애인 화장실이 있나요?</Question>
+          <Text className="font-pretendard-regular text-[14px] leading-[20px] text-gray-70">
+            휠체어 사용자도 이용 가능한 화장실인 경우에만 '있음'으로
+            선택해주세요.
+          </Text>
           <View className="flex-row flex-wrap items-start gap-2">
             <Controller
               name="toiletLocationType"

--- a/src/screens/ToiletDetailScreen/index.tsx
+++ b/src/screens/ToiletDetailScreen/index.tsx
@@ -1,6 +1,7 @@
 import Clipboard from '@react-native-clipboard/clipboard';
 import {useNavigation} from '@react-navigation/native';
 import {useQuery} from '@tanstack/react-query';
+import dayjs from 'dayjs';
 import React from 'react';
 import {SafeAreaView, ScrollView} from 'react-native';
 import styled from 'styled-components/native';
@@ -25,7 +26,10 @@ import {ScreenLayout} from '@/components/ScreenLayout';
 import {SccTouchableOpacity} from '@/components/SccTouchableOpacity';
 import {color} from '@/constant/color';
 import {font} from '@/constant/font';
-import {ToiletDetailDto} from '@/generated-sources/openapi';
+import {
+  ToiletAccessibilityDto,
+  ToiletDetailDto,
+} from '@/generated-sources/openapi';
 import useAppComponents from '@/hooks/useAppComponents';
 import {ScreenProps} from '@/navigation/Navigation.screens';
 import AvailableLabel from '@/screens/ToiletDetailScreen/AvailableLabel';
@@ -88,13 +92,18 @@ const ToiletDetail = ({detail}: {detail: ToiletDetailDto}) => {
   const allImages = detail.accessibilities.flatMap(
     accessibility => accessibility.images,
   );
-  // 유저 리뷰 섹션: locationComment / comment가 있는 첫 번째 대표값만 사용한다.
-  const locationComment = detail.accessibilities
-    .map(accessibility => accessibility.locationComment)
-    .find((it): it is string => it != null);
-  const comment = detail.accessibilities
-    .map(accessibility => accessibility.comment)
-    .find((it): it is string => it != null);
+  // 유저 리뷰 섹션: locationComment / comment를 가진 첫 번째 대표 소스를 사용한다.
+  // (등록자/등록시점을 함께 표시하기 위해 값이 아니라 소스 accessibility를 찾는다.)
+  const locationCommentSource = detail.accessibilities.find(
+    accessibility => accessibility.locationComment != null,
+  );
+  const commentSource = detail.accessibilities.find(
+    accessibility => accessibility.comment != null,
+  );
+  const locationComment = locationCommentSource?.locationComment;
+  const comment = commentSource?.comment;
+  // 등록자/등록시점은 유저 리뷰 소스 기준으로 타이틀 영역에 한 번만 표시한다.
+  const reviewSource = locationCommentSource ?? commentSource;
   // 공공데이터 상세(toiletDetails): toiletDetails를 가진 첫 번째 대표 소스만 사용한다.
   const representativeToiletDetails = detail.accessibilities.find(
     accessibility => accessibility.toiletDetails != null,
@@ -141,17 +150,17 @@ const ToiletDetail = ({detail}: {detail: ToiletDetailDto}) => {
               )}
               <TitleText>{detail.name}</TitleText>
               {detail.address != null && (
-                <>
-                  <SubSectionLabel>{detail.address}</SubSectionLabel>
+                <AddressRow>
+                  <AddressText>{detail.address}</AddressText>
                   <CopyButton
                     elementName="toilet_detail_copy_button"
-                    onPress={onCopy}
-                    style={{marginTop: -4}}>
+                    onPress={onCopy}>
                     <CopyIcon />
                     <CopyText>복사</CopyText>
                   </CopyButton>
-                </>
+                </AddressRow>
               )}
+              {reviewSource && <RegistrantMeta source={reviewSource} />}
               <SectionDivider />
               <TextButtonContainer>
                 <TextButton
@@ -361,6 +370,20 @@ const ToiletPublicDetailSections = ({
   );
 };
 
+// 유저 리뷰 소스의 등록자/등록시점을 PDP 코멘트 박스와 동일한 스타일로 표시한다.
+function RegistrantMeta({source}: {source: ToiletAccessibilityDto}) {
+  const userName = source.registeredUserName ?? '익명';
+  const dateStr = source.createdAt
+    ? dayjs(source.createdAt.value).format('YYYY.MM.DD')
+    : null;
+  return (
+    <RegistrantRow>
+      <RegistrantName>{userName}</RegistrantName>
+      {dateStr != null && <RegistrantDate>{dateStr}</RegistrantDate>}
+    </RegistrantRow>
+  );
+}
+
 function AppBar() {
   const navigation = useNavigation();
 
@@ -531,6 +554,40 @@ const TitleArea = styled.View`
   align-items: flex-start;
   display: flex;
   flex-direction: column;
+`;
+
+const RegistrantRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+`;
+
+const RegistrantName = styled.Text`
+  font-size: 12px;
+  line-height: 16px;
+  font-family: ${() => font.pretendardMedium};
+  color: ${color.brand50};
+`;
+
+const RegistrantDate = styled.Text`
+  font-size: 12px;
+  line-height: 16px;
+  font-family: ${() => font.pretendardRegular};
+  color: ${color.gray60};
+`;
+
+const AddressRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 1;
+`;
+
+const AddressText = styled.Text`
+  font-size: 14px;
+  font-family: ${() => font.pretendardBold};
+  color: ${color.gray70};
+  flex-shrink: 1;
 `;
 
 const CopyButton = styled(SccTouchableOpacity)`


### PR DESCRIPTION
## 개요
화장실 상세에 유저 리뷰 **등록자/등록시점**을 표시하고 관련 안내 문구를 보강한다.

scc-api #114 / scc-server #958 (둘 다 main merge 완료, 서버 DEV/PROD 배포됨)

## 변경
- `ToiletDetailScreen`: 타이틀 영역(이름·주소 아래)에 등록자 닉네임·등록시점을 **1회** 표시 (PDP 코멘트 박스 스타일). 주소+복사 버튼 가로 배치(PDP 동일).
- PDP 빈 상태 문구: '아직 등록된 **장애인** 화장실 정보가 없어요'.
- 리뷰 폼 `ToiletSection`: '장애인 화장실이 있나요?' 아래 안내('휠체어 사용자도 이용 가능한 화장실인 경우에만 있음 선택').
- scc-api submodule → main(#114) + codegen.

## 검증
- `yarn tsc --noEmit`, `yarn lint` green. 네이티브 변경 없음(JS only → OTA 대상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toilet information now displays who registered it and when it was added
  * Added clarifying text for accessibility questions to specify wheelchair-accessible facilities

* **UI Improvements**
  * Refined empty-state messaging to specifically reference wheelchair-accessible toilet information
  * Restructured address section layout in toilet detail view for better presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->