### PR TITLE
fix(pdp): AI 요약 툴팁 닫기 아이콘 8.17px 복원

### DIFF
--- a/src/screens/PlaceDetailV2Screen/components/AiSummarySection.tsx
+++ b/src/screens/PlaceDetailV2Screen/components/AiSummarySection.tsx
@@ -100,7 +100,7 @@ export default function AiSummarySection({
                 elementName="ai_summary_notice_close"
                 onPress={() => setShowNotice(false)}
                 hitSlop={8}>
-                <CloseIcon width={12} height={12} />
+                <CloseIcon width={8.17} height={8.17} />
               </SccPressable>
             </CloseButtonSlot>
           </NoticeRow>


### PR DESCRIPTION
이전 작업에서 임의로 12x12로 되돌렸던 툴팁 닫기 아이콘 크기를 사용자 지정 값 8.17x8.17 로 복원.

🤖 Generated with [Claude Code](https://claude.com/claude-code)