### PR TITLE
feat(pdp): AI 접근성 요약 섹션 추가

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -179,6 +179,12 @@ export interface AccessibilityInfoV2Dto {
      * @memberof AccessibilityInfoV2Dto
      */
     'buildingAccessibilities'?: Array<BuildingAccessibility>;
+    /**
+     * 
+     * @type {PlaceAiSummaryDto}
+     * @memberof AccessibilityInfoV2Dto
+     */
+    'aiSummary'?: PlaceAiSummaryDto;
 }
 /**
  * 
@@ -204,6 +210,12 @@ export interface AccessibilityInfoV2DtoAllOf {
      * @memberof AccessibilityInfoV2DtoAllOf
      */
     'buildingAccessibilities'?: Array<BuildingAccessibility>;
+    /**
+     * 
+     * @type {PlaceAiSummaryDto}
+     * @memberof AccessibilityInfoV2DtoAllOf
+     */
+    'aiSummary'?: PlaceAiSummaryDto;
 }
 /**
  * 
@@ -355,6 +367,20 @@ export const AccessibilitySourceDto = {
 } as const;
 
 export type AccessibilitySourceDto = typeof AccessibilitySourceDto[keyof typeof AccessibilitySourceDto];
+
+
+/**
+ * AI 요약 한 줄의 출처 탭.
+ * @export
+ * @enum {string}
+ */
+
+export const AiSummarySourceTabDto = {
+    Accessibility: 'ACCESSIBILITY',
+    Review: 'REVIEW'
+} as const;
+
+export type AiSummarySourceTabDto = typeof AiSummarySourceTabDto[keyof typeof AiSummarySourceTabDto];
 
 
 /**
@@ -4477,6 +4503,44 @@ export interface PlaceAccessibilityComment {
      * @memberof PlaceAccessibilityComment
      */
     'createdAt': EpochMillisTimestamp;
+}
+/**
+ * PDP 상단에 노출하는 AI 접근성/리뷰 요약.
+ * @export
+ * @interface PlaceAiSummaryDto
+ */
+export interface PlaceAiSummaryDto {
+    /**
+     * 요약 문장 리스트 (최대 4줄).
+     * @type {Array<PlaceAiSummaryItemDto>}
+     * @memberof PlaceAiSummaryDto
+     */
+    'items': Array<PlaceAiSummaryItemDto>;
+    /**
+     * 실험 단계 안내 문구/툴팁 노출 여부.
+     * @type {boolean}
+     * @memberof PlaceAiSummaryDto
+     */
+    'isExperimental': boolean;
+}
+/**
+ * AI 요약의 한 줄.
+ * @export
+ * @interface PlaceAiSummaryItemDto
+ */
+export interface PlaceAiSummaryItemDto {
+    /**
+     * 요약 문장.
+     * @type {string}
+     * @memberof PlaceAiSummaryItemDto
+     */
+    'text': string;
+    /**
+     * 
+     * @type {AiSummarySourceTabDto}
+     * @memberof PlaceAiSummaryItemDto
+     */
+    'sourceTab'?: AiSummarySourceTabDto;
 }
 /**
  * 

--- a/src/screens/PlaceDetailScreen/hooks/useDeleteReview.ts
+++ b/src/screens/PlaceDetailScreen/hooks/useDeleteReview.ts
@@ -39,11 +39,6 @@ export function useDeleteReview({
           queryKey: ['PlaceDetailV2', placeId, UpvoteTargetTypeDto.PlaceReview],
         });
 
-        // AI 요약(리뷰 불릿)이 접근성 응답에 실려오므로 함께 무효화해 재조회
-        queryClient.invalidateQueries({
-          queryKey: ['PlaceDetailV2', placeId, 'Accessibility'],
-        });
-
         // 내 리뷰 > 내가 작성한 리뷰 리스트
         queryClient.invalidateQueries({
           queryKey: ['MyReviews', UpvoteTargetTypeDto.PlaceReview],

--- a/src/screens/PlaceDetailScreen/hooks/useDeleteReview.ts
+++ b/src/screens/PlaceDetailScreen/hooks/useDeleteReview.ts
@@ -39,6 +39,11 @@ export function useDeleteReview({
           queryKey: ['PlaceDetailV2', placeId, UpvoteTargetTypeDto.PlaceReview],
         });
 
+        // AI 요약(리뷰 불릿)이 접근성 응답에 실려오므로 함께 무효화해 재조회
+        queryClient.invalidateQueries({
+          queryKey: ['PlaceDetailV2', placeId, 'Accessibility'],
+        });
+
         // 내 리뷰 > 내가 작성한 리뷰 리스트
         queryClient.invalidateQueries({
           queryKey: ['MyReviews', UpvoteTargetTypeDto.PlaceReview],

--- a/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
+++ b/src/screens/PlaceDetailV2Screen/PlaceDetailV2Screen.tsx
@@ -20,6 +20,7 @@ import V2TabBar from './components/V2TabBar';
 import {ScreenLayout} from '@/components/ScreenLayout';
 import {color} from '@/constant/color';
 import {
+  AiSummarySourceTabDto,
   Building,
   ElevatorCorrectionTargetDto,
   FloorMovingMethodTypeDto,
@@ -70,6 +71,7 @@ import V2RestroomTab from './tabs/V2RestroomTab';
 import V2ConquerorTab from './tabs/V2ConquerorTab';
 import V2BottomBar from './components/V2BottomBar';
 import V2ThumbnailRow from './components/V2ThumbnailRow';
+import AiSummarySection from './components/AiSummarySection';
 import PlaceDetailRegistrationSheet from './components/PlaceDetailRegistrationSheet';
 
 export interface PlaceDetailV2ScreenParams {
@@ -973,6 +975,16 @@ export default function PlaceDetailV2Screen({
                 }
                 onNameLayout={handleNameLayout}
                 onActionButtonsLayout={handleActionButtonsLayout}
+              />
+              <AiSummarySection
+                aiSummary={accessibilityPost?.aiSummary}
+                onPressSourceTab={sourceTab =>
+                  setCurrentTab(
+                    sourceTab === AiSummarySourceTabDto.Review
+                      ? 'review'
+                      : 'accessibility',
+                  )
+                }
               />
               <V2ThumbnailRow
                 accessibility={accessibilityPost}

--- a/src/screens/PlaceDetailV2Screen/components/AiSummarySection.tsx
+++ b/src/screens/PlaceDetailV2Screen/components/AiSummarySection.tsx
@@ -1,0 +1,168 @@
+import React, {useState} from 'react';
+import styled from 'styled-components/native';
+
+import CircleInfoIcon from '@/assets/icon/ic_circle_info.svg';
+import CloseIcon from '@/assets/icon/close.svg';
+import {SccPressable} from '@/components/SccPressable';
+import {color} from '@/constant/color';
+import {font} from '@/constant/font';
+import {
+  AiSummarySourceTabDto,
+  PlaceAiSummaryDto,
+} from '@/generated-sources/openapi';
+import {LogParamsProvider} from '@/logging/LogParamsProvider';
+
+/** PDP 최상단 "AI 접근성 요약" 섹션. 서버가 조립한 문장 리스트를 그대로 렌더하는 dumb 컴포넌트. */
+export default function AiSummarySection({
+  aiSummary,
+  onPressSourceTab,
+}: {
+  aiSummary: PlaceAiSummaryDto | undefined;
+  onPressSourceTab: (sourceTab: AiSummarySourceTabDto) => void;
+}) {
+  const [showNotice, setShowNotice] = useState(false);
+
+  if (!aiSummary || aiSummary.items.length === 0) {
+    return null;
+  }
+
+  return (
+    <LogParamsProvider params={{displaySectionName: 'ai_summary'}}>
+      <Container>
+        <Header>
+          <TitleText>AI 접근성 요약</TitleText>
+          {aiSummary.isExperimental && (
+            <SccPressable
+              elementName="ai_summary_info_icon"
+              onPress={() => setShowNotice(prev => !prev)}
+              hitSlop={8}>
+              <CircleInfoIcon width={16} height={16} />
+            </SccPressable>
+          )}
+        </Header>
+        {showNotice && (
+          <NoticeRow>
+            <NoticeText>
+              등록된 외부 접근성 정보와 방문 리뷰를 바탕으로 AI가 요약한
+              내용입니다. 실험 단계로 정확하지 않을 수 있어요.
+            </NoticeText>
+            <SccPressable
+              elementName="ai_summary_notice_close"
+              onPress={() => setShowNotice(false)}
+              hitSlop={8}>
+              <CloseIcon width={12} height={12} />
+            </SccPressable>
+          </NoticeRow>
+        )}
+        {aiSummary.items.map((item, index) => {
+          const sourceTab = item.sourceTab;
+          return (
+            <ItemRow key={index}>
+              <Bullet>{'•'}</Bullet>
+              <ItemContent>
+                <SummaryText>{item.text}</SummaryText>
+                {sourceTab && (
+                  <SccPressable
+                    elementName="ai_summary_source_badge"
+                    logParams={{sourceTab, index}}
+                    onPress={() => onPressSourceTab(sourceTab)}
+                    hitSlop={4}>
+                    <SourceBadge>
+                      <SourceBadgeText>{index + 1}</SourceBadgeText>
+                    </SourceBadge>
+                  </SccPressable>
+                )}
+              </ItemContent>
+            </ItemRow>
+          );
+        })}
+      </Container>
+    </LogParamsProvider>
+  );
+}
+
+// ponytail: Figma 타이틀은 blue→purple 그라디언트 텍스트지만, RN 텍스트 그라디언트는
+// MaskedView/SVG 추가 구현이 필요해 v1에서는 근사 단색(blue50)으로 대체. 필요 시 업그레이드.
+const Container = styled.View`
+  background-color: ${color.gray5};
+  border-radius: 5px;
+  padding: 10px 8px;
+  gap: 6px;
+`;
+
+const Header = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  padding-left: 6px;
+`;
+
+const TitleText = styled.Text`
+  font-family: ${font.pretendardBold};
+  font-size: 13px;
+  line-height: 18px;
+  letter-spacing: -0.26px;
+  color: ${color.blue50};
+`;
+
+const NoticeRow = styled.View`
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  background-color: ${color.white};
+  border-radius: 4px;
+`;
+
+const NoticeText = styled.Text`
+  flex: 1;
+  font-family: ${font.pretendardRegular};
+  font-size: 12px;
+  line-height: 18px;
+  color: ${color.gray70v2};
+`;
+
+const ItemRow = styled.View`
+  flex-direction: row;
+  padding-left: 8px;
+`;
+
+const Bullet = styled.Text`
+  font-family: ${font.pretendardRegular};
+  font-size: 15px;
+  line-height: 24px;
+  color: ${color.gray70v2};
+  width: 14px;
+`;
+
+const ItemContent = styled.View`
+  flex: 1;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+`;
+
+const SummaryText = styled.Text`
+  font-family: ${font.pretendardRegular};
+  font-size: 15px;
+  line-height: 24px;
+  letter-spacing: -0.3px;
+  color: ${color.gray70v2};
+`;
+
+const SourceBadge = styled.View`
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  background-color: ${color.gray25};
+  align-items: center;
+  justify-content: center;
+`;
+
+const SourceBadgeText = styled.Text`
+  font-family: ${font.pretendardRegular};
+  font-size: 11px;
+  line-height: 14px;
+  color: ${color.gray70v2};
+`;


### PR DESCRIPTION
서버 PR: Stair-Crusher-Club/scc-server#983

## 배경
PDP 최상단에 "AI 접근성 요약" 섹션. 서버(`getAccessibilityV2`)가 조립한 `aiSummary` 를 렌더.

## 변경
- 신규 `AiSummarySection.tsx` — `PlaceDetailV2Screen` 의 `V2SummarySection` 아래·`V2ThumbnailRow` 위 삽입.
- 데이터: 기존 `accessibilityPost.aiSummary` 재사용 (추가 fetch 없음).
- `aiSummary` 없거나 items 비면 미노출.
- 출처 넘버 배지 ①②③: `sourceTab` → `setCurrentTab('accessibility'|'review')` 이동 + 클릭 로깅(`ai_summary_source_badge`, KPI).
- circle-info(`isExperimental`) → dismissible 안내 문구.

## 검증
- `yarn tsc --noEmit` / `yarn lint` 0 error.
- E2E 3/3 PASS (에뮬레이터), Figma node 1-302 1:1 대조.

## 알려진 minor delta (v1 허용, 기획 "우선 구현 후 다듬기")
- 안내 툴팁 테두리색(Figma 파란테두리 vs 앱 무테두리), 타이틀 blue→purple 그라디언트(단색 근사, RN MaskedView 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI accessibility summary section to place details, showing summary items when available.
  * Summary items may include source badges to switch directly to the related tab.
  * When enabled, experimental AI summaries now include a dismissible notice.
* **Bug Fixes**
  * After successfully deleting a place review, the accessibility-related section is refreshed to reflect updated data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->