### PR TITLE
fix(search): 검색어 없을 때 최근 검색어/추천 화면 표시

### DIFF
--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -338,7 +338,9 @@ export default function useSearchRequest() {
   }, [keyboard.keyboardShown]);
 
   return {
-    data: items,
+    // 검색어가 없으면 null을 반환해 랜딩(최근 검색어/추천) 화면을 띄운다.
+    // items로 뭉개면 []가 되어 "검색 결과 없음"이 대신 렌더된다.
+    data: hasActiveSearch ? items : null,
     resultMode,
     isLoading: isFetching,
     refetch,


### PR DESCRIPTION
## 문제
SearchScreen에서 input을 포커스해도 최근 검색어가 뜨지 않고 "검색 결과 없음" 화면이 떴다.

## 원인
`useSearchRequest`가 검색어 없는 랜딩 상태에서 결과를 `null` 대신 `[]`로 반환.
- queryFn은 검색어 없으면 `null`을 리턴 (랜딩)
- 훅이 `data?.items ?? []`로 `[]`로 뭉갬
- `SearchSummaryView`는 `searchResults === null`일 때만 최근검색어/추천을 렌더 → 죽은 분기
- `[]`라서 `length === 0` → `SearchNoResult` 렌더

## 수정
이미 있던 `hasActiveSearch` 플래그로 랜딩 상태를 명시 구분해 `null` 반환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now only show “no results” when a search is actually active.
  * Clearing the search text will no longer display an empty-results state for the default view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->