### PR TITLE
fix: 검색 추천 칩을 카테고리 칩 맨 앞으로 이동

### DIFF
--- a/src/screens/SearchScreen/components/SearchHeader/SearchCategory.tsx
+++ b/src/screens/SearchScreen/components/SearchHeader/SearchCategory.tsx
@@ -123,7 +123,6 @@ export default function SearchCategory({
       horizontal={true}
       showsHorizontalScrollIndicator={false}>
       <View style={{flexDirection: 'row', gap: 6}}>
-        {_renderItem({item: SEARCH_CATEGORIES[0]})}
         {recommendations.map(item => (
           <PressableCategory
             key={item.id}
@@ -136,7 +135,7 @@ export default function SearchCategory({
             <CategoryText>{item.name}</CategoryText>
           </PressableCategory>
         ))}
-        {SEARCH_CATEGORIES.slice(1).map(item => _renderItem({item}))}
+        {SEARCH_CATEGORIES.map(item => _renderItem({item}))}
       </View>
     </ScrollView>
   );


### PR DESCRIPTION
## 변경

검색 추천 칩(PlaceSearchRecommendation)이 화장실 칩과 음식점 칩 **사이**에 노출되던 것을 **맨 앞**으로 이동.

`recommendations`를 먼저 렌더하고 그 뒤에 `SEARCH_CATEGORIES` 전체(화장실→음식점→…)를 순서대로 렌더하도록 변경.

- 변경 전: 화장실 → [추천] → 음식점 → …
- 변경 후: [추천] → 화장실 → 음식점 → …

## 검증

- `yarn tsc --noEmit` + `yarn lint` 통과
- 순수 렌더 순서 변경 (데이터/로직/컴포넌트 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and simplification with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->