### PR TITLE
fix(map): 오버레이 카드 하단 정렬 — 썸네일 없는 카드 아래 여백 제거

### DIFF
--- a/src/components/maps/ItemMapView.tsx
+++ b/src/components/maps/ItemMapView.tsx
@@ -438,7 +438,9 @@ const OverlayCardContainer = styled.View`
   align-self: stretch;
   height: ${CARD_LIST_HEIGHT}px;
   align-items: center;
-  justify-content: flex-start;
+  /* 카드 하단을 밴드 바닥에 고정 → 썸네일 없는 짧은 카드는 위쪽이 열려
+     지도 아래가 비지 않는다 (top 고정이면 아래가 텅 빔). */
+  justify-content: flex-end;
 `;
 
 const OverlayCardWrapper = styled.View`


### PR DESCRIPTION
썸네일 없는 화장실 카드가 짧아질 때 OverlayCardContainer가 top 고정(flex-start)이라 지도 아래가 텅 비던 문제. flex-end로 하단 고정. tsc/lint 통과.