### PR TITLE
fix(search): 추천 칩 글로우 Android 정적화로 갤S25 ANR 해결

### DIFF
--- a/src/components/GradientBorderPill.tsx
+++ b/src/components/GradientBorderPill.tsx
@@ -17,11 +17,13 @@ import {Defs, LinearGradient, Rect, Stop, Svg} from 'react-native-svg';
  * @param outerStyle   outerWrapper에 적용할 추가 스타일 (drop-shadow 등)
  * @param contentStyle contentView에 적용할 추가 스타일 (padding 등)
  * @param gradientId   SVG LinearGradient id — chip/tag 간 충돌 방지용 (고유 문자열)
+ * @param colors       그라데이션 색상(2색 이상). 미지정 시 기본 초록→파랑.
+ * @param borderRadius pill 라운드. 미지정 시 100(완전 pill).
+ * @param contentBackgroundColor 콘텐츠 배경. 미지정 시 white.
  */
 
-const GRADIENT_START = '#4AAB84';
-const GRADIENT_END = '#3596F7';
-const BORDER_RADIUS = 100;
+const DEFAULT_COLORS = ['#4AAB84', '#3596F7'];
+const DEFAULT_BORDER_RADIUS = 100;
 
 interface GradientBorderPillProps {
   borderWidth: number;
@@ -29,6 +31,9 @@ interface GradientBorderPillProps {
   outerStyle?: ViewStyle;
   contentStyle?: ViewStyle;
   gradientId: string;
+  colors?: string[];
+  borderRadius?: number;
+  contentBackgroundColor?: string;
 }
 
 export default function GradientBorderPill({
@@ -37,8 +42,11 @@ export default function GradientBorderPill({
   outerStyle,
   contentStyle,
   gradientId,
+  colors = DEFAULT_COLORS,
+  borderRadius = DEFAULT_BORDER_RADIUS,
+  contentBackgroundColor = 'white',
 }: GradientBorderPillProps) {
-  const innerBorderRadius = BORDER_RADIUS - borderWidth;
+  const innerBorderRadius = borderRadius - borderWidth;
 
   return (
     // 바깥 wrapper에 white bg + borderRadius를 줘야 Android elevation이 pill 모양 그림자를
@@ -49,14 +57,14 @@ export default function GradientBorderPill({
         {
           alignSelf: 'flex-start',
           backgroundColor: 'white',
-          borderRadius: BORDER_RADIUS,
+          borderRadius: borderRadius,
         },
         outerStyle,
       ]}>
       {/* innerWrapper: overflow hidden + borderRadius → 그라데이션 SVG가 pill 모양으로 잘림 */}
       <View
         style={{
-          borderRadius: BORDER_RADIUS,
+          borderRadius: borderRadius,
           overflow: 'hidden',
         }}>
         {/* 그라데이션 보더 레이어 — absoluteFill */}
@@ -66,8 +74,14 @@ export default function GradientBorderPill({
           height="100%">
           <Defs>
             <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
-              <Stop offset="0" stopColor={GRADIENT_START} stopOpacity="1" />
-              <Stop offset="1" stopColor={GRADIENT_END} stopOpacity="1" />
+              {colors.map((c, i) => (
+                <Stop
+                  key={i}
+                  offset={colors.length === 1 ? 0 : i / (colors.length - 1)}
+                  stopColor={c}
+                  stopOpacity="1"
+                />
+              ))}
             </LinearGradient>
           </Defs>
           <Rect
@@ -83,7 +97,7 @@ export default function GradientBorderPill({
           style={[
             {
               margin: borderWidth,
-              backgroundColor: 'white',
+              backgroundColor: contentBackgroundColor,
               borderRadius: innerBorderRadius,
               flexDirection: 'row',
               alignItems: 'center',

--- a/src/screens/SearchScreen/components/SearchHeader/RecommendationChipGlow.tsx
+++ b/src/screens/SearchScreen/components/SearchHeader/RecommendationChipGlow.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import {Platform} from 'react-native';
+import AnimatedGlow, {type PresetConfig} from 'react-native-animated-glow';
+
+import GradientBorderPill from '@/components/GradientBorderPill';
+
+/**
+ * 저장리스트 추천 칩 글로우 shell (블랙 칩 + 빛나는 테두리).
+ *
+ * - iOS: react-native-animated-glow(Skia/Metal 백엔드)로 애니메이션 글로우 유지.
+ * - Android: Skia OpenGL(Ganesh) present가 Adreno GPU(갤S25/안드16)에서
+ *   eglSwapBuffers→Fence::waitForever 로 메인스레드 영구 블록 → ANR/강제종료를 유발한다.
+ *   (skia 2.6.7·animated-glow 3.1.0 최신에서도 재현, Android는 Vulkan 전환 escape hatch 없음.)
+ *   → 애니메이션을 빼고 정적 그라데이션 테두리로 대체해 Android에서 Skia canvas를 아예
+ *   mount하지 않는다(= OpenGL 컨텍스트 미생성). 색상은 iOS 글로우와 동일 계열.
+ */
+
+const CHIP_BACKGROUND = '#16181C'; // Figma 블랙 칩
+const CHIP_CORNER_RADIUS = 20;
+const CHIP_BORDER_COLORS = ['#1EFF00', '#0093FF', '#00FFFA']; // green → blue → cyan
+
+export default function RecommendationChipGlow({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  if (Platform.OS === 'ios') {
+    return (
+      <AnimatedGlow preset={RECOMMENDATION_CHIP_GLOW}>{children}</AnimatedGlow>
+    );
+  }
+
+  return (
+    <GradientBorderPill
+      borderWidth={2}
+      borderRadius={CHIP_CORNER_RADIUS}
+      colors={CHIP_BORDER_COLORS}
+      contentBackgroundColor={CHIP_BACKGROUND}
+      gradientId="recommendationChipBorder">
+      {children}
+    </GradientBorderPill>
+  );
+}
+
+// iOS 애니메이션 글로우 프리셋 — react-native-animated-glow "Confirmation Green" 기반.
+// (Slack 디자인 협의: 시인성↑ + 고대비를 위한 '블랙 버튼 + 빛나는 테두리')
+// borderColor: #1EFF00(green) → #0093FF(blue) → #00FFFA(cyan), background: Figma 블랙 칩(#16181C)
+const RECOMMENDATION_CHIP_GLOW: PresetConfig = {
+  metadata: {
+    name: 'Recommendation Chip Glow',
+    textColor: '#FFFFFF',
+    category: 'Custom',
+    tags: ['recommendation', 'chip'],
+  },
+  states: [
+    {
+      name: 'default',
+      preset: {
+        cornerRadius: CHIP_CORNER_RADIUS,
+        outlineWidth: 2,
+        borderColor: CHIP_BORDER_COLORS,
+        backgroundColor: CHIP_BACKGROUND,
+        animationSpeed: 2,
+        borderSpeedMultiplier: 1,
+        glowLayers: [
+          {
+            glowPlacement: 'behind',
+            colors: ['#0fff47', 'rgba(255, 241, 0, 1)', '#00d646'],
+            glowSize: 10,
+            opacity: 0.05,
+            speedMultiplier: 1,
+            coverage: 1,
+            relativeOffset: 0,
+          },
+          {
+            glowPlacement: 'behind',
+            colors: ['#0fff47', 'rgba(255, 241, 0, 1)', '#00d646'],
+            glowSize: 4,
+            opacity: 0.1,
+            speedMultiplier: 1,
+            coverage: 1,
+            relativeOffset: 0,
+          },
+          {
+            glowPlacement: 'inside',
+            colors: ['rgba(99, 255, 0, 1)', 'rgba(180, 255, 65, 1)'],
+            glowSize: [0, 20],
+            opacity: 0.02,
+            speedMultiplier: 1,
+            coverage: 0.3,
+            relativeOffset: 0,
+          },
+          {
+            glowPlacement: 'over',
+            colors: ['rgba(135, 255, 0, 1)', 'rgba(255, 248, 196, 1)'],
+            glowSize: [0, 1],
+            opacity: 0.5,
+            speedMultiplier: 1,
+            coverage: 0.4,
+            relativeOffset: 0,
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/src/screens/SearchScreen/components/SearchHeader/SearchCategory.tsx
+++ b/src/screens/SearchScreen/components/SearchHeader/SearchCategory.tsx
@@ -2,7 +2,6 @@ import {keepPreviousData, useQuery} from '@tanstack/react-query';
 import {useAtomValue} from 'jotai';
 import React from 'react';
 import {Image, ScrollView, View} from 'react-native';
-import AnimatedGlow, {type PresetConfig} from 'react-native-animated-glow';
 import styled from 'styled-components/native';
 
 import {SccTouchableOpacity} from '@/components/SccTouchableOpacity';
@@ -18,6 +17,7 @@ import {draftCameraRegionAtom} from '@/screens/SearchScreen/atoms';
 import type {SearchMode} from '@/screens/SearchScreen/atoms';
 import useNavigation from '@/navigation/useNavigation';
 
+import RecommendationChipGlow from './RecommendationChipGlow.tsx';
 import SearchCategoryIcon, {Icons} from './SearchCategoryIcon.tsx';
 
 const locationPinImage = require('@/assets/img/ic_location_pin.png');
@@ -127,8 +127,8 @@ export default function SearchCategory({
               placeListId: item.placeListId,
             }}
             onPress={() => handleRecommendationChipPress(item)}>
-            {/* 발견성 강화: Figma 블랙 칩 + react-native-animated-glow 빛나는 테두리(항상 ON) */}
-            <AnimatedGlow preset={RECOMMENDATION_CHIP_GLOW}>
+            {/* 발견성 강화: Figma 블랙 칩 + 빛나는 테두리 (iOS 애니메이션 / Android 정적) */}
+            <RecommendationChipGlow>
               <View
                 style={{
                   flexDirection: 'row',
@@ -146,7 +146,7 @@ export default function SearchCategory({
                 />
                 <RecommendationChipText>{item.name}</RecommendationChipText>
               </View>
-            </AnimatedGlow>
+            </RecommendationChipGlow>
           </SccTouchableOpacity>
         );
       }
@@ -213,71 +213,6 @@ const RecommendationChipText = styled.Text`
   line-height: 20px;
   letter-spacing: -0.28px;
 `;
-
-// 저장리스트 추천 칩 글로우 — react-native-animated-glow "Confirmation Green" 프리셋 기반.
-// (Slack 디자인 협의: 시인성↑ + 고대비를 위한 '블랙 버튼 + 빛나는 테두리' 조합)
-// 기본 프리셋에서 General borderColor만 아래 3색으로 교체하고,
-// backgroundColor는 Figma 블랙 칩(#16181C)으로 지정. 애니메이션은 항상(default 상태) 동작.
-// borderColor: #1EFF00(green) → #0093FF(blue) → #00FFFA(cyan)
-const RECOMMENDATION_CHIP_GLOW: PresetConfig = {
-  metadata: {
-    name: 'Recommendation Chip Glow',
-    textColor: '#FFFFFF',
-    category: 'Custom',
-    tags: ['recommendation', 'chip'],
-  },
-  states: [
-    {
-      name: 'default',
-      preset: {
-        cornerRadius: 20,
-        outlineWidth: 2,
-        borderColor: ['#1EFF00', '#0093FF', '#00FFFA'],
-        backgroundColor: '#16181C',
-        animationSpeed: 2,
-        borderSpeedMultiplier: 1,
-        glowLayers: [
-          {
-            glowPlacement: 'behind',
-            colors: ['#0fff47', 'rgba(255, 241, 0, 1)', '#00d646'],
-            glowSize: 10,
-            opacity: 0.05,
-            speedMultiplier: 1,
-            coverage: 1,
-            relativeOffset: 0,
-          },
-          {
-            glowPlacement: 'behind',
-            colors: ['#0fff47', 'rgba(255, 241, 0, 1)', '#00d646'],
-            glowSize: 4,
-            opacity: 0.1,
-            speedMultiplier: 1,
-            coverage: 1,
-            relativeOffset: 0,
-          },
-          {
-            glowPlacement: 'inside',
-            colors: ['rgba(99, 255, 0, 1)', 'rgba(180, 255, 65, 1)'],
-            glowSize: [0, 20],
-            opacity: 0.02,
-            speedMultiplier: 1,
-            coverage: 0.3,
-            relativeOffset: 0,
-          },
-          {
-            glowPlacement: 'over',
-            colors: ['rgba(135, 255, 0, 1)', 'rgba(255, 248, 196, 1)'],
-            glowSize: [0, 1],
-            opacity: 0.5,
-            speedMultiplier: 1,
-            coverage: 0.4,
-            relativeOffset: 0,
-          },
-        ],
-      },
-    },
-  ],
-};
 
 type SearchCategoryItem = {
   category: keyof typeof Icons;


### PR DESCRIPTION
## 문제

갤럭시 S25 플러스 / 안드로이드 16 / 앱 1.3.10 에서 검색·정복 지도 화면 진입 시 지도만 뜨고 세부 사항이 안 뜬 채 앱이 종료됨. ([Slack](https://staircrusherclub.slack.com/archives/C09G2TB1GCA/p1783400247304479?thread_ts=1783400171.301329&cid=C09G2TB1GCA))

## 원인 (Crashlytics ANR 트레이스 분석)

메인 스레드가 아래에서 영구 블록 → ANR → OS 강제 종료:

```
eglSwapBuffers → android::Fence::waitForever        # GPU fence 영구 대기
RNSkia::OpenGLWindowContext::present
RNSkia::RNSkView::requestRedraw
com.swmansion.worklets.AndroidUIScheduler.triggerUI  # reanimated/worklets가 매 프레임 redraw 구동
Handler → Looper.loop → ActivityThread.main
```

- 앱의 **유일한 Skia 소비자**는 추천 칩의 "항상 ON" 글로우(`react-native-animated-glow`). 전수 grep 결과 `SearchCategory.tsx` 1곳뿐. (vision-camera는 Skia frame processor 미사용.)
- react-native-skia는 **Android에서 OpenGL(Ganesh)만** 사용. Vulkan/Graphite는 experimental(프로덕션 비권장)이라 백엔드 전환 방법이 없음. 갤S25(Adreno)에서 continuous present가 fence에 물려 hang (트레이스에 Naver 지도 `GLThread` GLSurfaceView 공존 → GL 서피스 경합 가중 추정).
- **skia 2.6.7 · animated-glow 3.1.0 둘 다 이미 최신** → 업그레이드로 해결 불가.
- iOS는 Skia가 Metal 백엔드라 무관 — 크래시는 Android(Adreno) 전용.

## 변경

- **iOS**: 기존 Skia 애니메이션 글로우 **그대로 유지** (품질 100% 보존).
- **Android**: 애니메이션 제거 → **정적 그라데이션 테두리**(검정 칩 + green→blue→cyan)로 대체. Android에서 Skia canvas를 아예 mount하지 않아 GL 컨텍스트 미생성 → ANR 원천 차단.
- `RecommendationChipGlow` shell 컴포넌트로 플랫폼 분기. 정적 테두리는 기존 `GradientBorderPill`을 `colors`/`borderRadius`/`contentBackgroundColor` 옵션으로 backward-compatible 확장해 재사용.
- 네이티브(pod/gradle) 변경 없음 — **순수 JS/OTA 대상.** Skia·animated-glow 의존성은 iOS가 계속 쓰므로 제거 안 함.

## 검증

- [x] `yarn tsc --noEmit` 0 error
- [x] `yarn lint` 0 error
- [ ] iOS 시뮬레이터: 추천 칩 애니메이션 글로우 기존과 동일 렌더 확인
- [ ] Android 에뮬레이터: 추천 칩이 검정 배경 + 정적 3색 그라데이션 테두리로 렌더(애니메이션 없음) 확인
- [ ] (가능 시) 갤S25 실기기에서 지도 화면 진입 크래시 재현 안 됨 확인 — Adreno fence 행은 에뮬레이터(host GPU)에서 재현 불가라 by-construction 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommendation chips now have a more polished glow/border treatment with platform-appropriate rendering.
  * The pill-style border component now supports customizable gradient colors, corner rounding, and content background color.

* **Bug Fixes**
  * Improved visual consistency across platforms by using a shared chip glow component with a static fallback where needed.
  * Better handling of single-color gradients and border radius calculations for more reliable rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->