### PR TITLE
fix(web): 웹뷰 뒤로가기 무한로딩 / 배너 authGuard / 튜토리얼 / 로그인 복귀

### DIFF
--- a/src/screens/HomeScreenV2/HomeScreenV2.tsx
+++ b/src/screens/HomeScreenV2/HomeScreenV2.tsx
@@ -119,6 +119,10 @@ const HomeScreenV2 = ({navigation}: any) => {
   // 미가입자에게만 노출 (가입자에게는 TutorialIntroPopup으로 외출 튜토리얼 유도).
   // Deferred deep link가 있으면 이번에는 tutorial 스킵 (hasShownHomeTutorial은 세팅하지 않아 다음에 정상 노출).
   const [needsPlaceSearchTutorial] = useState(() => {
+    // 웹에서는 장소 검색 튜토리얼 오버레이를 띄우지 않는다(플로우가 어색함).
+    if (Platform.OS === 'web') {
+      return false;
+    }
     if (getDeferredDeepLinkUrl()) {
       return false;
     }

--- a/src/screens/HomeScreenV2/sections/MainBannerSection.tsx
+++ b/src/screens/HomeScreenV2/sections/MainBannerSection.tsx
@@ -1,5 +1,11 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {Animated, Dimensions, Easing, PanResponder} from 'react-native';
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  PanResponder,
+  Platform,
+} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 import styled from 'styled-components/native';
 
@@ -299,7 +305,10 @@ function MainBanner({banner, index, trackView = false}: MainBannerProps) {
       elementName="home_v2_main_banner"
       logParams={{banner_key: banner.loggingKey, index}}
       trackView={trackView}
-      onPress={() => checkAuth(openBanner)}>
+      onPress={() =>
+        // 웹: 배너는 비회원도 그냥 볼 수 있게 authGuard 없이 바로 연다.
+        Platform.OS === 'web' ? openBanner() : checkAuth(openBanner)
+      }>
       <BannerContainer>
         <SccRemoteImage
           imageUrl={banner.imageUrl}

--- a/src/screens/HomeScreenV2/sections/StripBannerSection.tsx
+++ b/src/screens/HomeScreenV2/sections/StripBannerSection.tsx
@@ -1,5 +1,11 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {Animated, Dimensions, Easing, PanResponder} from 'react-native';
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  PanResponder,
+  Platform,
+} from 'react-native';
 import {useIsFocused} from '@react-navigation/native';
 
 import styled from 'styled-components/native';
@@ -291,7 +297,10 @@ function StripBanner({banner, index, trackView = false}: StripBannerProps) {
       elementName="home_v2_strip_banner"
       logParams={{banner_key: banner.loggingKey, index}}
       trackView={trackView}
-      onPress={() => checkAuth(openBanner)}>
+      onPress={() =>
+        // 웹: 배너는 비회원도 그냥 볼 수 있게 authGuard 없이 바로 연다.
+        Platform.OS === 'web' ? openBanner() : checkAuth(openBanner)
+      }>
       <BannerContainer>
         <SccRemoteImage
           imageUrl={banner.imageUrl}

--- a/src/screens/WebViewScreen.web.tsx
+++ b/src/screens/WebViewScreen.web.tsx
@@ -19,8 +19,9 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     const resolved = resolveTemplatedExternalUrl(url, {userId: userInfo?.id});
     if (resolved.startsWith(WEB_ORIGIN)) {
       // 같은 origin → 그대로 이동(리다이렉트). 현재 origin이 web.staircrusher.club이면
-      // 동일 출처 내 경로 이동이 된다.
-      window.location.assign(resolved);
+      // 동일 출처 내 경로 이동이 된다. replace 로 /webview 히스토리 엔트리를 덮어써
+      // 목적지에서 뒤로 가기 시 /webview 로 돌아와 effect 가 재실행(무한 로딩)되는 걸 막는다.
+      window.location.replace(resolved);
       return;
     }
     // 외부 링크 → 새 탭. 그 후 빈 Webview 라우트에 머무르지 않도록 뒤로.

--- a/src/utils/checkAuth.ts
+++ b/src/utils/checkAuth.ts
@@ -1,5 +1,6 @@
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {useAtomValue} from 'jotai';
+import {Platform} from 'react-native';
 
 import {isAnonymousUserAtom} from '@/atoms/Auth';
 import {ScreenParams} from '@/navigation/Navigation.screens';
@@ -20,6 +21,18 @@ export function useCheckAuth() {
     if (isAnonymousUser) {
       onFailed?.();
       console.log('anonymous user! open login');
+      // 웹: 카카오 로그인은 풀 페이지 리다이렉트라 모달 네비 스택이 소실된다.
+      // 로그인 후 원래 페이지로 돌아오도록 현재 경로를 redirect 로 넘긴다.
+      if (Platform.OS === 'web') {
+        const loc = (
+          globalThis as {location?: {pathname?: string; search?: string}}
+        ).location;
+        const current = loc
+          ? (loc.pathname ?? '') + (loc.search ?? '')
+          : undefined;
+        navigation.navigate('Login', {asModal: true, redirect: current});
+        return;
+      }
       navigation.navigate('Login', {asModal: true});
       return;
     }

--- a/web/mocks/kakao-login.js
+++ b/web/mocks/kakao-login.js
@@ -18,11 +18,24 @@
 export const login = () => {
   const origin = window.location.origin;
   const redirectUri = `${origin}/oauth/kakao`;
-  // 로그인 후 돌아갈 곳: ?redirect= 가 있으면 그 경로, 없으면 홈('/').
-  // (로그인 화면 경로 '/login' 으로 되돌아가지 않도록 — next param 없으면 홈)
+  // 로그인 후 돌아갈 곳 결정 (우선순위):
+  //   1) ?redirect= 쿼리 (checkAuth / 라우트 게이트가 원래 경로를 넘김)
+  //   2) 현재 경로 (모달 로그인이 URL 을 /login 으로 안 바꾼 경우 — 사용자가 있던 페이지)
+  //   3) 홈('/')
+  // 단, 인증 경로(/login·/signup·/oauth)로는 절대 되돌아가지 않는다.
+  const isAuthPath = p =>
+    p.startsWith('/login') ||
+    p.startsWith('/signup') ||
+    p.startsWith('/oauth');
   const params = new URLSearchParams(window.location.search);
   const redirect = params.get('redirect');
-  const dest = redirect && redirect.startsWith('/') ? redirect : '/';
+  const currentPath = window.location.pathname + window.location.search;
+  let dest = '/';
+  if (redirect && redirect.startsWith('/') && !isAuthPath(redirect)) {
+    dest = redirect;
+  } else if (currentPath.startsWith('/') && !isAuthPath(currentPath)) {
+    dest = currentPath;
+  }
   const state = encodeURIComponent(dest);
 
   const Kakao = globalThis.Kakao;


### PR DESCRIPTION
웹 E2E 중 발견된 버그 4건 수정. **모두 웹 전용** — 네이티브 동작은 `Platform.OS === 'web'` 가드로 불변.

## 수정 내용
1. **웹뷰 뒤로가기 무한로딩**: 홈에서 `web.staircrusher.club` 목적지 웹뷰는 같은 origin 리다이렉트인데, `window.location.assign` 이 `/webview` 히스토리 엔트리를 남겨 뒤로가기 시 effect 가 재실행돼 무한 로딩에 빠짐 → `replace` 로 변경해 엔트리를 덮어씀.
2. **배너 authGuard 제거(웹)**: 비회원이 홈 배너를 클릭하면 로그인 가드가 걸렸음. 배너는 그냥 봐도 되므로 웹에서는 가드 없이 바로 열도록.
3. **튜토리얼 오버레이 비노출(웹)**: 장소검색 튜토리얼 오버레이가 웹에서 플로우가 어색 → 소스(`needsPlaceSearchTutorial`)에서 웹은 항상 false.
4. **로그인 후 원래 페이지 복귀**: PDP 등에서 authGuard 로 카카오 로그인 시 홈으로 가버림. 카카오는 풀 페이지 리다이렉트라 모달 네비 스택이 소실되기 때문. `checkAuth`(web)가 현재 경로를 `redirect` 로 넘기고, 카카오 mock 이 `redirect 쿼리 → 현재 경로 → 홈` 순으로 복귀지를 결정.

## 검증
- `yarn tsc --noEmit` 0 error
- `yarn lint` 0 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled place-search tutorial overlay on web platforms
  * Banner interactions on web now skip authentication verification
  * Improved browser navigation history handling for same-origin URLs
  * Enhanced authentication redirect flow for web to preserve intended destination
  * Optimized login redirect logic to prevent redirect loops

<!-- end of auto-generated comment: release notes by coderabbit.ai -->