### PR TITLE
fix(devtool): API 로그를 요청당 1 row로 병합

### DIFF
--- a/src/components/DevTool/devToolEventStore.ts
+++ b/src/components/DevTool/devToolEventStore.ts
@@ -45,19 +45,37 @@ export const convertToDevToolLoggedEvent = (
 };
 
 // Helper to add API log to store
+// 같은 id가 이미 있으면(요청 시 추가된 PENDING row) 새 row를 쌓지 않고 그 자리에서
+// 응답/에러 정보를 병합한다 → 요청 1건당 row 1개 (PENDING → 결과로 갱신).
 export const convertToDevToolAPILog = (
   apiLogs: DevToolAPILog[],
-  newLog: Omit<DevToolAPILog, 'id' | 'timestamp'> & {timestamp?: number},
+  newLog: Omit<DevToolAPILog, 'id' | 'timestamp'> & {
+    id?: string;
+    timestamp?: number;
+  },
 ): DevToolAPILog[] => {
+  if (newLog.id) {
+    const index = apiLogs.findIndex(l => l.id === newLog.id);
+    if (index >= 0) {
+      const merged = [...apiLogs];
+      merged[index] = {
+        ...merged[index],
+        ...newLog,
+        id: merged[index].id,
+        timestamp: merged[index].timestamp,
+      };
+      return merged;
+    }
+  }
+
   const log: DevToolAPILog = {
     ...newLog,
-    id: `${Date.now()}-${Math.random()}`,
-    timestamp: newLog.timestamp || Date.now(),
+    id: newLog.id ?? `${Date.now()}-${Math.random()}`,
+    timestamp: newLog.timestamp ?? Date.now(),
   };
 
   // Keep only last 100 API logs
-  const updatedLogs = [log, ...apiLogs].slice(0, 100);
-  return updatedLogs;
+  return [log, ...apiLogs].slice(0, 100);
 };
 
 // DevTool API tracking helpers
@@ -70,7 +88,10 @@ export const initializeAPILoggingDevTool = (setter: (apiLogs: any) => void) => {
 };
 
 const trackAPI = (
-  apiLog: Omit<DevToolAPILog, 'id' | 'timestamp'> & {timestamp?: number},
+  apiLog: Omit<DevToolAPILog, 'id' | 'timestamp'> & {
+    id?: string;
+    timestamp?: number;
+  },
 ) => {
   if (shouldShowDevTool() && apiLoggingEnabled && setAPILogs) {
     setAPILogs((prev: any) => convertToDevToolAPILog(prev, apiLog));

--- a/src/utils/DebugUtils.ts
+++ b/src/utils/DebugUtils.ts
@@ -18,6 +18,9 @@ export const logDebug = (...args: any[]) => {
 
 // Store for tracking request timing
 const requestTimestamps = new Map<string, number>();
+// 요청별 DevTool 로그 id — 요청 시 PENDING row를 만들고, 응답/에러에서 같은 id로 갱신해
+// row가 2개로 쌓이지 않게 한다.
+const requestLogIds = new Map<string, string>();
 
 export const logRequest = (config: InternalAxiosRequestConfig) => {
   if (!isAPILoggingEnabled) return;
@@ -25,9 +28,11 @@ export const logRequest = (config: InternalAxiosRequestConfig) => {
   const {method, url, data, headers} = config;
   const requestKey = `${method}-${url}`;
   const timestamp = Date.now();
+  const logId = `${timestamp}-${Math.random()}`;
 
   // Store timestamp for duration calculation
   requestTimestamps.set(requestKey, timestamp);
+  requestLogIds.set(requestKey, logId);
 
   console.log('🚀 API Request:', {
     method: method?.toUpperCase(),
@@ -39,6 +44,7 @@ export const logRequest = (config: InternalAxiosRequestConfig) => {
   // Send to DevTool if enabled
   if (shouldShowDevTool()) {
     logAPICall({
+      id: logId,
       method: method?.toUpperCase() || 'UNKNOWN',
       url: url || '',
       requestHeaders: headers as Record<string, string>,
@@ -56,9 +62,11 @@ export const logResponse = (response: AxiosResponse) => {
   const endTime = Date.now();
   const startTime = requestTimestamps.get(requestKey);
   const duration = startTime ? endTime - startTime : undefined;
+  const logId = requestLogIds.get(requestKey);
 
   // Clean up timestamp
   requestTimestamps.delete(requestKey);
+  requestLogIds.delete(requestKey);
 
   console.log('✅ API Response:', {
     status,
@@ -69,6 +77,7 @@ export const logResponse = (response: AxiosResponse) => {
   // Send to DevTool if enabled
   if (shouldShowDevTool()) {
     logAPICall({
+      id: logId,
       method: config.method?.toUpperCase() || 'UNKNOWN',
       url: config.url || '',
       requestHeaders: config.headers as Record<string, string>,
@@ -90,9 +99,11 @@ export const logError = (error: unknown, context?: string) => {
     const endTime = Date.now();
     const startTime = requestTimestamps.get(requestKey);
     const duration = startTime ? endTime - startTime : undefined;
+    const logId = requestLogIds.get(requestKey);
 
     // Clean up timestamp
     requestTimestamps.delete(requestKey);
+    requestLogIds.delete(requestKey);
 
     let errorTitle = '';
 
@@ -113,6 +124,7 @@ export const logError = (error: unknown, context?: string) => {
     // Send to DevTool if enabled
     if (shouldShowDevTool()) {
       logAPICall({
+        id: logId,
         method: error.config?.method?.toUpperCase() || 'UNKNOWN',
         url: error.config?.url || '',
         requestHeaders: error.config?.headers as Record<string, string>,


### PR DESCRIPTION
## 문제
DevTool API 로깅이 요청 시 PENDING row, 응답 시 결과 row를 **각각 append**해서 요청 1건당 row가 2개씩 쌓였다.

## 변경
- `DebugUtils.ts`: 요청별 stable `logId`를 발급(`requestLogIds` 맵)해 PENDING row를 만들고, 응답/에러에서 같은 `logId`를 전달.
- `devToolEventStore.ts`: `convertToDevToolAPILog`가 같은 `id`가 있으면 새 row를 쌓지 않고 그 자리에서 in-place 병합 → 요청당 row 1개 (PENDING → 결과로 갱신). `id`가 없으면 기존대로 새 row.

검색 기능과 무관한 devtool 개선이라 별도 PR로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)