### PR TITLE
fix(logging): PlaceListDetail 이벤트에 place_list_id 계측

### DIFF
--- a/src/screens/PlaceListDetailScreen/PlaceListDetailScreen.tsx
+++ b/src/screens/PlaceListDetailScreen/PlaceListDetailScreen.tsx
@@ -344,153 +344,155 @@ const PlaceListDetailScreen = ({
   );
 
   return (
-    <Layout isHeaderVisible={false} safeAreaEdges={['top']}>
-      <HeaderRow $isMapMode={viewMode === 'map'}>
-        <HeaderLeftToggle
-          elementName={
-            viewMode === 'list'
-              ? 'place_list_detail_map_toggle'
-              : 'place_list_detail_list_toggle'
-          }
-          activeOpacity={0.8}
-          onPress={toggleViewMode}>
-          {viewMode === 'list' ? (
-            <MapIcon width={24} height={24} color={color.black} />
-          ) : (
-            <MenuIcon width={24} height={24} color={color.black} />
-          )}
-          <HeaderToggleText>
-            {viewMode === 'list' ? '지도' : '목록'}
-          </HeaderToggleText>
-        </HeaderLeftToggle>
-        <HeaderTitle numberOfLines={1}>{title}</HeaderTitle>
-        <SccTouchableOpacity
-          elementName="place_list_detail_close"
-          activeOpacity={0.8}
-          hitSlop={14}
-          onPress={() => navigation.goBack()}>
-          <CloseIcon width={16} height={16} color={color.black} />
-        </SccTouchableOpacity>
-      </HeaderRow>
+    <LogParamsProvider params={{place_list_id: placeListId}}>
+      <Layout isHeaderVisible={false} safeAreaEdges={['top']}>
+        <HeaderRow $isMapMode={viewMode === 'map'}>
+          <HeaderLeftToggle
+            elementName={
+              viewMode === 'list'
+                ? 'place_list_detail_map_toggle'
+                : 'place_list_detail_list_toggle'
+            }
+            activeOpacity={0.8}
+            onPress={toggleViewMode}>
+            {viewMode === 'list' ? (
+              <MapIcon width={24} height={24} color={color.black} />
+            ) : (
+              <MenuIcon width={24} height={24} color={color.black} />
+            )}
+            <HeaderToggleText>
+              {viewMode === 'list' ? '지도' : '목록'}
+            </HeaderToggleText>
+          </HeaderLeftToggle>
+          <HeaderTitle numberOfLines={1}>{title}</HeaderTitle>
+          <SccTouchableOpacity
+            elementName="place_list_detail_close"
+            activeOpacity={0.8}
+            hitSlop={14}
+            onPress={() => navigation.goBack()}>
+            <CloseIcon width={16} height={16} color={color.black} />
+          </SccTouchableOpacity>
+        </HeaderRow>
 
-      {isLoading ? (
-        <SearchLoading />
-      ) : isError ? (
-        <ErrorContainer>
-          <ErrorText>리스트를 불러올 수 없습니다.</ErrorText>
-        </ErrorContainer>
-      ) : (
-        <ContentContainer>
-          {/* Fix 1: 지도 항상 렌더링 (뒤에 깔아두기) */}
-          <MapAbsoluteContainer
-            style={viewMode === 'list' ? {opacity: 0} : undefined}
-            pointerEvents={viewMode === 'list' ? 'none' : 'auto'}>
-            <ItemMapView
-              ref={mapRef}
-              items={items}
-              ItemCard={PlaceListItemCard}
-              isRefreshVisible={false}
-              onRefresh={() => {}}
-              onCameraIdle={() => {}}
-              myLocationBottomOffset={16}
-            />
-          </MapAbsoluteContainer>
-
-          {viewMode === 'list' ? (
-            <ListOverlay>
-              <FlatList
-                data={listData}
-                keyExtractor={item => item.key}
-                stickyHeaderIndices={[1]}
-                contentContainerStyle={{paddingBottom: 100}}
-                renderItem={renderListItem}
+        {isLoading ? (
+          <SearchLoading />
+        ) : isError ? (
+          <ErrorContainer>
+            <ErrorText>리스트를 불러올 수 없습니다.</ErrorText>
+          </ErrorContainer>
+        ) : (
+          <ContentContainer>
+            {/* Fix 1: 지도 항상 렌더링 (뒤에 깔아두기) */}
+            <MapAbsoluteContainer
+              style={viewMode === 'list' ? {opacity: 0} : undefined}
+              pointerEvents={viewMode === 'list' ? 'none' : 'auto'}>
+              <ItemMapView
+                ref={mapRef}
+                items={items}
+                ItemCard={PlaceListItemCard}
+                isRefreshVisible={false}
+                onRefresh={() => {}}
+                onCameraIdle={() => {}}
+                myLocationBottomOffset={16}
               />
-              <FloatingViewModeButton
-                elementName="place_list_detail_floating_map"
-                activeOpacity={0.8}
-                onPress={toggleViewMode}
-                style={{bottom: insets.bottom + 24}}
-                $isBlue>
-                <MapIcon width={16} height={16} color={color.white} />
-                <FloatingViewModeText $isBlue>지도보기</FloatingViewModeText>
-              </FloatingViewModeButton>
-            </ListOverlay>
-          ) : (
-            <>
-              <LogParamsProvider params={{viewMode: 'map'}}>
-                <MapFilterOverlay>
-                  <FilterBar
-                    mode="map"
-                    filters={filters}
-                    onOpenFilterModal={setFilterModalState}
-                  />
-                </MapFilterOverlay>
-              </LogParamsProvider>
-              <MapRightFloatingContainer>
-                <FloatingCircleButton
-                  elementName="place_list_detail_map_save"
+            </MapAbsoluteContainer>
+
+            {viewMode === 'list' ? (
+              <ListOverlay>
+                <FlatList
+                  data={listData}
+                  keyExtractor={item => item.key}
+                  stickyHeaderIndices={[1]}
+                  contentContainerStyle={{paddingBottom: 100}}
+                  renderItem={renderListItem}
+                />
+                <FloatingViewModeButton
+                  elementName="place_list_detail_floating_map"
                   activeOpacity={0.8}
-                  onPress={handleToggleSave}>
-                  {isSaved ? (
-                    <BookmarkOnIcon
-                      width={16}
-                      height={20}
-                      viewBox="-2.5 -0.5 20 20"
-                      color={color.brand40}
+                  onPress={toggleViewMode}
+                  style={{bottom: insets.bottom + 24}}
+                  $isBlue>
+                  <MapIcon width={16} height={16} color={color.white} />
+                  <FloatingViewModeText $isBlue>지도보기</FloatingViewModeText>
+                </FloatingViewModeButton>
+              </ListOverlay>
+            ) : (
+              <>
+                <LogParamsProvider params={{viewMode: 'map'}}>
+                  <MapFilterOverlay>
+                    <FilterBar
+                      mode="map"
+                      filters={filters}
+                      onOpenFilterModal={setFilterModalState}
                     />
-                  ) : (
-                    <BookmarkIcon
-                      width={16}
-                      height={20}
-                      viewBox="-2.5 -0.5 20 20"
-                      color={color.gray90}
-                    />
-                  )}
-                </FloatingCircleButton>
-                <FloatingCircleButton
-                  elementName="place_list_detail_map_share"
+                  </MapFilterOverlay>
+                </LogParamsProvider>
+                <MapRightFloatingContainer>
+                  <FloatingCircleButton
+                    elementName="place_list_detail_map_save"
+                    activeOpacity={0.8}
+                    onPress={handleToggleSave}>
+                    {isSaved ? (
+                      <BookmarkOnIcon
+                        width={16}
+                        height={20}
+                        viewBox="-2.5 -0.5 20 20"
+                        color={color.brand40}
+                      />
+                    ) : (
+                      <BookmarkIcon
+                        width={16}
+                        height={20}
+                        viewBox="-2.5 -0.5 20 20"
+                        color={color.gray90}
+                      />
+                    )}
+                  </FloatingCircleButton>
+                  <FloatingCircleButton
+                    elementName="place_list_detail_map_share"
+                    activeOpacity={0.8}
+                    onPress={handleShare}>
+                    <ShareIcon width={20} height={20} color={color.black} />
+                  </FloatingCircleButton>
+                </MapRightFloatingContainer>
+                {/* Fix 2: 동적 bottom으로 카드 위에 배치 */}
+                <FloatingViewModeButton
+                  elementName="place_list_detail_floating_list"
                   activeOpacity={0.8}
-                  onPress={handleShare}>
-                  <ShareIcon width={20} height={20} color={color.black} />
-                </FloatingCircleButton>
-              </MapRightFloatingContainer>
-              {/* Fix 2: 동적 bottom으로 카드 위에 배치 */}
-              <FloatingViewModeButton
-                elementName="place_list_detail_floating_list"
-                activeOpacity={0.8}
-                onPress={toggleViewMode}
-                style={{bottom: floatingBottom}}
-                $isBlue={false}>
-                <MenuIcon width={16} height={16} color="#24262B" />
-                <FloatingViewModeText $isBlue={false}>
-                  목록보기
-                </FloatingViewModeText>
-              </FloatingViewModeButton>
-            </>
-          )}
-        </ContentContainer>
-      )}
-      <PlaceListFilterModal />
-      {showSaveMissionCompleted && (
-        <MissionCompletedOverlay
-          isVisible={true}
-          itemImage={require('@/assets/img/tutorial/mission_complete_img_map.png')}
-          description={`접근성 지도 획득!\n${
-            userInfo?.nickname ?? '크러셔'
-          }님이 찾은 지도로 접근성 좋은\n맛집, 카페를 확인할 수 있게 됐어요 👍`}
-          confirmElementName="tutorial_mission_2_completed_confirm"
-          onClose={() => {
-            // 미션 완료 팝업 노출 자체가 fromTutorial=true 진입에서만 발생한다.
-            // 닫기 시 TutorialMissionScreen 으로 popTo (native-stack v7 popTo 는
-            // stack 에 있는 라우트까지 pop).
-            setShowSaveMissionCompleted(false);
-            navigation.popTo('TutorialMission', {
-              scrollResetToken: Date.now(),
-            });
-          }}
-        />
-      )}
-    </Layout>
+                  onPress={toggleViewMode}
+                  style={{bottom: floatingBottom}}
+                  $isBlue={false}>
+                  <MenuIcon width={16} height={16} color="#24262B" />
+                  <FloatingViewModeText $isBlue={false}>
+                    목록보기
+                  </FloatingViewModeText>
+                </FloatingViewModeButton>
+              </>
+            )}
+          </ContentContainer>
+        )}
+        <PlaceListFilterModal />
+        {showSaveMissionCompleted && (
+          <MissionCompletedOverlay
+            isVisible={true}
+            itemImage={require('@/assets/img/tutorial/mission_complete_img_map.png')}
+            description={`접근성 지도 획득!\n${
+              userInfo?.nickname ?? '크러셔'
+            }님이 찾은 지도로 접근성 좋은\n맛집, 카페를 확인할 수 있게 됐어요 👍`}
+            confirmElementName="tutorial_mission_2_completed_confirm"
+            onClose={() => {
+              // 미션 완료 팝업 노출 자체가 fromTutorial=true 진입에서만 발생한다.
+              // 닫기 시 TutorialMissionScreen 으로 popTo (native-stack v7 popTo 는
+              // stack 에 있는 라우트까지 pop).
+              setShowSaveMissionCompleted(false);
+              navigation.popTo('TutorialMission', {
+                scrollResetToken: Date.now(),
+              });
+            }}
+          />
+        )}
+      </Layout>
+    </LogParamsProvider>
   );
 };
 

--- a/src/screens/RootScreen.tsx
+++ b/src/screens/RootScreen.tsx
@@ -35,6 +35,7 @@ const ROUTE_PARAMS_LOGGING_RULES: Record<string, string> = {
   'placeInfo.placeId': 'place_id',
   'placeInfo.place.id': 'place_id',
   'placeInfo.name': 'place_name',
+  placeListId: 'place_list_id', // PlaceListDetail screen_view 를 리스트별로 귀속 (튜토리얼·딥링크·탭 모든 진입 포함)
   // 필요에 따라 추가...
 };
 


### PR DESCRIPTION
## 문제
`PlaceListDetail` 의 `screen_view`·저장버튼(`place_list_detail_save_button`) 등 이벤트에 `place_list_id` 가 실리지 않아, GA에서 저장리스트 **조회/저장을 리스트별로 귀속할 수 없었다** (BI 저장전환율·per-list 조회수 집계 불가). 데이터 분석 중 발견 — 예: "윌리의 외출 보상" 리스트는 서버 view_count 22회인데 GA로는 조회 2로 잡혀 전환율이 깨졌다.

## 근본 원인
`RootScreen` 의 screen_view route-param 화이트리스트 `ROUTE_PARAMS_LOGGING_RULES` 가 `place_id`/`place_name` 만 허용 → `placeListId` route param 이 screen_view 에서 드롭됨.

## 수정
- **RootScreen**: `ROUTE_PARAMS_LOGGING_RULES` 에 `placeListId → place_list_id` 추가. 모든 진입 경로(탭·튜토리얼 자동이동·공유 딥링크)의 `screen_view` 가 리스트에 귀속된다.
- **PlaceListDetailScreen**: 최상위를 `<LogParamsProvider params={{place_list_id}}>` 로 감싸 저장버튼 등 화면 내 `element_click`/`element_view` 가 `place_list_id` 를 싣게 함. (JSX 래핑으로 인한 하위 들여쓰기 변경 포함 — prettier)

## 영향
- 계측 전용 변경(파라미터 추가). UI/동작 변화 없음. JS-only(네이티브 빌드 불필요, OTA 가능).
- 반영 후 GA `screen_view` 기반으로 리스트별 조회수를 주별·모수별(전체/휠체어)로 정확히 집계 가능 → 저장전환율 정상화.

## 검증
- `yarn tsc --noEmit` 0 error, `yarn eslint` 0 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking consistency for place list detail views across different entry points.
  * View-related context is now captured more reliably while browsing a place list, including map and list interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->