### PR TITLE
feat(search): 저장리스트 추천 칩 글로우 강조

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.60.0",
     "react-native": "0.80.0",
+    "react-native-animated-glow": "^3.1.0",
     "react-native-codegen": "^0.70.7",
     "react-native-compressor": "^1.16.0",
     "react-native-config": "^1.5.5",

--- a/src/screens/SearchScreen/components/SearchHeader/SearchCategory.tsx
+++ b/src/screens/SearchScreen/components/SearchHeader/SearchCategory.tsx
@@ -2,9 +2,9 @@ import {keepPreviousData, useQuery} from '@tanstack/react-query';
 import {useAtomValue} from 'jotai';
 import React from 'react';
 import {Image, ScrollView, View} from 'react-native';
+import AnimatedGlow, {type PresetConfig} from 'react-native-animated-glow';
 import styled from 'styled-components/native';
 
-import GradientBorderPill from '@/components/GradientBorderPill';
 import {SccTouchableOpacity} from '@/components/SccTouchableOpacity';
 import {color} from '@/constant/color.ts';
 import {font} from '@/constant/font.ts';
@@ -127,31 +127,26 @@ export default function SearchCategory({
               placeListId: item.placeListId,
             }}
             onPress={() => handleRecommendationChipPress(item)}>
-            {/* drop-shadow는 GradientBorderPill의 outerStyle에 — overflow:hidden 밖 */}
-            <GradientBorderPill
-              borderWidth={1.5}
-              gradientId="chip-gradient"
-              outerStyle={{
-                shadowColor: color.black,
-                shadowOpacity: 0.25,
-                shadowRadius: 1.5,
-                shadowOffset: {width: 0, height: 0},
-                elevation: 2,
-              }}
-              contentStyle={{
-                paddingTop: 8,
-                paddingBottom: 8,
-                paddingLeft: 10,
-                paddingRight: 16,
-                gap: 2,
-              }}>
-              <Image
-                source={locationPinImage}
-                style={{width: 20, height: 20}}
-                resizeMode="contain"
-              />
-              <RecommendationChipText>{item.name}</RecommendationChipText>
-            </GradientBorderPill>
+            {/* 발견성 강화: Figma 블랙 칩 + react-native-animated-glow 빛나는 테두리(항상 ON) */}
+            <AnimatedGlow preset={RECOMMENDATION_CHIP_GLOW}>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  paddingTop: 8,
+                  paddingBottom: 8,
+                  paddingLeft: 10,
+                  paddingRight: 16,
+                  gap: 2,
+                }}>
+                <Image
+                  source={locationPinImage}
+                  style={{width: 20, height: 20}}
+                  resizeMode="contain"
+                />
+                <RecommendationChipText>{item.name}</RecommendationChipText>
+              </View>
+            </AnimatedGlow>
           </SccTouchableOpacity>
         );
       }
@@ -214,10 +209,75 @@ const CategoryText = styled.Text`
 const RecommendationChipText = styled.Text`
   font-size: 14px; /* Figma: 카테고리 칩과 동일 14px */
   font-family: ${font.pretendardMedium};
-  color: ${color.gray90};
+  color: ${color.white}; /* Figma 블랙 칩 위 흰 텍스트 */
   line-height: 20px;
   letter-spacing: -0.28px;
 `;
+
+// 저장리스트 추천 칩 글로우 — react-native-animated-glow "Confirmation Green" 프리셋 기반.
+// (Slack 디자인 협의: 시인성↑ + 고대비를 위한 '블랙 버튼 + 빛나는 테두리' 조합)
+// 기본 프리셋에서 General borderColor만 아래 3색으로 교체하고,
+// backgroundColor는 Figma 블랙 칩(#16181C)으로 지정. 애니메이션은 항상(default 상태) 동작.
+// borderColor: #1EFF00(green) → #0093FF(blue) → #00FFFA(cyan)
+const RECOMMENDATION_CHIP_GLOW: PresetConfig = {
+  metadata: {
+    name: 'Recommendation Chip Glow',
+    textColor: '#FFFFFF',
+    category: 'Custom',
+    tags: ['recommendation', 'chip'],
+  },
+  states: [
+    {
+      name: 'default',
+      preset: {
+        cornerRadius: 20,
+        outlineWidth: 2,
+        borderColor: ['#1EFF00', '#0093FF', '#00FFFA'],
+        backgroundColor: '#16181C',
+        animationSpeed: 2,
+        borderSpeedMultiplier: 1,
+        glowLayers: [
+          {
+            glowPlacement: 'behind',
+            colors: ['#0fff47', 'rgba(255, 241, 0, 1)', '#00d646'],
+            glowSize: 10,
+            opacity: 0.05,
+            speedMultiplier: 1,
+            coverage: 1,
+            relativeOffset: 0,
+          },
+          {
+            glowPlacement: 'behind',
+            colors: ['#0fff47', 'rgba(255, 241, 0, 1)', '#00d646'],
+            glowSize: 4,
+            opacity: 0.1,
+            speedMultiplier: 1,
+            coverage: 1,
+            relativeOffset: 0,
+          },
+          {
+            glowPlacement: 'inside',
+            colors: ['rgba(99, 255, 0, 1)', 'rgba(180, 255, 65, 1)'],
+            glowSize: [0, 20],
+            opacity: 0.02,
+            speedMultiplier: 1,
+            coverage: 0.3,
+            relativeOffset: 0,
+          },
+          {
+            glowPlacement: 'over',
+            colors: ['rgba(135, 255, 0, 1)', 'rgba(255, 248, 196, 1)'],
+            glowSize: [0, 1],
+            opacity: 0.5,
+            speedMultiplier: 1,
+            coverage: 0.4,
+            relativeOffset: 0,
+          },
+        ],
+      },
+    },
+  ],
+};
 
 type SearchCategoryItem = {
   category: keyof typeof Icons;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8618,6 +8618,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canvaskit-wasm@npm:0.39.1":
+  version: 0.39.1
+  resolution: "canvaskit-wasm@npm:0.39.1"
+  dependencies:
+    "@webgpu/types": "npm:0.1.21"
+  checksum: 10c0/0ae60ae5c430aaa88152f3a20f40fc9a6debb15714a2ce1bdebef93005ec6d5e72e0316b91ab637f50aab220dd8694101abac497209bcf16788d00db78f5a898
+  languageName: node
+  linkType: hard
+
 "canvaskit-wasm@npm:0.41.0":
   version: 0.41.0
   resolution: "canvaskit-wasm@npm:0.41.0"
@@ -16047,6 +16056,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-animated-glow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "react-native-animated-glow@npm:3.1.0"
+  dependencies:
+    canvaskit-wasm: "npm:0.39.1"
+  peerDependencies:
+    "@shopify/react-native-skia": ">=0.2.0 || ^2.0.0-next"
+    react: "*"
+    react-native: "*"
+    react-native-gesture-handler: ">=2.0.0"
+    react-native-reanimated: ">=3.0.0"
+  checksum: 10c0/1dd21151b4f07047914890d5a34da258ff9bc83c5a1cb94e0b0c365ee3e432057a0344f76caef253d76de81f5a18c7be8c4fbe0e88b4f1a94bce555ab6597aa0
+  languageName: node
+  linkType: hard
+
 "react-native-codegen@npm:^0.70.7":
   version: 0.70.7
   resolution: "react-native-codegen@npm:0.70.7"
@@ -17209,6 +17233,7 @@ __metadata:
     react-dom: "npm:19.1.0"
     react-hook-form: "npm:^7.60.0"
     react-native: "npm:0.80.0"
+    react-native-animated-glow: "npm:^3.1.0"
     react-native-codegen: "npm:^0.70.7"
     react-native-compressor: "npm:^1.16.0"
     react-native-config: "npm:^1.5.5"


### PR DESCRIPTION
## 개요
검색 플로우에서 저장리스트 노출을 강화하기 위해, `PlaceSearchRecommendation` 추천 칩(RegionBased)을 **시각적으로 발견하기 쉽도록** 강조했습니다.

## 변경 내용
| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 래퍼 | `GradientBorderPill` (흰 배경 + 초록→파랑 그라데이션 테두리) | `AnimatedGlow` (`react-native-animated-glow`) |
| 배경 | 흰색 | **블랙 `#16181C`** (Figma `9184-478` "chip_hotplace") |
| 텍스트 | gray90 | **흰색** |
| 테두리 | 정적 그라데이션 | **빛나는 애니메이션 글로우 (항상 ON)** |

### 글로우 설정 (Slack 디자인 협의)
- `react-native-animated-glow`의 **"Confirmation Green" 프리셋**을 기반으로, General `borderColor`만 캡처된 3색으로 교체:
  - `['#1EFF00', '#0093FF', '#00FFFA']` (green → blue → cyan)
- 나머지 glow 레이어(behind×2 / inside / over)·`animationSpeed: 2`·`cornerRadius: 20` 등 프리셋 원본값 유지
- interactivity(hover/press) 없이 `default` 상태만 두어 **항상 글로우가 동작**

## 네이티브 영향 없음 (OTA 배포 가능)
- `react-native-animated-glow`는 `ios/`·`android/`·`podspec`이 없는 **순수 JS 라이브러리**. 자체 네이티브 모듈 없음.
- peer 의존성(Skia / Reanimated / gesture-handler)은 커밋 `124b1f7`로 추가되어 **1.3.10 릴리스 바이너리에 이미 포함**됨.
- ⚠️ 단, CI 정책(`3adc1c5`)상 package.json/yarn.lock 변경 시 네이티브 빌드가 자동 트리거됩니다.

## 검증
- `yarn tsc --noEmit` ✅
- `yarn lint` (대상 파일) ✅
- 시각 E2E는 미진행 (요청에 따라 생략)

## 디자인 레퍼런스
- Figma: node `9184-479` / `9184-478`
- Slack: #C09V7L434VB 스레드 (블랙 버튼 + 빛나는 테두리, borderColor 3색, 항상 적용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new animated glow effect for recommendation chips in search, giving the UI a more prominent highlighted look.
  * Introduced a new app dependency to support the glowing chip animation.
* **Style**
  * Updated recommendation chip text and layout styling for better contrast and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->