### PR TITLE
fix(web): 카카오 토큰 교환을 JS키로 (백엔드 aud 일치)

### DIFF
--- a/web/screens/KakaoCallbackScreen.tsx
+++ b/web/screens/KakaoCallbackScreen.tsx
@@ -48,9 +48,13 @@ export default function KakaoCallbackScreen() {
           },
           body: new URLSearchParams({
             grant_type: 'authorization_code',
-            // 웹 전용 Kakao REST API 키 (authorize와 동일해야 함).
+            // 토큰 교환 client_id = authorize 와 동일한 JS키. 카카오 /oauth/token 은
+            // JS키도 client_id 로 허용하며(실측 확인), 이때 발급되는 idToken 의 aud 가
+            // 그 JS키가 된다. 백엔드는 웹 idToken 의 aud 를 web-oauth-client-id(=이 JS키)
+            // 로 검증하므로 일치해야 한다. (REST키로 교환하면 aud=REST키가 되어
+            // 백엔드에서 "audience does not match" 발생 — KOE 아님, 백엔드 검증 실패.)
             client_id:
-              Config.KAKAO_REST_API_KEY ?? '1ae6e66e491cf3bf3041015e235c08e1',
+              Config.KAKAO_JS_KEY ?? '484a369f5c19e5d59aac0d975beabc78',
             redirect_uri: window.location.origin + '/oauth/kakao',
             code: code,
           }),


### PR DESCRIPTION
## 원인 (백엔드 aud 검증)
`KakaoLoginServiceImpl.validateKakaoIdToken`은 idToken `aud`를 `oauth-client-id`(네이티브) **또는** `web-oauth-client-id`(웹)로 검증한다. prod 백엔드 복호화 확인 결과 **`web-oauth-client-id` = JS키 `484a369f`**.

카카오 OIDC는 토큰 교환 client_id 가 idToken의 `aud`가 된다. 기존 웹은 REST키(`54f75f`)로 교환 → aud=REST키 → `web-oauth-client-id`(JS키)와 불일치 → `{"msg":"audience does not match"}`.

## 수정
- `KakaoCallbackScreen` 토큰 교환 client_id 를 `KAKAO_JS_KEY`(484a369f)로. (카카오 `/oauth/token`이 JS키도 허용함을 더미 code 응답 KOE320으로 확인)
- authorize(JS SDK)·token 모두 JS키로 통일. `KAKAO_REST_API_KEY` 제거(서브모듈).

## 검증
- 로컬 `web-dist/bundle.js`: `484a369f` 19×, `54f75f`/`1ae6e66e` 0
- `yarn tsc`/`yarn lint` 0 error
- 실제 로그인 완료는 배포 후 사용자 테스트 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kakao authentication to properly validate OAuth tokens during the login callback process. The token exchange now correctly verifies tokens to meet security requirements and ensure reliable login functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->