### PR TITLE
feat(signup): 회원가입 Figma 코멘트 반영 + 이동수단 enum/텍스트 정리

### DIFF
--- a/src/components/form/UserMobilityToolsForm.tsx
+++ b/src/components/form/UserMobilityToolsForm.tsx
@@ -10,6 +10,9 @@ import {
 } from '@/constant/mobilityTool';
 import {UserMobilityToolDto} from '@/generated-sources/openapi';
 import SelectableItem from '@/screens/SignupScreen/components/SelectableItem';
+import ToastUtils from '@/utils/ToastUtils';
+
+const MAX_SELECTION = 3;
 
 // Figma: 2열 그리드. 좌우 패딩 20, 아이템 간격 8px → 절반 너비 = (width - 40 - 8) / 2
 const H_PADDING = 20;
@@ -49,6 +52,10 @@ export default function UserMobilityToolsForm({
     if (value.includes(pressed)) {
       onChangeValue(value.filter(tool => tool !== pressed));
     } else {
+      if (value.length >= MAX_SELECTION) {
+        ToastUtils.show(`최대 ${MAX_SELECTION}개까지 선택할 수 있어요.`);
+        return;
+      }
       onChangeValue([...value, pressed]);
     }
   };

--- a/src/components/form/UserMobilityToolsForm.tsx
+++ b/src/components/form/UserMobilityToolsForm.tsx
@@ -44,6 +44,7 @@ export default function UserMobilityToolsForm({
       return;
     }
 
+    // NONE 선택 상태에서 다른 옵션 탭 → NONE 해제하고 그 옵션으로 전환(원탭)
     if (isNoneSelected) {
       onChangeValue([pressed]);
       return;

--- a/src/components/form/UserPhoneForm.tsx
+++ b/src/components/form/UserPhoneForm.tsx
@@ -372,7 +372,7 @@ const ActionButton = styled(SccTouchableOpacity)<{
   disabled?: boolean;
   isActive: boolean;
 }>`
-  height: 56px;
+  height: 48px;
   width: 100%;
   justify-content: center;
   align-items: center;

--- a/src/components/form/UserPhoneForm.tsx
+++ b/src/components/form/UserPhoneForm.tsx
@@ -383,8 +383,8 @@ const ActionButton = styled(SccTouchableOpacity)<{
 
 const ActionButtonText = styled.Text<{isActive: boolean}>`
   font-family: ${font.pretendardSemibold};
-  font-size: 18px;
-  line-height: 26px;
-  letter-spacing: -0.36px;
+  font-size: 16px;
+  line-height: 24px;
+  letter-spacing: -0.32px;
   color: ${props => (props.isActive ? color.white : color.gray30v2)};
 `;

--- a/src/constant/mobilityTool.ts
+++ b/src/constant/mobilityTool.ts
@@ -1,25 +1,24 @@
 import {UserMobilityToolDto} from '@/generated-sources/openapi';
 
 export const MOBILITY_TOOL_LABELS: Record<UserMobilityToolDto, string> = {
-  [UserMobilityToolDto.ManualWheelchair]: '수동 휠체어',
-  [UserMobilityToolDto.ElectricWheelchair]: '전동 휠체어',
-  [UserMobilityToolDto.ManualAndElectricWheelchair]: '수전동 휠체어',
-  [UserMobilityToolDto.Scooter]: '스쿠터',
-  [UserMobilityToolDto.WheelchairUserCompanion]:
+  [UserMobilityToolDto.ManualWheelchair]: '수동휠체어',
+  [UserMobilityToolDto.ElectricWheelchair]: '전동휠체어',
+  [UserMobilityToolDto.ManualAndElectricWheelchair]: '수전동휠체어',
+  [UserMobilityToolDto.Scooter]: '전동스쿠터(의료용)',
+  [UserMobilityToolDto.FriendOfWheelchairUser]:
     '휠체어 사용자의 가족 · 친구 · 동료',
   [UserMobilityToolDto.ProstheticFoot]: '의족',
-  [UserMobilityToolDto.Walker]: '워커',
   [UserMobilityToolDto.Cane]: '지팡이',
-  [UserMobilityToolDto.WalkingCart]: '보행차',
+  [UserMobilityToolDto.WalkerAndWalkingCart]: '워커 · 보행차',
   [UserMobilityToolDto.Crutch]: '목발',
-  [UserMobilityToolDto.None]: '해당하는 유형없음',
+  [UserMobilityToolDto.FriendOfWalkingAidUser]:
+    '보행 보조 기기 사용자의 가족 · 친구 · 동료',
+  [UserMobilityToolDto.None]: '해당 없음',
   [UserMobilityToolDto.Stroller]: '유아차 동반',
-  [UserMobilityToolDto.WalkingDifficulty]:
-    '보행 대체 · 보조 기기가 없으나 보행 불편',
+  [UserMobilityToolDto.WalkingDifficulty]: '보행 보조 기기가 없으나 보행 불편',
   // 하위호환 유지 (신규 UI에 미표시)
   [UserMobilityToolDto.WalkingAssistanceDevice]: '보행보조도구',
   [UserMobilityToolDto.Cluch]: '클러치(목발, 지팡이 등)',
-  [UserMobilityToolDto.FriendOfToolUser]: '이동약자의 친구/가족/동료',
 };
 
 export interface MobilityToolOption {
@@ -35,7 +34,7 @@ export interface MobilityToolGroup {
 
 export const MOBILITY_TOOL_GROUPS: MobilityToolGroup[] = [
   {
-    groupLabel: '휠체어 사용',
+    groupLabel: '이동수단',
     options: [
       {
         value: UserMobilityToolDto.ManualWheelchair,
@@ -55,35 +54,35 @@ export const MOBILITY_TOOL_GROUPS: MobilityToolGroup[] = [
         label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.Scooter],
       },
       {
-        value: UserMobilityToolDto.WheelchairUserCompanion,
-        label:
-          MOBILITY_TOOL_LABELS[UserMobilityToolDto.WheelchairUserCompanion],
+        value: UserMobilityToolDto.FriendOfWheelchairUser,
+        label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.FriendOfWheelchairUser],
         fullWidth: true,
       },
     ],
   },
   {
-    groupLabel: '보행 대체 · 보조 기기',
+    groupLabel: '보행 보조 기기',
     options: [
       {
         value: UserMobilityToolDto.ProstheticFoot,
         label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.ProstheticFoot],
       },
       {
-        value: UserMobilityToolDto.Walker,
-        label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.Walker],
-      },
-      {
         value: UserMobilityToolDto.Cane,
         label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.Cane],
       },
       {
-        value: UserMobilityToolDto.WalkingCart,
-        label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.WalkingCart],
+        value: UserMobilityToolDto.WalkerAndWalkingCart,
+        label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.WalkerAndWalkingCart],
       },
       {
         value: UserMobilityToolDto.Crutch,
         label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.Crutch],
+      },
+      {
+        value: UserMobilityToolDto.FriendOfWalkingAidUser,
+        label: MOBILITY_TOOL_LABELS[UserMobilityToolDto.FriendOfWalkingAidUser],
+        fullWidth: true,
       },
     ],
   },
@@ -107,10 +106,10 @@ export const MOBILITY_TOOL_GROUPS: MobilityToolGroup[] = [
   },
 ];
 
-// 레거시 호환: 기존 flat 옵션 계약 유지 (그룹에 미노출된 하위호환 값도 포함해야 함)
-export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS)
-  .filter(([value]) => value !== UserMobilityToolDto.FriendOfToolUser) // 친구 선택은 NONE 선택 이후 진행됨
-  .map(([value, label]) => ({
+// 레거시 호환: 기존 flat 옵션 계약 유지
+export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS).map(
+  ([value, label]) => ({
     value: value as UserMobilityToolDto,
     label,
-  }));
+  }),
+);

--- a/src/constant/review.ts
+++ b/src/constant/review.ts
@@ -12,7 +12,7 @@ type UserMobilityToolMap = typeof UserMobilityToolDto;
 
 export type UserMobilityToolMapDto = UserMobilityToolMap[keyof Omit<
   UserMobilityToolMap,
-  'FriendOfToolUser' | 'Cluch'
+  'Cluch'
 >];
 
 export const MOBILITY_TOOL_LABELS: Record<UserMobilityToolMapDto, string> = {
@@ -23,23 +23,24 @@ export const MOBILITY_TOOL_LABELS: Record<UserMobilityToolMapDto, string> = {
   [UserMobilityToolDto.ProstheticFoot]: '의족',
   [UserMobilityToolDto.Stroller]: '유아차 동반',
   [UserMobilityToolDto.None]: '해당없음',
-  [UserMobilityToolDto.Scooter]: '스쿠터',
-  [UserMobilityToolDto.WheelchairUserCompanion]:
+  [UserMobilityToolDto.Scooter]: '전동스쿠터(의료용)',
+  [UserMobilityToolDto.FriendOfWheelchairUser]:
     '휠체어 사용자의 가족 · 친구 · 동료',
-  [UserMobilityToolDto.Walker]: '워커',
   [UserMobilityToolDto.Cane]: '지팡이',
-  [UserMobilityToolDto.WalkingCart]: '보행차',
+  [UserMobilityToolDto.WalkerAndWalkingCart]: '워커 · 보행차',
   [UserMobilityToolDto.Crutch]: '목발',
+  [UserMobilityToolDto.FriendOfWalkingAidUser]:
+    '보행 보조 기기 사용자의 가족 · 친구 · 동료',
   [UserMobilityToolDto.WalkingDifficulty]:
     '보행 대체 · 보조 기기가 없으나 보행 불편',
 };
 
-export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS)
-  .filter(([value]) => value !== UserMobilityToolDto.FriendOfToolUser)
-  .map(([value, label]) => ({
+export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS).map(
+  ([value, label]) => ({
     value: value as UserMobilityToolDto,
     label,
-  }));
+  }),
+);
 
 export function getMobilityToolDefaultValue(
   mobilityTools?: UserMobilityToolDto[],

--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -7598,13 +7598,12 @@ export const UserMobilityToolDto = {
     WalkingAssistanceDevice: 'WALKING_ASSISTANCE_DEVICE',
     Cluch: 'CLUCH',
     None: 'NONE',
-    FriendOfToolUser: 'FRIEND_OF_TOOL_USER',
+    FriendOfWheelchairUser: 'FRIEND_OF_WHEELCHAIR_USER',
     Scooter: 'SCOOTER',
-    WheelchairUserCompanion: 'WHEELCHAIR_USER_COMPANION',
-    Walker: 'WALKER',
     Cane: 'CANE',
-    WalkingCart: 'WALKING_CART',
+    WalkerAndWalkingCart: 'WALKER_AND_WALKING_CART',
     Crutch: 'CRUTCH',
+    FriendOfWalkingAidUser: 'FRIEND_OF_WALKING_AID_USER',
     WalkingDifficulty: 'WALKING_DIFFICULTY'
 } as const;
 

--- a/src/screens/SignupScreen/SignupMobilityToolPage.tsx
+++ b/src/screens/SignupScreen/SignupMobilityToolPage.tsx
@@ -22,7 +22,7 @@ export default function SignupMobilityToolPage({
         <Text className="font-pretendard-bold text-[24px] text-gray-100 mt-[12px]">
           나에게 해당하는 이동 유형을{'\n'}모두 선택해주세요.{' '}
           <Text className="text-gray-50 font-pretendard-regular text-[16px]">
-            (중복선택가능)
+            (최대 3개까지 선택)
           </Text>
         </Text>
         <Text className="font-pretendard-medium text-[16px] text-gray-70 mt-[4px]">

--- a/src/screens/SignupScreen/components/SelectableItem.tsx
+++ b/src/screens/SignupScreen/components/SelectableItem.tsx
@@ -31,9 +31,7 @@ export default function SelectableItem({
       style={{opacity: isDimmed ? 0.4 : 1}}
       className={cn(
         'flex-row items-center gap-[8px] pl-[10px] pr-[12px] py-[12px] rounded-[12px] border-[1px]',
-        isSelected
-          ? 'bg-brand-5 border-brand-color'
-          : 'bg-white border-gray-20',
+        isSelected ? 'bg-brand-5 border-brand-50' : 'bg-white border-gray-20',
       )}>
       {isSelected ? (
         <FilledCheckIcon width={24} height={24} />

--- a/src/screens/SignupScreen/components/SelectableItem.tsx
+++ b/src/screens/SignupScreen/components/SelectableItem.tsx
@@ -23,6 +23,8 @@ export default function SelectableItem({
   text,
   elementName,
 }: SelectableItemProps) {
+  // 라벨 끝의 부가설명 괄호는 작게 (예: "전동스쿠터(의료용)" → (의료용) 14px). 디자인 node 2439:35068
+  const parenMatch = text.match(/^(.*?)(\([^)]+\))$/);
   return (
     <SccPressable
       elementName={elementName}
@@ -47,7 +49,16 @@ export default function SelectableItem({
           letterSpacing: -0.2,
           color: color.gray90v2,
         }}>
-        {text}
+        {parenMatch ? (
+          <>
+            {parenMatch[1]}
+            <Text style={{fontSize: 14, letterSpacing: -0.28}}>
+              {parenMatch[2]}
+            </Text>
+          </>
+        ) : (
+          text
+        )}
       </Text>
     </SccPressable>
   );


### PR DESCRIPTION
## 배경
회원가입 개선 Figma 코멘트 4건 반영 + 이동수단 선택 화면(node 2439:35046) 텍스트 전수 재검토. enum cascade: Stair-Crusher-Club/scc-server#982 (← Stair-Crusher-Club/scc-api#120).

## Figma 코멘트 4건
1. **선택 칩 테두리 검정→파랑**: `SelectableItem`의 `border-brand-color`가 tailwind에 없는 무효 클래스 → RN 기본 검정으로 폴백되던 버그. `border-brand-50`(#0E64D3)로 수정.
2. **"(중복선택가능)"→"(최대 3개까지 선택)"** + 4번째 선택 시 토스트로 차단.
3. **"인증번호 받기" 버튼 텍스트 18→16px** (디자인 active 토큰 일치).
4. "인증번호 다시 받기" 14px — 이미 일치(시각 확인만).

## 이동수단 텍스트/구조 재검토
- 그룹 헤더: 휠체어 사용→**이동수단**, 보행 대체·보조 기기→**보행 보조 기기**
- 라벨: 수동휠체어/전동휠체어/수전동휠체어(붙임), 스쿠터→**전동스쿠터(의료용)**, 해당하는 유형없음→**해당 없음** 등 디자인 일치
- 구조: **워커·보행차 통합**, **보행 보조 기기 동반자 신규**, 동반자 `FRIEND_OF_*` 통일 (codegen 반영)

## 검증
`yarn codegen` + `yarn tsc --noEmit` + `yarn eslint` 0 errors.
실기기 E2E(에뮬레이터 시각 확인)는 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear limit for mobility tool selection: users can now choose up to 3 items, with a message shown when the limit is reached.
  * Updated mobility tool options and labels to better match the available choices during signup.

* **Bug Fixes**
  * Improved consistency in mobility tool selection and display text.
  * Refined button and selected-item styling for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->