### PR TITLE
feat(search): 지역명+화장실 검색을 장애인 화장실 모드로 렌더

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -5125,6 +5125,20 @@ export type PlaceSearchRecommendationTypeDto = typeof PlaceSearchRecommendationT
 
 
 /**
+ * /searchPlaces 응답의 결과 종류 판별자.
+ * @export
+ * @enum {string}
+ */
+
+export const PlaceSearchResultModeDto = {
+    Place: 'PLACE',
+    AccessibleToilet: 'ACCESSIBLE_TOILET'
+} as const;
+
+export type PlaceSearchResultModeDto = typeof PlaceSearchResultModeDto[keyof typeof PlaceSearchResultModeDto];
+
+
+/**
  * 장소의 특수 접근성 정보. 뿌클로드 등 특수한 방식으로 접근성 정보를 제공하는 장소에 대한 메타데이터.
  * @export
  * @interface PlaceSpecialAccessibilityDto
@@ -6615,6 +6629,24 @@ export interface SearchPlacesResponseDto {
      * @memberof SearchPlacesResponseDto
      */
     'items': Array<PlaceListItem>;
+    /**
+     * 
+     * @type {PlaceSearchResultModeDto}
+     * @memberof SearchPlacesResponseDto
+     */
+    'mode'?: PlaceSearchResultModeDto;
+    /**
+     * mode가 ACCESSIBLE_TOILET일 때의 장애인 화장실 검색 결과. 그 외에는 비어있다.
+     * @type {Array<ToiletSummaryDto>}
+     * @memberof SearchPlacesResponseDto
+     */
+    'toiletItems'?: Array<ToiletSummaryDto>;
+    /**
+     * 
+     * @type {Location}
+     * @memberof SearchPlacesResponseDto
+     */
+    'toiletSearchCenter'?: Location;
 }
 /**
  * 

--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -6641,12 +6641,6 @@ export interface SearchPlacesResponseDto {
      * @memberof SearchPlacesResponseDto
      */
     'toiletItems'?: Array<ToiletSummaryDto>;
-    /**
-     * 
-     * @type {Location}
-     * @memberof SearchPlacesResponseDto
-     */
-    'toiletSearchCenter'?: Location;
 }
 /**
  * 

--- a/src/screens/SearchScreen/components/SearchMapView.tsx
+++ b/src/screens/SearchScreen/components/SearchMapView.tsx
@@ -16,7 +16,7 @@ import {PlaceListItem} from '@/generated-sources/openapi';
 import {LogParamsProvider} from '@/logging/LogParamsProvider';
 import {
   draftCameraRegionAtom,
-  searchModeAtom,
+  SearchMode,
   searchQueryAtom,
   toiletLayerActiveAtom,
   viewStateAtom,
@@ -40,10 +40,10 @@ const SearchMapView = forwardRef<
   SearchMapViewHandle,
   {
     data: SearchResultItem[];
+    resultMode: SearchMode;
     onRefresh: () => void;
   }
->(({data, onRefresh}, ref) => {
-  const searchMode = useAtomValue(searchModeAtom);
+>(({data, resultMode, onRefresh}, ref) => {
   const [toiletLayerActive, setToiletLayerActive] = useAtom(
     toiletLayerActiveAtom,
   );
@@ -74,16 +74,16 @@ const SearchMapView = forwardRef<
   const viewState = useAtomValue(viewStateAtom);
   const setDraftCameraRegion = useSetAtom(draftCameraRegionAtom);
   const datasForUI: MapViewItem[] = useMemo(() => {
-    if (searchMode === 'toilet') {
+    if (resultMode === 'toilet') {
       // Toilet data is already mapped with MarkerItem
       return (data as (ToiletDetails & MarkerItem)[]) ?? [];
     }
     // Place data needs to be mapped
     return (data as PlaceListItem[])?.map(toPlaceMarkerItem) ?? [];
-  }, [data, searchMode]);
+  }, [data, resultMode]);
   const isSearchQueryEmpty = !searchQuery.text;
 
-  const showToiletLayerToggle = searchMode !== 'toilet';
+  const showToiletLayerToggle = resultMode !== 'toilet';
 
   const handleOverlayMarkerPress = useCallback(
     (item: MarkerItem) => {
@@ -123,7 +123,7 @@ const SearchMapView = forwardRef<
           onRefresh={onRefresh}
           isRefreshVisible={!isSearchQueryEmpty}
           ItemCard={
-            (searchMode === 'toilet'
+            (resultMode === 'toilet'
               ? ToiletCard
               : SearchItemCard) as React.FC<{
               item: MapViewItem;

--- a/src/screens/SearchScreen/index.tsx
+++ b/src/screens/SearchScreen/index.tsx
@@ -112,10 +112,9 @@ const SearchScreenContent = ({
   const setFilter = useSetAtom(filterAtom);
   const [searchQuery, setSearchQuery] = useAtom(searchQueryAtom);
   const setSearchMode = useSetAtom(searchModeAtom);
-  const searchMode = useAtomValue(searchModeAtom);
   const setToiletLayerActive = useSetAtom(toiletLayerActiveAtom);
 
-  const {data, isLoading, updateQuery, setOnFetchCompleted} =
+  const {data, resultMode, isLoading, updateQuery, setOnFetchCompleted} =
     useSearchRequest();
 
   const searchRequestId = useAtomValue(searchRequestIdAtom);
@@ -356,9 +355,10 @@ const SearchScreenContent = ({
                 );
               }}
               data={data ?? []}
+              resultMode={resultMode}
             />
           </View>
-          {viewState.inputMode && searchMode === 'place' && (
+          {viewState.inputMode && resultMode === 'place' && (
             <SearchSummaryView
               onItemSelect={onItemSelect}
               isLoading={isLoading}
@@ -377,7 +377,7 @@ const SearchScreenContent = ({
           )}
           {!viewState.inputMode &&
             viewState.type === 'list' &&
-            searchMode === 'place' && (
+            resultMode === 'place' && (
               <SearchListView
                 isVisible={true}
                 isLoading={isLoading}
@@ -386,7 +386,7 @@ const SearchScreenContent = ({
             )}
           {!viewState.inputMode &&
             viewState.type === 'list' &&
-            searchMode === 'toilet' && (
+            resultMode === 'toilet' && (
               <ToiletListView
                 isVisible={true}
                 isLoading={isLoading}

--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -232,8 +232,6 @@ export default function useSearchRequest() {
         logger.logElementClick('toilet_search', {
           search_query: text,
           search_request_id: requestId,
-          search_lat: response.data.toiletSearchCenter?.lat,
-          search_lng: response.data.toiletSearchCenter?.lng,
           search_region_type: 'region_keyword',
           result_count: toiletResult.length,
           top_result_ids: toiletResult

--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -8,6 +8,7 @@ import {MarkerItem} from '@/components/maps/MarkerItem.ts';
 import {getCenterAndRadius} from '@/components/maps/Types.tsx';
 import {
   PlaceListItem,
+  PlaceSearchResultModeDto,
   RectangleSearchRegionDto,
   SearchPlaceSortDto,
 } from '@/generated-sources/openapi';
@@ -17,6 +18,7 @@ import {
   SortOption,
   draftCameraRegionAtom,
   filterAtom,
+  SearchMode,
   searchModeAtom,
   searchQueryAtom,
   searchRequestIdAtom,
@@ -31,6 +33,17 @@ import GeolocationUtils from '@/utils/GeolocationUtils';
 import ToastUtils from '@/utils/ToastUtils.ts';
 
 export type SearchResultItem = PlaceListItem | (ToiletDetails & MarkerItem);
+
+/**
+ * 검색 결과와 그 결과의 렌더 모드를 함께 담는다. mode/items가 동일 응답에서 나오므로
+ * "toilet 모드인데 place 데이터" 같은 desync가 원천적으로 없다.
+ * (fetch 분기는 searchModeAtom, 렌더 분기는 이 mode를 쓴다 — "강남 화장실"은 place 엔드포인트로
+ *  fetch되지만 서버가 화장실 결과를 내려주면 mode='toilet'이 된다.)
+ */
+export interface SearchResult {
+  mode: SearchMode;
+  items: SearchResultItem[];
+}
 
 function generateRequestId(): string {
   const now = new Date();
@@ -54,8 +67,8 @@ export default function useSearchRequest() {
   const devTool = useDevTool();
   const keyboard = useKeyboard();
   const keyboardRef = useRef(keyboard);
-  const {data, isFetching, refetch} = useQuery({
-    initialData: [],
+  const {data, isFetching, refetch} = useQuery<SearchResult | null>({
+    initialData: {mode: 'place', items: []},
     throwOnError: error => {
       ToastUtils.showOnApiError(error);
       return false;
@@ -74,7 +87,7 @@ export default function useSearchRequest() {
         searchMode,
       },
     ],
-    queryFn: async ({signal}): Promise<SearchResultItem[] | null> => {
+    queryFn: async ({signal}): Promise<SearchResult | null> => {
       if (!text) {
         return null; // No search text -> Do not call API because it is landing page
       }
@@ -151,7 +164,7 @@ export default function useSearchRequest() {
           : (location ?? currentLocation);
         if (!toiletCurrentLocation) {
           ToastUtils.show('현재 위치를 확인할 수 없습니다.');
-          return [];
+          return {mode: 'toilet', items: []};
         }
         const response = await toiletApi.searchToilets(
           {
@@ -183,7 +196,7 @@ export default function useSearchRequest() {
         }
         onFetchCompleted.current?.(result);
         onFetchCompleted.current = () => {};
-        return result;
+        return {mode: 'toilet', items: result};
       }
 
       // Default: place search
@@ -207,6 +220,35 @@ export default function useSearchRequest() {
         },
         {signal},
       );
+
+      // "<지역명> 화장실" 검색은 place 엔드포인트로 나갔지만 서버가 장애인 화장실 검색으로
+      // 처리해 내려줄 수 있다. 이 경우 2차 fetch 없이 인라인 toiletItems를 그대로 화장실 결과로 쓴다.
+      if (response?.data.mode === PlaceSearchResultModeDto.AccessibleToilet) {
+        const toiletResult = (response.data.toiletItems ?? []).map(
+          mapSummaryToToiletDetails,
+        );
+        const requestId = generateRequestId();
+        setSearchRequestId(requestId);
+        logger.logElementClick('toilet_search', {
+          search_query: text,
+          search_request_id: requestId,
+          search_lat: response.data.toiletSearchCenter?.lat,
+          search_lng: response.data.toiletSearchCenter?.lng,
+          search_region_type: 'region_keyword',
+          result_count: toiletResult.length,
+          top_result_ids: toiletResult
+            .slice(0, 3)
+            .map(item => item.id)
+            .join(','),
+        });
+        if (toiletResult.length === 0) {
+          ToastUtils.show('검색 결과가 없습니다.');
+        }
+        onFetchCompleted.current?.(toiletResult);
+        onFetchCompleted.current = () => {};
+        return {mode: 'toilet', items: toiletResult};
+      }
+
       const result = response?.data.items || [];
       const requestId = generateRequestId();
       setSearchRequestId(requestId);
@@ -237,7 +279,7 @@ export default function useSearchRequest() {
       }
       onFetchCompleted.current?.(result);
       onFetchCompleted.current = () => {};
-      return result;
+      return {mode: 'place', items: result};
     },
   });
   const onFetchCompleted = useRef<(result: SearchResultItem[]) => void>(
@@ -272,10 +314,14 @@ export default function useSearchRequest() {
   const isTransitioningToMapView =
     !viewState.inputMode && viewState.type === 'map';
 
+  // mode/items를 항상 같은 응답에서 가져와 desync를 막는다. 렌더는 resultMode로 분기한다.
+  const items = data?.items ?? [];
+  const resultMode: SearchMode = data?.mode ?? 'place';
+
   useEffect(() => {
     if (isTransitioningToMapView && hasActiveSearch && !isFetching) {
       setTimeout(() => {
-        onFetchCompleted.current?.(data ?? []);
+        onFetchCompleted.current?.(items);
         onFetchCompleted.current = () => {};
       });
     }
@@ -294,7 +340,8 @@ export default function useSearchRequest() {
   }, [keyboard.keyboardShown]);
 
   return {
-    data,
+    data: items,
+    resultMode,
     isLoading: isFetching,
     refetch,
     updateQuery,


### PR DESCRIPTION
## 배경

서버가 "강남 화장실"처럼 **지역명 + (장애인)?화장실** 검색을 장애인 화장실 지역 검색으로 처리해, `/searchPlaces` 응답에 `mode=ACCESSIBLE_TOILET` + `toiletItems`를 담아 내려준다(scc-server PR #994). 앱은 이를 이미 구현된 장애인 화장실 검색 모드(토일렛 핀/카드)로 렌더한다.

## 변경

- **fetch 모드와 render 모드 분리**: `useSearchRequest` 쿼리가 `{mode, items}`를 **한 응답에서** 반환 → "toilet 모드인데 place 데이터" desync를 원천 차단. 훅은 배열 `data` + 파생 `resultMode`를 반환.
- place 브랜치 응답이 `ACCESSIBLE_TOILET`이면 **2차 fetch 없이** `toiletItems`를 기존 `mapSummaryToToiletDetails`로 매핑해 화장실 결과로 사용.
- `SearchMapView`/`index.tsx`의 렌더 분기(핀·카드·리스트)를 `resultMode`로 전환. fetch 분기(어떤 엔드포인트를 부를지)는 기존 `searchModeAtom` 유지.
- "강남 화장실"은 이미 `/searchPlaces`로 나가므로 앱 검색어 감지(`isToiletSearchKeyword`)는 **변경 없음**. 순수 "화장실"/"장애인화장실"은 기존 near-me 화장실 모드 그대로.

## 관련 PR
- scc-api: https://github.com/Stair-Crusher-Club/scc-api/pull/122
- scc-server: https://github.com/Stair-Crusher-Club/scc-server/pull/994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search results now support multiple result modes, including places and accessible toilets.
  - The search screen can automatically switch the summary, list, and map views based on the returned result mode.

- **Bug Fixes**
  - Improved alignment between fetched search data and what is rendered in the UI.
  - Accessible toilet results now load more directly, reducing additional transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->