### PR TITLE
fix(toilet): 카드 라이브 로드뷰 WebView 제거(iOS 크래시) + 주소 오버플로우 클립

### DIFF
--- a/src/components/toilet/ToiletCard.tsx
+++ b/src/components/toilet/ToiletCard.tsx
@@ -11,7 +11,6 @@ import ShareIcon from '@/assets/icon/ic_share.svg';
 import {currentLocationAtom} from '@/atoms/Location';
 import Tags from '@/components/Tag';
 import {MarkerItem} from '@/components/maps/MarkerItem.ts';
-import PanoramaCanvas from '@/components/maps/PanoramaCanvas';
 import {
   accessibilitySourceLabel,
   ToiletDetails,
@@ -42,7 +41,6 @@ export default function ToiletCard({item}: {item: ToiletDetails & MarkerItem}) {
   })();
   const images = item.imageUrl ? [{imageUrl: item.imageUrl}] : [];
   const hasImage = images.length > 0;
-  const showRoadview = !hasImage;
   const onShare = () => {
     ToastUtils.show('준비 중입니다.');
   };
@@ -60,7 +58,7 @@ export default function ToiletCard({item}: {item: ToiletDetails & MarkerItem}) {
       }}>
       <Container
         elementName="toilet_card"
-        hasImage={hasImage || showRoadview}
+        hasImage={hasImage}
         onPress={() => {
           navigation.navigate('ToiletDetail', {
             toiletId: item.toiletId,
@@ -96,7 +94,9 @@ export default function ToiletCard({item}: {item: ToiletDetails & MarkerItem}) {
             <LocationBox>
               <DistanceText>{distanceText}</DistanceText>
               <LocationDivider />
-              <AddressText>{item.address}</AddressText>
+              <AddressText numberOfLines={1} ellipsizeMode="tail">
+                {item.address}
+              </AddressText>
             </LocationBox>
           </TitleArea>
           {tagTexts.length > 0 && (
@@ -121,18 +121,6 @@ export default function ToiletCard({item}: {item: ToiletDetails & MarkerItem}) {
           <View style={{width: '100%', flexShrink: 2, overflow: 'hidden'}}>
             <ImageList images={images} />
           </View>
-        )}
-        {showRoadview && (
-          // ponytail: pointerEvents="none" so taps pass through to Container → TDP navigate
-          <RoadviewPreviewBox pointerEvents="none">
-            <PanoramaCanvas
-              position={{lat: item.location.lat, lng: item.location.lng}}
-              label={item.name}
-              showPin={false}
-              interactive={false}
-              style={{width: '100%', height: '100%'}}
-            />
-          </RoadviewPreviewBox>
         )}
       </Container>
     </LogParamsProvider>
@@ -202,6 +190,7 @@ const DistanceText = styled.Text`
 `;
 
 const AddressText = styled.Text`
+  flex: 1;
   font-size: 14px;
   font-family: ${() => font.pretendardRegular};
   color: ${() => color.gray80};
@@ -213,6 +202,7 @@ const LocationBox = styled.View`
   align-items: center;
   justify-content: flex-start;
   gap: 4px;
+  width: 100%;
 `;
 
 const LocationDivider = styled.View`
@@ -240,13 +230,4 @@ const SourceDateText = styled.Text`
   font-size: 11px;
   font-family: ${() => font.pretendardRegular};
   color: ${() => color.gray50};
-`;
-
-const RoadviewPreviewBox = styled.View`
-  width: 100%;
-  height: 150px;
-  border-radius: 12px;
-  overflow: hidden;
-  background-color: ${() => color.gray10};
-  flex-shrink: 2;
 `;


### PR DESCRIPTION
## 문제
iOS에서 장애인화장실(MOIS, 사진 없음) 카드를 보면 로드뷰가 렌더되다 앱이 크래시.

## 원인
검색 리스트/맵 카드가 사진 없는 카드마다 네이버 파노라마 **WKWebView**(`PanoramaCanvas`)를 라이브 mount. iOS는 CoreAnimation 단일 레이어 트리를 메인스레드에서 재귀 인코딩하는데, 무거운 WKWebView 서브트리가 다수 쌓이면 commit 중 `abort`(크래시 로그: `CA::Render::Encoder::grow`/`commit_if_needed` 깊은 재귀). Android는 컴포지팅 방식 + software 레이어 평탄화로 무사.

## 수정
- 카드의 라이브 WebView 제거. 인터랙티브 로드뷰는 TDP(`RoadView`, 단일 WebView)에서만 유지.
- 긴 주소 카드 밖 오버플로우: `AddressText` flex:1 + `numberOfLines=1` ellipsize, `LocationBox` width:100%.

## 검증
- tsc/lint 통과. (로컬 에뮬레이터 Metro는 sibling clone에서 구동 중이라 live 검증 불가 — OTA는 git main 빌드라 무관)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the toilet card display when no image is available by removing the empty preview area and keeping the layout consistent.
  * Address text now stays on a single line with an ellipsis, preventing overflow and improving readability.
* **Style**
  * Adjusted spacing and sizing in the card layout for a cleaner, more stable presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->