### PR TITLE
fix(review): 이동수단 옵션 '해당없음' 항상 마지막 정렬

### DIFF
--- a/src/constant/review.ts
+++ b/src/constant/review.ts
@@ -35,12 +35,17 @@ export const MOBILITY_TOOL_LABELS: Record<UserMobilityToolMapDto, string> = {
     '보행 대체 · 보조 기기가 없으나 보행 불편',
 };
 
-export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS).map(
-  ([value, label]) => ({
+export const MOBILITY_TOOL_OPTIONS = Object.entries(MOBILITY_TOOL_LABELS)
+  .map(([value, label]) => ({
     value: value as UserMobilityToolDto,
     label,
-  }),
-);
+  }))
+  // '해당없음'(NONE)은 라벨 목록 순서가 바뀌어도 항상 마지막에 오도록 한다. (Array.sort는 stable이라 나머지 순서는 유지)
+  .sort(
+    (a, b) =>
+      (a.value === UserMobilityToolDto.None ? 1 : 0) -
+      (b.value === UserMobilityToolDto.None ? 1 : 0),
+  );
 
 export function getMobilityToolDefaultValue(
   mobilityTools?: UserMobilityToolDto[],

--- a/src/screens/PlaceDetailV2Screen/components/AiSummarySection.tsx
+++ b/src/screens/PlaceDetailV2Screen/components/AiSummarySection.tsx
@@ -54,38 +54,40 @@ export default function AiSummarySection({
             </SccPressable>
           )}
         </Header>
-        {aiSummary.items.map((item, index) => {
-          const sourceTab = item.sourceTab;
-          const sourceBadgeNumber =
-            sourceTab === AiSummarySourceTabDto.Accessibility
-              ? 1
-              : hasAccessibilityItem
-                ? 2
-                : 1;
-          return (
-            <ItemRow key={index}>
-              <Bullet>{'•'}</Bullet>
-              {/* 배지를 SummaryText(<Text>) 안 인라인 자식으로 넣는다 (RN은 <Text> 안에
-                  고정 크기 <View>를 넣으면 인라인으로 렌더됨). 텍스트가 여러 줄로 감겨도
-                  마지막 글자 바로 다음에 배지가 이어진다 (별도 우측 컬럼 X). */}
-              <SummaryText>
-                {item.text}
-                {sourceTab ? '  ' : ''}
-                {sourceTab && (
-                  <SccPressable
-                    elementName="ai_summary_source_badge"
-                    logParams={{sourceTab, index}}
-                    onPress={() => onPressSourceTab(sourceTab)}
-                    hitSlop={4}>
-                    <BadgeInline>
-                      <SourceBadgeText>{sourceBadgeNumber}</SourceBadgeText>
-                    </BadgeInline>
-                  </SccPressable>
-                )}
-              </SummaryText>
-            </ItemRow>
-          );
-        })}
+        <ItemContainer>
+          {aiSummary.items.map((item, index) => {
+            const sourceTab = item.sourceTab;
+            const sourceBadgeNumber =
+              sourceTab === AiSummarySourceTabDto.Accessibility
+                ? 1
+                : hasAccessibilityItem
+                  ? 2
+                  : 1;
+            return (
+              <ItemRow key={index}>
+                <Bullet>{'•'}</Bullet>
+                {/* 배지를 SummaryText(<Text>) 안 인라인 자식으로 넣는다 (RN은 <Text> 안에
+                    고정 크기 <View>를 넣으면 인라인으로 렌더됨). 텍스트가 여러 줄로 감겨도
+                    마지막 글자 바로 다음에 배지가 이어진다 (별도 우측 컬럼 X). */}
+                <SummaryText>
+                  {item.text}
+                  {sourceTab ? '  ' : ''}
+                  {sourceTab && (
+                    <SccPressable
+                      elementName="ai_summary_source_badge"
+                      logParams={{sourceTab, index}}
+                      onPress={() => onPressSourceTab(sourceTab)}
+                      hitSlop={4}>
+                      <BadgeInline>
+                        <SourceBadgeText>{sourceBadgeNumber}</SourceBadgeText>
+                      </BadgeInline>
+                    </SccPressable>
+                  )}
+                </SummaryText>
+              </ItemRow>
+            );
+          })}
+        </ItemContainer>
         {/* 다른 레이아웃을 밀어내지 않도록 absolute 오버레이로 띄운다 (Figma node 1-650). */}
         {showNotice && (
           <NoticeRow>
@@ -158,7 +160,7 @@ const Container = styled.View`
   background-color: ${color.gray5};
   border-radius: 5px;
   margin: 0 20px;
-  padding: 10px 8px;
+  padding: 12px 8px;
   gap: 6px;
   position: relative;
   overflow: visible;
@@ -220,6 +222,9 @@ const NoticeText = styled.Text`
 const CloseButtonSlot = styled.View`
   height: 16px;
   justify-content: center;
+`;
+
+const ItemContainer = styled.View`
 `;
 
 const ItemRow = styled.View`


### PR DESCRIPTION
## 변경
- 리뷰 폼 '어떤 이동수단으로 방문하셨나요?' 선택지에서 **'해당없음'(NONE)이 중간에 뜨던 문제** 수정. `MOBILITY_TOOL_LABELS` 에서 NONE이 중간(7번째)에 정의돼 있어 옵션도 중간에 노출됐음. `MOBILITY_TOOL_OPTIONS` 를 NONE이 **항상 마지막**이 되도록 stable sort — 라벨 목록이 바뀌어도 '해당없음'은 마지막 유지.
- AI 요약 섹션 items를 `ItemContainer` 로 감싸는 레이아웃 버그 수정 함께 포함(사용자 작업).

## 검증
- `yarn tsc --noEmit` + `yarn lint` 0 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)