### PR TITLE
feat: 장소 카테고리 표시에 displayCategoryName 우선 적용

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -4244,6 +4244,12 @@ export interface Place {
      */
     'category'?: PlaceCategoryDto;
     /**
+     * vendor 원본 데이터에서 추출한 세부 카테고리명(e.g. \"육류,고기\"). 없으면 category 기반 라벨로 표시한다.
+     * @type {string}
+     * @memberof Place
+     */
+    'displayCategoryName'?: string;
+    /**
      * 내가 즐겨찾기한 점포인지 여부.
      * @type {boolean}
      * @memberof Place

--- a/src/models/Place.ts
+++ b/src/models/Place.ts
@@ -1,4 +1,5 @@
 import type {Place} from '@/generated-sources/openapi';
+import {PlaceCategoryDto} from '@/generated-sources/openapi';
 
 /**
  * 리뷰 등록이 가능한 카테고리인지 확인합니다.
@@ -6,4 +7,56 @@ import type {Place} from '@/generated-sources/openapi';
  */
 export function isReviewEnabled(_place: Place | undefined): boolean {
   return true;
+}
+
+/**
+ * 장소에 표시할 카테고리 라벨을 반환합니다.
+ * vendor 원본에서 추출한 세부 카테고리명(displayCategoryName)이 있으면 우선 사용하고,
+ * 없으면 category enum 기반 라벨로 fallback 합니다.
+ */
+export function getPlaceCategoryLabel(place: Place): string {
+  return place.displayCategoryName || getCategoryText(place.category);
+}
+
+function getCategoryText(category?: PlaceCategoryDto): string {
+  switch (category) {
+    case PlaceCategoryDto.Restaurant:
+      return '식당';
+    case PlaceCategoryDto.Cafe:
+      return '카페';
+    case PlaceCategoryDto.Accomodation:
+      return '숙소';
+    case PlaceCategoryDto.Market:
+      return '시장';
+    case PlaceCategoryDto.ConvenienceStore:
+      return '편의점';
+    case PlaceCategoryDto.Kindergarten:
+      return '유치원';
+    case PlaceCategoryDto.School:
+      return '학교';
+    case PlaceCategoryDto.Academy:
+      return '학원';
+    case PlaceCategoryDto.ParkingLot:
+      return '주차장';
+    case PlaceCategoryDto.GasStation:
+      return '주유소';
+    case PlaceCategoryDto.SubwayStation:
+      return '지하철역';
+    case PlaceCategoryDto.Bank:
+      return '은행';
+    case PlaceCategoryDto.CulturalFacilities:
+      return '문화시설';
+    case PlaceCategoryDto.Agency:
+      return '대행사';
+    case PlaceCategoryDto.PublicOffice:
+      return '공공기관';
+    case PlaceCategoryDto.Attraction:
+      return '관광명소';
+    case PlaceCategoryDto.Hospital:
+      return '병원';
+    case PlaceCategoryDto.Pharmacy:
+      return '약국';
+    default:
+      return '';
+  }
 }

--- a/src/screens/SearchScreen/components/SearchItemCard.tsx
+++ b/src/screens/SearchScreen/components/SearchItemCard.tsx
@@ -17,14 +17,13 @@ import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 import {
   BbucleRoadAccessibilityDtoBbucleRoadTypeEnum,
-  PlaceCategoryDto,
   PlaceListItem,
 } from '@/generated-sources/openapi';
 import {usePlaceDetailScreenName} from '@/hooks/useFeatureFlags';
 import {useToggleFavoritePlace} from '@/hooks/useToggleFavoritePlace';
 import useNavigateWithLocationCheck from '@/hooks/useNavigateWithLocationCheck';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
-import {isReviewEnabled} from '@/models/Place';
+import {getPlaceCategoryLabel, isReviewEnabled} from '@/models/Place';
 import useNavigation from '@/navigation/useNavigation';
 import ImageList from '@/screens/PlaceDetailScreen/components/PlaceDetailImageList';
 import LGButton from '@/screens/SearchScreen/components/LGButton';
@@ -366,10 +365,7 @@ function SearchItemCard({
           <TitleArea>
             <TextWrapper>
               <TitleText>{item.place.name}</TitleText>
-              <CategoryText>
-                {item.place.displayCategoryName ||
-                  getCategoryText(item.place.category)}
-              </CategoryText>
+              <CategoryText>{getPlaceCategoryLabel(item.place)}</CategoryText>
             </TextWrapper>
             <LocationBox>
               <DistanceText>{distanceText}</DistanceText>
@@ -457,49 +453,6 @@ function SearchItemCard({
       {LocationConfirmModal}
     </LogParamsProvider>
   );
-}
-
-function getCategoryText(category?: PlaceCategoryDto) {
-  switch (category) {
-    case PlaceCategoryDto.Restaurant:
-      return '식당';
-    case PlaceCategoryDto.Cafe:
-      return '카페';
-    case PlaceCategoryDto.Accomodation:
-      return '숙소';
-    case PlaceCategoryDto.Market:
-      return '시장';
-    case PlaceCategoryDto.ConvenienceStore:
-      return '편의점';
-    case PlaceCategoryDto.Kindergarten:
-      return '유치원';
-    case PlaceCategoryDto.School:
-      return '학교';
-    case PlaceCategoryDto.Academy:
-      return '학원';
-    case PlaceCategoryDto.ParkingLot:
-      return '주차장';
-    case PlaceCategoryDto.GasStation:
-      return '주유소';
-    case PlaceCategoryDto.SubwayStation:
-      return '지하철역';
-    case PlaceCategoryDto.Bank:
-      return '은행';
-    case PlaceCategoryDto.CulturalFacilities:
-      return '문화시설';
-    case PlaceCategoryDto.Agency:
-      return '대행사';
-    case PlaceCategoryDto.PublicOffice:
-      return '공공기관';
-    case PlaceCategoryDto.Attraction:
-      return '관광명소';
-    case PlaceCategoryDto.Hospital:
-      return '병원';
-    case PlaceCategoryDto.Pharmacy:
-      return '약국';
-    default:
-      return '';
-  }
 }
 
 const InfoArea = styled.View`

--- a/src/screens/SearchScreen/components/SearchItemCard.tsx
+++ b/src/screens/SearchScreen/components/SearchItemCard.tsx
@@ -367,7 +367,8 @@ function SearchItemCard({
             <TextWrapper>
               <TitleText>{item.place.name}</TitleText>
               <CategoryText>
-                {getCategoryText(item.place.category)}
+                {item.place.displayCategoryName ||
+                  getCategoryText(item.place.category)}
               </CategoryText>
             </TextWrapper>
             <LocationBox>

--- a/src/screens/SearchScreen/components/SearchItemCard.web.tsx
+++ b/src/screens/SearchScreen/components/SearchItemCard.web.tsx
@@ -284,7 +284,8 @@ function SearchItemCard({
             <TextWrapper>
               <TitleText>{item.place.name}</TitleText>
               <CategoryText>
-                {getCategoryText(item.place.category)}
+                {item.place.displayCategoryName ||
+                  getCategoryText(item.place.category)}
               </CategoryText>
             </TextWrapper>
             <LocationBox>

--- a/src/screens/SearchScreen/components/SearchItemCard.web.tsx
+++ b/src/screens/SearchScreen/components/SearchItemCard.web.tsx
@@ -12,9 +12,9 @@ import {font} from '@/constant/font';
 import {
   BbucleRoadAccessibilityDtoBbucleRoadTypeEnum,
   PlaceListItem,
-  PlaceCategoryDto,
 } from '@/generated-sources/openapi';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
+import {getPlaceCategoryLabel} from '@/models/Place';
 import ImageList from '@/screens/PlaceDetailScreen/components/PlaceDetailImageList';
 import ScoreLabel from '@/screens/SearchScreen/components/ScoreLabel';
 import {distanceInMeter, prettyFormatMeter} from '@/utils/DistanceUtils';
@@ -283,10 +283,7 @@ function SearchItemCard({
           <TitleArea>
             <TextWrapper>
               <TitleText>{item.place.name}</TitleText>
-              <CategoryText>
-                {item.place.displayCategoryName ||
-                  getCategoryText(item.place.category)}
-              </CategoryText>
+              <CategoryText>{getPlaceCategoryLabel(item.place)}</CategoryText>
             </TextWrapper>
             <LocationBox>
               <DistanceText>{distanceText}</DistanceText>
@@ -316,49 +313,6 @@ function SearchItemCard({
       </Container>
     </LogParamsProvider>
   );
-}
-
-function getCategoryText(category?: PlaceCategoryDto) {
-  switch (category) {
-    case PlaceCategoryDto.Restaurant:
-      return '식당';
-    case PlaceCategoryDto.Cafe:
-      return '카페';
-    case PlaceCategoryDto.Accomodation:
-      return '숙소';
-    case PlaceCategoryDto.Market:
-      return '시장';
-    case PlaceCategoryDto.ConvenienceStore:
-      return '편의점';
-    case PlaceCategoryDto.Kindergarten:
-      return '유치원';
-    case PlaceCategoryDto.School:
-      return '학교';
-    case PlaceCategoryDto.Academy:
-      return '학원';
-    case PlaceCategoryDto.ParkingLot:
-      return '주차장';
-    case PlaceCategoryDto.GasStation:
-      return '주유소';
-    case PlaceCategoryDto.SubwayStation:
-      return '지하철역';
-    case PlaceCategoryDto.Bank:
-      return '은행';
-    case PlaceCategoryDto.CulturalFacilities:
-      return '문화시설';
-    case PlaceCategoryDto.Agency:
-      return '대행사';
-    case PlaceCategoryDto.PublicOffice:
-      return '공공기관';
-    case PlaceCategoryDto.Attraction:
-      return '관광명소';
-    case PlaceCategoryDto.Hospital:
-      return '병원';
-    case PlaceCategoryDto.Pharmacy:
-      return '약국';
-    default:
-      return '';
-  }
 }
 
 // Styled components from original


### PR DESCRIPTION
## 개요

검색 결과 카드에서 `place.displayCategoryName`이 있으면 우선 표시하고, 없을 때만 기존 `category` 기반 라벨("식당"·"카페" 등)로 fallback 한다. 이를 통해 "국수"·"육류,고기"·"약국"처럼 더 구체적인 카테고리를 보여준다.

## 변경

- codegen: `Place.displayCategoryName` 타입 생성
- `SearchItemCard.tsx` / `SearchItemCard.web.tsx`: `item.place.displayCategoryName || getCategoryText(item.place.category)`

## 의존
- scc-server: https://github.com/Stair-Crusher-Club/scc-server/pull/972

## 검증
- `yarn tsc --noEmit` 0 error, `yarn lint` 0 error
- ⚠️ 미실행: 실기기 E2E 시각 검증 (별도 진행 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search result cards can now show a more descriptive category label when available from enriched vendor data.
  * Places may include an optional display category name to improve how categories are presented.

* **Bug Fixes**
  * Category labels now correctly prefer the new display category name when present, and reliably fall back to the existing category mapping when it isn’t.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->