### PR TITLE
fix(web): 홈 딥링크 인앱 네비게이션 + checkAuth app-install 오분류

### DIFF
--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 /**
  * build-articles.js — Notion → web.staircrusher.club/articles 정적 생성기 (결정론적, incremental)
  *
@@ -57,14 +58,19 @@ async function api(method, p, body) {
     body: body ? JSON.stringify(body) : undefined,
   });
   const j = await res.json();
-  if (j && j.object === 'error') throw new Error(`Notion ${j.code}: ${j.message}`);
+  if (j && j.object === 'error')
+    throw new Error(`Notion ${j.code}: ${j.message}`);
   return j;
 }
 async function queryAllPages() {
   const out = [];
   let cursor;
   do {
-    const j = await api('POST', `databases/${DB_ID}/query`, cursor ? {start_cursor: cursor} : {});
+    const j = await api(
+      'POST',
+      `databases/${DB_ID}/query`,
+      cursor ? {start_cursor: cursor} : {},
+    );
     out.push(...j.results);
     cursor = j.has_more ? j.next_cursor : undefined;
   } while (cursor);
@@ -169,7 +175,17 @@ function resolveRow(page) {
       faq = [];
     }
   }
-  return {rowId: page.id, contentPageId, isMention: !!mention, title, slug, summary, ogImage, tags, faq};
+  return {
+    rowId: page.id,
+    contentPageId,
+    isMention: !!mention,
+    title,
+    slug,
+    summary,
+    ogImage,
+    tags,
+    faq,
+  };
 }
 
 // ---------- 이미지 다운로드 (presigned 만료 대응) ----------
@@ -179,14 +195,32 @@ async function downloadImage(url, destDir, idx) {
   if (!res.ok) throw new Error(`image ${res.status}`);
   const buf = Buffer.from(await res.arrayBuffer());
   const ct = res.headers.get('content-type') || '';
-  const ext = ct.includes('png') ? 'png' : ct.includes('webp') ? 'webp' : ct.includes('gif') ? 'gif' : ct.includes('svg') ? 'svg' : 'jpg';
+  const ext = ct.includes('png')
+    ? 'png'
+    : ct.includes('webp')
+      ? 'webp'
+      : ct.includes('gif')
+        ? 'gif'
+        : ct.includes('svg')
+          ? 'svg'
+          : 'jpg';
   const name = `img-${idx}.${ext}`;
   fs.writeFileSync(path.join(destDir, name), buf);
   return `assets/${name}`;
 }
 
 // ---------- rich text → inline HTML ----------
-const COLOR = {gray:'#787774',brown:'#9f6b53',orange:'#d9730d',yellow:'#cb912f',green:'#448361',blue:'#337ea9',purple:'#9065b0',pink:'#c14c8a',red:'#d44c47'};
+const COLOR = {
+  gray: '#787774',
+  brown: '#9f6b53',
+  orange: '#d9730d',
+  yellow: '#cb912f',
+  green: '#448361',
+  blue: '#337ea9',
+  purple: '#9065b0',
+  pink: '#c14c8a',
+  red: '#d44c47',
+};
 function renderRich(rich) {
   return (rich || [])
     .map(r => {
@@ -219,7 +253,9 @@ async function renderBlocks(blocks, ctx) {
       let items = '';
       while (i < blocks.length && blocks[i].type === b.type) {
         const it = blocks[i];
-        const inner = it.__children ? await renderBlocks(it.__children, ctx) : '';
+        const inner = it.__children
+          ? await renderBlocks(it.__children, ctx)
+          : '';
         items += `<li>${renderRich(it[it.type].rich_text)}${inner}</li>`;
         i++;
       }
@@ -277,7 +313,9 @@ async function renderBlock(b, ctx) {
     case 'bookmark':
     case 'embed': {
       const url = d.url || '';
-      return url ? `<p><a href="${esc(url)}" rel="noopener">${esc(url)}</a></p>` : '';
+      return url
+        ? `<p><a href="${esc(url)}" rel="noopener">${esc(url)}</a></p>`
+        : '';
     }
     case 'column_list': {
       let cols = '';
@@ -288,13 +326,14 @@ async function renderBlock(b, ctx) {
     case 'table': {
       const rows = b.__children || [];
       const body = rows
-        .map((r, ri) =>
-          `<tr>${r.table_row.cells
-            .map(c => {
-              const tag = ri === 0 && d.has_column_header ? 'th' : 'td';
-              return `<${tag}>${renderRich(c)}</${tag}>`;
-            })
-            .join('')}</tr>`,
+        .map(
+          (r, ri) =>
+            `<tr>${r.table_row.cells
+              .map(c => {
+                const tag = ri === 0 && d.has_column_header ? 'th' : 'td';
+                return `<${tag}>${renderRich(c)}</${tag}>`;
+              })
+              .join('')}</tr>`,
         )
         .join('');
       return `<table>${body}</table>`;
@@ -303,7 +342,9 @@ async function renderBlock(b, ctx) {
     case 'file':
     case 'pdf': {
       const url = d.type === 'external' ? d.external?.url : d.file?.url;
-      return url ? `<p><a href="${esc(url)}" rel="noopener">${esc(t)}: ${esc(url)}</a></p>` : '';
+      return url
+        ? `<p><a href="${esc(url)}" rel="noopener">${esc(t)}: ${esc(url)}</a></p>`
+        : '';
     }
     default:
       if (d.rich_text) return `<p>${renderRich(d.rich_text)}</p>`;
@@ -325,7 +366,8 @@ async function buildArticle(meta, times) {
   const contentHtml = await renderBlocks(blocks, ctx);
 
   // ctx.firstImage = "/articles/<slug>/assets/img-0.ext" (루트절대) → og는 도메인 붙여 절대 URL
-  const ogImageUrl = meta.ogImage || (ctx.firstImage ? `${SITE.baseUrl}${ctx.firstImage}` : '');
+  const ogImageUrl =
+    meta.ogImage || (ctx.firstImage ? `${SITE.baseUrl}${ctx.firstImage}` : '');
 
   const html = renderArticlePage({
     title: meta.title,
@@ -348,13 +390,22 @@ function mergeSitemap(articles) {
   const today = new Date().toISOString().split('T')[0];
   const urls = [
     {loc: `${SITE.baseUrl}/articles`, pr: '0.9'},
-    ...articles.map(a => ({loc: `${SITE.baseUrl}/articles/${a.slug}`, pr: '0.8'})),
+    ...articles.map(a => ({
+      loc: `${SITE.baseUrl}/articles/${a.slug}`,
+      pr: '0.8',
+    })),
   ]
-    .map(u => `  <url><loc>${u.loc}</loc><lastmod>${today}</lastmod><changefreq>weekly</changefreq><priority>${u.pr}</priority></url>`)
+    .map(
+      u =>
+        `  <url><loc>${u.loc}</loc><lastmod>${today}</lastmod><changefreq>weekly</changefreq><priority>${u.pr}</priority></url>`,
+    )
     .join('\n');
   let xml = readFileOr(sp, '');
   if (xml.includes('</urlset>')) {
-    xml = xml.replace(/\s*<url>(?:(?!<\/url>)[\s\S])*?\/articles(?:\/[^<]*)?<\/loc>[\s\S]*?<\/url>/g, '');
+    xml = xml.replace(
+      /\s*<url>(?:(?!<\/url>)[\s\S])*?\/articles(?:\/[^<]*)?<\/loc>[\s\S]*?<\/url>/g,
+      '',
+    );
     xml = xml.replace('</urlset>', `${urls}\n</urlset>`);
   } else {
     xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`;
@@ -405,14 +456,27 @@ async function main() {
   const changed = rows.filter(r => {
     if (FORCE) return true;
     const prev = manifest[r.meta.rowId];
-    return !prev || prev.editedTime !== r.times.editedTime || prev.slug !== r.meta.slug;
+    return (
+      !prev ||
+      prev.editedTime !== r.times.editedTime ||
+      prev.slug !== r.meta.slug
+    );
   });
   const deleted = Object.keys(manifest).filter(id => !current.has(id));
 
-  console.log(`🔎 신규/변경 ${changed.length} · 삭제 ${deleted.length} · 메타미비(스킵) ${needsMeta.length} · 전체 ${pages.length}`);
+  console.log(
+    `🔎 신규/변경 ${changed.length} · 삭제 ${deleted.length} · 메타미비(스킵) ${needsMeta.length} · 전체 ${pages.length}`,
+  );
   if (needsMeta.length)
-    console.log(`   ⚠️ slug/summary 없는 문서(스킬 STEP 2에서 메타 생성·라이트백 필요):\n` +
-      needsMeta.map(n => `      - "${n.meta.title}" (rowId=${n.meta.rowId}, contentPageId=${n.meta.contentPageId})`).join('\n'));
+    console.log(
+      `   ⚠️ slug/summary 없는 문서(스킬 STEP 2에서 메타 생성·라이트백 필요):\n` +
+        needsMeta
+          .map(
+            n =>
+              `      - "${n.meta.title}" (rowId=${n.meta.rowId}, contentPageId=${n.meta.contentPageId})`,
+          )
+          .join('\n'),
+    );
 
   if (DRY) {
     console.log('   (--dry: 변경 없음)');
@@ -443,7 +507,8 @@ async function main() {
   fs.mkdirSync(DIST_ARTICLES, {recursive: true});
   // 공용 에셋(로고 등): web-articles/_assets → web-dist/articles/assets
   const sharedAssets = path.join(SRC_DIR, '_assets');
-  if (fs.existsSync(sharedAssets)) copyDir(sharedAssets, path.join(DIST_ARTICLES, 'assets'));
+  if (fs.existsSync(sharedAssets))
+    copyDir(sharedAssets, path.join(DIST_ARTICLES, 'assets'));
   const published = Object.values(manifest).sort((a, b) =>
     (b.createdTime || '').localeCompare(a.createdTime || ''),
   );
@@ -451,7 +516,10 @@ async function main() {
     const src = path.join(SRC_DIR, a.slug);
     if (fs.existsSync(src)) copyDir(src, path.join(DIST_ARTICLES, a.slug));
   }
-  fs.writeFileSync(path.join(DIST_ARTICLES, 'index.html'), renderListPage(published));
+  fs.writeFileSync(
+    path.join(DIST_ARTICLES, 'index.html'),
+    renderListPage(published),
+  );
   mergeSitemap(published);
   writeRobots();
   writeLlms(published);

--- a/src/hooks/useNavigateWithLocationCheck.tsx
+++ b/src/hooks/useNavigateWithLocationCheck.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useCallback} from 'react';
+import {Platform} from 'react-native';
 
 import {Location} from '@/generated-sources/openapi';
 import LocationConfirmBottomSheet from '@/modals/LocationConfirmBottomSheet';
@@ -29,6 +30,13 @@ export default function useNavigateWithLocationCheck() {
       type,
       onNavigate,
     }: NavigateWithLocationCheckParams) => {
+      // 웹: 위치 확인 모달은 "현장 방문" 전제라 의미가 없고, 대상(정보등록/리뷰)은
+      // 모두 앱 전용이라 어차피 라우트 게이트가 앱 설치를 유도한다. 모달 없이 바로
+      // 진행해 앱 설치 팝업이 위치 모달에 가려지지 않고 즉시 뜨게 한다.
+      if (Platform.OS === 'web') {
+        onNavigate();
+        return;
+      }
       // 거리 체크
       const distance =
         await getDistanceMetersFromCurrentLocation(targetLocation);

--- a/src/screens/HomeScreenV2/sections/MainBannerSection.tsx
+++ b/src/screens/HomeScreenV2/sections/MainBannerSection.tsx
@@ -1,11 +1,5 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {
-  Animated,
-  Dimensions,
-  Easing,
-  Linking,
-  PanResponder,
-} from 'react-native';
+import {Animated, Dimensions, Easing, PanResponder} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 import styled from 'styled-components/native';
 
@@ -17,6 +11,7 @@ import {font} from '@/constant/font';
 import {HomeBannerDto} from '@/generated-sources/openapi';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import useNavigation from '@/navigation/useNavigation';
+import {openAppDeepLink} from '@/utils/appLinkNavigation';
 import {isAppDeepLink} from '@/utils/deepLinkUtils';
 import {useCheckAuth} from '@/utils/checkAuth';
 
@@ -290,7 +285,7 @@ function MainBanner({banner, index, trackView = false}: MainBannerProps) {
     const url = banner.clickPageUrl;
 
     if (isAppDeepLink(url)) {
-      await Linking.openURL(url);
+      openAppDeepLink(url, navigation);
     } else {
       navigation.navigate('Webview', {
         fixedTitle: banner.clickPageTitle,

--- a/src/screens/HomeScreenV2/sections/QuickMenuSection.tsx
+++ b/src/screens/HomeScreenV2/sections/QuickMenuSection.tsx
@@ -1,6 +1,6 @@
 import {useSetAtom} from 'jotai';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {Animated, Dimensions, Easing, Image, Linking} from 'react-native';
+import {Animated, Dimensions, Easing, Image} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 import styled from 'styled-components/native';
 
@@ -13,6 +13,7 @@ import {HomeAnnouncementDto} from '@/generated-sources/openapi';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import useNavigation from '@/navigation/useNavigation';
 import {searchModeAtom} from '@/screens/SearchScreen/atoms';
+import {openAppDeepLink} from '@/utils/appLinkNavigation';
 import {isAppDeepLink} from '@/utils/deepLinkUtils';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -253,7 +254,7 @@ function AnnouncementItem({
     const url = announcement.linkUrl;
 
     if (isAppDeepLink(url)) {
-      await Linking.openURL(url);
+      openAppDeepLink(url, navigation);
     } else {
       navigation.navigate('Webview', {
         fixedTitle: '공지사항',

--- a/src/screens/HomeScreenV2/sections/RecommendedContentSection.tsx
+++ b/src/screens/HomeScreenV2/sections/RecommendedContentSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FlatList, Linking, View} from 'react-native';
+import {FlatList, View} from 'react-native';
 import styled from 'styled-components/native';
 
 import Skeleton from '@/components/Skeleton';
@@ -10,6 +10,7 @@ import {font} from '@/constant/font';
 import {HomeRecommendedContentDto} from '@/generated-sources/openapi';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import useNavigation from '@/navigation/useNavigation';
+import {openAppDeepLink} from '@/utils/appLinkNavigation';
 import {isAppDeepLink} from '@/utils/deepLinkUtils';
 
 const CARD_WIDTH = 130;
@@ -97,7 +98,7 @@ function ContentCard({content, index}: ContentCardProps) {
     const url = content.linkUrl;
 
     if (isAppDeepLink(url)) {
-      await Linking.openURL(url);
+      openAppDeepLink(url, navigation);
     } else {
       navigation.navigate('Webview', {
         fixedTitle: content.title,

--- a/src/screens/HomeScreenV2/sections/StripBannerSection.tsx
+++ b/src/screens/HomeScreenV2/sections/StripBannerSection.tsx
@@ -1,11 +1,5 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {
-  Animated,
-  Dimensions,
-  Easing,
-  Linking,
-  PanResponder,
-} from 'react-native';
+import {Animated, Dimensions, Easing, PanResponder} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 
 import styled from 'styled-components/native';
@@ -17,6 +11,7 @@ import {color} from '@/constant/color';
 import {HomeBannerDto} from '@/generated-sources/openapi';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import useNavigation from '@/navigation/useNavigation';
+import {openAppDeepLink} from '@/utils/appLinkNavigation';
 import {useCheckAuth} from '@/utils/checkAuth';
 import {isAppDeepLink} from '@/utils/deepLinkUtils';
 
@@ -282,7 +277,7 @@ function StripBanner({banner, index, trackView = false}: StripBannerProps) {
     const url = banner.clickPageUrl;
 
     if (isAppDeepLink(url)) {
-      await Linking.openURL(url);
+      openAppDeepLink(url, navigation);
     } else {
       navigation.navigate('Webview', {
         fixedTitle: banner.clickPageTitle,

--- a/src/utils/appLinkNavigation.ts
+++ b/src/utils/appLinkNavigation.ts
@@ -1,0 +1,49 @@
+import {
+  getActionFromState,
+  getStateFromPath,
+  NavigationProp,
+} from '@react-navigation/native';
+import {Linking, Platform} from 'react-native';
+
+import {ScreenParams} from '@/navigation/Navigation.screens';
+import {webLinkingScreensConfig} from '@/navigation/linkingConfig';
+import {stripPrefix} from '@/utils/deepLinkUtils';
+
+// getStateFromPath/getActionFromState 의 Options 타입은 중첩 screens(Main 탭)를
+// 좁게 추론해 literal config 와 안 맞는다. 런타임은 동일 config 로 NavigationContainer
+// linking 이 정상 동작하므로 호출 경계에서만 캐스팅한다.
+type LinkingConfigArg = Parameters<typeof getStateFromPath>[1];
+
+/**
+ * 앱 내부 딥링크(stair-crusher://...)를 연다.
+ *
+ * - 네이티브: OS 딥링크 핸들러로 위임(Linking.openURL → RootScreen 가 처리).
+ * - 웹: 브라우저는 stair-crusher:// 커스텀 스킴을 열 수 없으므로, 경로를 파싱해
+ *   react-navigation 으로 직접 이동한다. (홈 배너/추천콘텐츠/퀵메뉴 등에서
+ *   stair-crusher://place-list/{id} 같은 링크 클릭 시 웹에서도 동작하도록.)
+ *
+ * 호출 전 isAppDeepLink(url) 로 앱 딥링크인지 확인하고 사용한다(외부 http URL 은
+ * 각 호출처가 Webview/새 탭으로 처리).
+ */
+export function openAppDeepLink(
+  url: string,
+  navigation: NavigationProp<ScreenParams>,
+): void {
+  if (Platform.OS !== 'web') {
+    Linking.openURL(url).catch(() => {});
+    return;
+  }
+  const path = stripPrefix(url);
+  if (!path) {
+    return;
+  }
+  const config = webLinkingScreensConfig as unknown as LinkingConfigArg;
+  const state = getStateFromPath(path, config);
+  if (!state) {
+    return;
+  }
+  const action = getActionFromState(state, config);
+  if (action !== undefined) {
+    navigation.dispatch(action);
+  }
+}

--- a/src/utils/checkAuth.ts
+++ b/src/utils/checkAuth.ts
@@ -1,33 +1,26 @@
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAtomValue} from 'jotai';
-import {Platform} from 'react-native';
 
 import {isAnonymousUserAtom} from '@/atoms/Auth';
 import {ScreenParams} from '@/navigation/Navigation.screens';
-import {showAppInstallPrompt} from '@/utils/appInstallPrompt';
 
 export function useCheckAuth() {
   const navigation = useNavigation<NavigationProp<ScreenParams>>();
   const isAnonymousUser = useAtomValue(isAnonymousUserAtom);
 
+  // 3번째 인자(message)는 네이티브 호환용 자리. 웹의 앱 전용(카메라 등록 등) 기능
+  // 진입은 message 가 아니라 RootScreen 라우트 게이트(APP_ONLY 라우트 진입 시 앱 설치
+  // 유도)가 일괄 처리한다. 도움돼요/저장처럼 웹에서 가능한 액션은 그대로 실행한다.
   const checkAuth = (
     onAuth: () => void,
     onFailed?: () => void,
-    message?: string,
+    _message?: string,
   ) => {
     // 비회원이라면 로그인 페이지를 열고 (웹도 로그인 지원 → 웹/네이티브 공통)
     if (isAnonymousUser) {
       onFailed?.();
       console.log('anonymous user! open login');
       navigation.navigate('Login', {asModal: true});
-      return;
-    }
-    // 웹: 로그인했지만 웹에서 불가능한 앱 전용 기능(message 지정 = 정보 등록/리뷰/
-    // 신고 등)은 진입 시도 즉시 앱 설치 유도. 위치 확인 모달/네비게이션까지 가지
-    // 않고 버튼 누르자마자 뜬다. (RootScreen 라우트 게이트는 직접 URL 진입 backstop.)
-    if (Platform.OS === 'web' && message) {
-      onFailed?.();
-      showAppInstallPrompt(message);
       return;
     }
     // 회원이라면 주어진 콜백을 실행


### PR DESCRIPTION
## 1) 홈 딥링크가 웹에서 동작 안 함
홈 배너/추천콘텐츠/퀵메뉴는 `if (isAppDeepLink(url)) Linking.openURL(url)` 인데, 웹 브라우저는 `stair-crusher://` 커스텀 스킴을 못 연다 → '저장리스트' 클릭(→ stair-crusher://place-list) 등이 무반응.
- `openAppDeepLink(url, navigation)` 유틸 신설: 웹에선 `stripPrefix → getStateFromPath → getActionFromState → navigation.dispatch`(MainScreen deferred-deeplink 와 동일 패턴, webLinkingScreensConfig 사용). 네이티브는 기존 `Linking.openURL` 유지.
- 4개 홈 섹션(Recommended/Strip/QuickMenu/MainBanner)에 적용.

## 2) 도움돼요/저장이 잘못 app-only 처리됨
`checkAuth(_,_,message)` 에 message 가 있으면 웹에서 무조건 앱설치 팝업을 띄우던 휴리스틱이 있었는데, 도움돼요(upvote)·저장(favorite)은 웹에서 가능한 액션이라 잘못 막혔다.
- checkAuth 의 web message→app-install 분기 제거. 앱 전용(카메라 등록/리뷰 등)은 RootScreen 라우트 게이트(APP_ONLY 라우트 진입 시 앱설치 유도)가 일괄 처리.
- `useNavigateWithLocationCheck`: 웹은 위치 확인 모달 skip(앱 전용 화면 진입 시 앱설치 팝업이 위치 모달에 가려지지 않고 즉시 뜨도록).

## 검증
- 딥링크 변환: `stair-crusher://place-list/{id}` → `NAVIGATE PlaceListDetail{placeListId}` 액션 생성 확인. `/place-list/:id` → PlaceListDetail 웹 라우트 매핑 확인.
- checkAuth: app-install 분기 제거(구조적). 앱 전용은 라우트 게이트가 처리.
- `yarn tsc`/`yarn lint` 0 error.

부수: `scripts/build-articles.js` eslint-env node(기존 Buffer no-undef) 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep link routing for banners, announcements, and content across the app.
  * Optimized web platform navigation to skip distance verification checks.

* **Chores**
  * Code formatting and linting improvements to build scripts.
  * Updated authentication flow to remove web-specific install prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->