### PR TITLE
fix(map): 캐러셀 카드 하단 정렬 — 썸네일 없는 카드 아래 여백 제거

### DIFF
--- a/src/components/maps/ItemMapList.tsx
+++ b/src/components/maps/ItemMapList.tsx
@@ -137,7 +137,9 @@ const ItemWrapper = styled.View`
   shadow-opacity: 0.25;
   shadow-radius: 3.84px;
   elevation: 3;
-  align-self: flex-start;
+  /* 카드 하단을 캐러셀 밴드 바닥에 고정 → 썸네일 없는 짧은 카드는 위쪽이 열려
+     지도 아래가 비지 않는다 (flex-start면 위에 붙어 아래가 텅 빔). */
+  align-self: flex-end;
   background-color: white;
   overflow: visible;
   width: ${() => ITEM_SIZE - 10}px;


### PR DESCRIPTION
화장실 검색 캐러셀(ItemMapList)의 ItemWrapper가 align-self: flex-start라 짧은 카드가 위에 붙어 지도 아래가 비던 문제. flex-end로 하단 고정. (이전 v1.3-20260630-03은 OverlayCardContainer=화장실 레이어 단일 오버레이만 고쳐 이 화면엔 미적용이었음.) tsc/lint 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted map item cards so they now align to the bottom of their container, improving layout consistency and reducing empty space below the map area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->