### PR TITLE
feat(share): SccContent 공유 재설계 — sccContentId 링크 + 플랫폼 라우팅

### DIFF
--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -2968,6 +2968,19 @@ export interface GetSccContentDetailsResponseDto {
     'upvoteSummary'?: SccContentUpvoteSummaryDto;
 }
 /**
+ * id 로 SccContent 단건을 조회하기 위한 요청. 
+ * @export
+ * @interface GetSccContentRequestDto
+ */
+export interface GetSccContentRequestDto {
+    /**
+     * 
+     * @type {string}
+     * @memberof GetSccContentRequestDto
+     */
+    'sccContentId': string;
+}
+/**
  * 
  * @export
  * @interface GetToiletRequestDto
@@ -9321,6 +9334,46 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * sccContentId 로 SccContent 를 조회한다. 비로그인 사용자도 호출 가능하다 (예: 공유된 컨텐츠 링크로 진입). 
+         * @summary SccContent 단건을 id로 조회한다.
+         * @param {GetSccContentRequestDto} getSccContentRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getSccContent: async (getSccContentRequestDto: GetSccContentRequestDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'getSccContentRequestDto' is not null or undefined
+            assertParamExists('getSccContent', 'getSccContentRequestDto', getSccContentRequestDto)
+            const localVarPath = `/getSccContent`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Anonymous required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(getSccContentRequestDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * 웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 요약을 통합 응답한다. - URL 기준으로 SccContent id + 현재 유저의 저장 여부. - 서버가 URL pattern 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 을 추론하여 응답의 upvoteSummary 에 좋아요 요약(totalCount, isUpvoted) 을 채운다. - 좋아요 개념이 적용되지 않는 URL 이면 upvoteSummary 는 null. - 한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다. 
          * @summary 웹뷰 컨텐츠의 저장 상태 + 좋아요 요약을 한 번에 조회한다.
          * @param {GetSccContentDetailsRequestDto} getSccContentDetailsRequestDto 
@@ -12076,6 +12129,17 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * sccContentId 로 SccContent 를 조회한다. 비로그인 사용자도 호출 가능하다 (예: 공유된 컨텐츠 링크로 진입). 
+         * @summary SccContent 단건을 id로 조회한다.
+         * @param {GetSccContentRequestDto} getSccContentRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getSccContent(getSccContentRequestDto: GetSccContentRequestDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SccContentDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getSccContent(getSccContentRequestDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * 웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 요약을 통합 응답한다. - URL 기준으로 SccContent id + 현재 유저의 저장 여부. - 서버가 URL pattern 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 을 추론하여 응답의 upvoteSummary 에 좋아요 요약(totalCount, isUpvoted) 을 채운다. - 좋아요 개념이 적용되지 않는 URL 이면 upvoteSummary 는 null. - 한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다. 
          * @summary 웹뷰 컨텐츠의 저장 상태 + 좋아요 요약을 한 번에 조회한다.
          * @param {GetSccContentDetailsRequestDto} getSccContentDetailsRequestDto 
@@ -13101,6 +13165,16 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         getReviewActivityReportPost(options?: any): AxiosPromise<GetReviewActivityReportResponseDto> {
             return localVarFp.getReviewActivityReportPost(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * sccContentId 로 SccContent 를 조회한다. 비로그인 사용자도 호출 가능하다 (예: 공유된 컨텐츠 링크로 진입). 
+         * @summary SccContent 단건을 id로 조회한다.
+         * @param {GetSccContentRequestDto} getSccContentRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getSccContent(getSccContentRequestDto: GetSccContentRequestDto, options?: any): AxiosPromise<SccContentDto> {
+            return localVarFp.getSccContent(getSccContentRequestDto, options).then((request) => request(axios, basePath));
         },
         /**
          * 웹뷰 진입 시 라운드트립 1회로 끝낼 수 있도록 저장 상태와 좋아요 요약을 통합 응답한다. - URL 기준으로 SccContent id + 현재 유저의 저장 여부. - 서버가 URL pattern 에서 좋아요 target (e.g. BBUCLE_ROAD path id) 을 추론하여 응답의 upvoteSummary 에 좋아요 요약(totalCount, isUpvoted) 을 채운다. - 좋아요 개념이 적용되지 않는 URL 이면 upvoteSummary 는 null. - 한 번도 저장된 적 없는 URL이면 sccContentId 는 null 로 응답한다. 
@@ -14142,6 +14216,18 @@ export class DefaultApi extends BaseAPI {
      */
     public getReviewActivityReportPost(options?: AxiosRequestConfig) {
         return DefaultApiFp(this.configuration).getReviewActivityReportPost(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * sccContentId 로 SccContent 를 조회한다. 비로그인 사용자도 호출 가능하다 (예: 공유된 컨텐츠 링크로 진입). 
+     * @summary SccContent 단건을 id로 조회한다.
+     * @param {GetSccContentRequestDto} getSccContentRequestDto 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getSccContent(getSccContentRequestDto: GetSccContentRequestDto, options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).getSccContent(getSccContentRequestDto, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -9355,10 +9355,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-            // authentication Anonymous required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -9394,10 +9390,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
-
-            // authentication Identified required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
 
     

--- a/src/generated-sources/openapi/api.ts
+++ b/src/generated-sources/openapi/api.ts
@@ -9391,6 +9391,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication Anonymous required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';

--- a/src/navigation/Navigation.screens.ts
+++ b/src/navigation/Navigation.screens.ts
@@ -96,6 +96,9 @@ import UpvoteAnalyticsScreen, {
 import ResolvingSharedLinkScreen, {
   ResolvingSharedLinkScreenParams,
 } from '@/screens/ResolvingSharedLinkScreen';
+import ResolvingSccContentScreen, {
+  ResolvingSccContentScreenParams,
+} from '@/screens/ResolvingSccContentScreen';
 import WebViewScreen, {WebViewScreenParams} from '@/screens/WebViewScreen';
 
 export type CustomNavigationOptions = NativeStackNavigationOptions & {
@@ -382,6 +385,11 @@ export const MainNavigationScreens: {
     component: ResolvingSharedLinkScreen,
     options: {headerShown: false},
   },
+  {
+    name: 'ResolvingSccContent',
+    component: ResolvingSccContentScreen,
+    options: {headerShown: false},
+  },
 ];
 
 export type ScreenParams = {
@@ -448,6 +456,7 @@ export type ScreenParams = {
   TutorialMissionSavePlaceList: PublicPlaceListsScreenParams;
   TutorialUpvoteAccessibilityMission: undefined;
   ResolvingSharedLink: ResolvingSharedLinkScreenParams;
+  ResolvingSccContent: ResolvingSccContentScreenParams;
 
   // 웹 전용 화면 (Platform.OS === 'web' 에서만 등록됨; webScreens 참조)
   BbucleRoad: {bbucleRoadId: string};

--- a/src/navigation/linkingConfig.ts
+++ b/src/navigation/linkingConfig.ts
@@ -69,6 +69,9 @@ export const linkingScreensConfig = {
     TutorialUpvoteAccessibilityMission: {
       path: 'tutorial-mission-upvote-accessibility',
     },
+    ResolvingSccContent: {
+      path: 'scc-content/:sccContentId',
+    },
   },
 };
 
@@ -109,5 +112,8 @@ export const webLinkingScreensConfig = {
     KakaoCallback: 'oauth/kakao',
     // Apple web OAuth popup Return URL target
     AppleCallback: 'oauth/apple',
+    ResolvingSccContent: {
+      path: 'scc-content/:sccContentId',
+    },
   },
 };

--- a/src/navigation/webAccess.ts
+++ b/src/navigation/webAccess.ts
@@ -16,6 +16,10 @@ const NO_TOKEN_ALLOWED = new Set<string>([
   'AppleCallback',
   'BbucleRoad',
   'BbucleRoadList',
+  'ResolvingSccContent',
+  // getSccContent 는 Anonymous 허용 API. ResolvingSccContent 가 resolve 후
+  // replace 하는 목적지도 token 없이 열려야 R2/R3(미설치/데스크탑 브라우저) 가 성립한다.
+  'Webview',
 ]);
 
 // Camera / photo capture flows — not possible on web → app install prompt.

--- a/src/screens/ResolvingSccContentScreen/index.tsx
+++ b/src/screens/ResolvingSccContentScreen/index.tsx
@@ -1,0 +1,62 @@
+import React, {useEffect} from 'react';
+import {ActivityIndicator, StyleSheet, Text, View} from 'react-native';
+
+import {ScreenLayout} from '@/components/ScreenLayout';
+import useAppComponents from '@/hooks/useAppComponents';
+import {ScreenProps} from '@/navigation/Navigation.screens';
+import ToastUtils from '@/utils/ToastUtils';
+
+export type ResolvingSccContentScreenParams = {
+  sccContentId: string;
+};
+
+type Props = ScreenProps<'ResolvingSccContent'>;
+
+export default function ResolvingSccContentScreen({navigation, route}: Props) {
+  const {sccContentId} = route.params;
+  const {api} = useAppComponents();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolve() {
+      try {
+        const res = await api.getSccContent({sccContentId});
+        const data = res.data;
+        if (cancelled) {
+          return;
+        }
+        navigation.replace('Webview', {
+          url: data.url,
+          fixedTitle: data.webPageDetail?.title ?? undefined,
+        });
+      } catch {
+        if (!cancelled) {
+          ToastUtils.show('컨텐츠를 찾지 못했어요');
+          navigation.goBack();
+        }
+      }
+    }
+
+    resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, [sccContentId, api, navigation]);
+
+  return (
+    <ScreenLayout isHeaderVisible={false}>
+      <View style={styles.container}>
+        <ActivityIndicator size="large" />
+        <Text style={styles.message}>
+          {'컨텐츠를 불러오는 중입니다\n잠시만 기다려주세요...'}
+        </Text>
+      </View>
+    </ScreenLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16},
+  message: {fontSize: 15, color: '#666', textAlign: 'center', lineHeight: 22},
+});

--- a/src/screens/WebViewScreen/components/SccContentFloatingBar.tsx
+++ b/src/screens/WebViewScreen/components/SccContentFloatingBar.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {Share, View} from 'react-native';
+import {View} from 'react-native';
 import {keepPreviousData, useQuery} from '@tanstack/react-query';
 import styled from 'styled-components/native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -109,15 +109,7 @@ export default function SccContentFloatingBar({
   // 공유하기
   const handleShare = useCallback(async () => {
     try {
-      if (sccContentId) {
-        await ShareUtils.shareBbucleRoad(sccContentId, title);
-      } else {
-        await Share.share({
-          message: title
-            ? `[${title}]를 계단뿌셔클럽에서 확인해보세요!\n${url}`
-            : url,
-        });
-      }
+      await ShareUtils.shareSccContent(sccContentId, url, title);
     } catch (_error) {
       // Share 취소는 에러로 처리하지 않음
     }

--- a/src/utils/ShareUtils.ts
+++ b/src/utils/ShareUtils.ts
@@ -2,8 +2,7 @@ import {Share} from 'react-native';
 
 import {Place} from '@/generated-sources/openapi';
 
-// TODO(airbridge): 발급된 shortId로 교체 — 콩알이 발급 대기
-const SCC_CONTENT_SHARE_SHORT_ID = 'scc_content_share';
+const SCC_CONTENT_SHARE_SHORT_ID = 'scc-content';
 
 const ShareUtils = {
   async sharePlace(place: Place) {

--- a/src/utils/ShareUtils.ts
+++ b/src/utils/ShareUtils.ts
@@ -2,6 +2,9 @@ import {Share} from 'react-native';
 
 import {Place} from '@/generated-sources/openapi';
 
+// TODO(airbridge): 발급된 shortId로 교체 — 콩알이 발급 대기
+const SCC_CONTENT_SHARE_SHORT_ID = 'scc_content_share';
+
 const ShareUtils = {
   async sharePlace(place: Place) {
     const url = `https://link.staircrusher.club/c8yi3t?placeId=${place.id}`;
@@ -9,10 +12,25 @@ const ShareUtils = {
       message: `[${place.name}]의 접근성 정보를 계단뿌셔클럽 앱에서 확인해보세요!\n${url}`,
     });
   },
-  async shareBbucleRoad(bbucleRoadId: string, title?: string) {
-    const url = `https://link.staircrusher.club/enz1zxm?bbucleRoadId=${bbucleRoadId}`;
+  // SccContent(웹뷰로 보는 컨텐츠) 공유. sccContentId 가 있으면 트래킹링크(id만 실어
+  // 앱/web.staircrusher.club 이 열렸을 때 원본 url로 라우팅)를, 없으면 contentUrl을 그대로 공유.
+  async shareSccContent(
+    sccContentId: string | null,
+    contentUrl: string,
+    title?: string,
+  ) {
+    if (sccContentId) {
+      const url = `https://link.staircrusher.club/${SCC_CONTENT_SHARE_SHORT_ID}?sccContentId=${encodeURIComponent(sccContentId)}`;
+      return Share.share({
+        message: title
+          ? `[${title}]를 계단뿌셔클럽에서 확인해보세요!\n${url}`
+          : url,
+      });
+    }
     return Share.share({
-      message: `[${title || '뿌클로드'}]를 계단뿌셔클럽 앱에서 확인해보세요!\n${url}`,
+      message: title
+        ? `[${title}]를 계단뿌셔클럽에서 확인해보세요!\n${contentUrl}`
+        : contentUrl,
     });
   },
 };

--- a/src/utils/ShareUtils.web.ts
+++ b/src/utils/ShareUtils.web.ts
@@ -1,6 +1,9 @@
 import type {Place} from '@/generated-sources/openapi';
 import ToastUtils from '@/utils/ToastUtils';
 
+// TODO(airbridge): 발급된 shortId로 교체 — 콩알이 발급 대기
+const SCC_CONTENT_SHARE_SHORT_ID = 'scc_content_share';
+
 async function copyToClipboard(url: string) {
   try {
     await navigator.clipboard.writeText(url);
@@ -34,8 +37,19 @@ const ShareUtils = {
   async sharePlace(place: Place) {
     await copyToClipboard(buildPlaceShareUrl(place.id));
   },
-  async shareBbucleRoad(_bbucleRoadId: string, _title?: string) {
-    await copyToClipboard(window.location.href);
+  // 네이티브와 동일 시그니처. id 있으면 트래킹링크, 없으면 contentUrl을 클립보드에 복사.
+  async shareSccContent(
+    sccContentId: string | null,
+    contentUrl: string,
+    _title?: string,
+  ) {
+    if (sccContentId) {
+      await copyToClipboard(
+        `https://link.staircrusher.club/${SCC_CONTENT_SHARE_SHORT_ID}?sccContentId=${encodeURIComponent(sccContentId)}`,
+      );
+      return;
+    }
+    await copyToClipboard(contentUrl);
   },
 };
 

--- a/src/utils/ShareUtils.web.ts
+++ b/src/utils/ShareUtils.web.ts
@@ -1,8 +1,7 @@
 import type {Place} from '@/generated-sources/openapi';
 import ToastUtils from '@/utils/ToastUtils';
 
-// TODO(airbridge): 발급된 shortId로 교체 — 콩알이 발급 대기
-const SCC_CONTENT_SHARE_SHORT_ID = 'scc_content_share';
+const SCC_CONTENT_SHARE_SHORT_ID = 'scc-content';
 
 async function copyToClipboard(url: string) {
   try {


### PR DESCRIPTION
## 배경
기존 공유하기는 `con.staircrusher.club/<sccContentId>`로 URL을 재조립 → (1) web.staircrusher.club/notion 컨텐츠에서 도메인 하드코딩으로 깨지고 (2) sccContentId ≠ 경로세그먼트라 깨졌다.

## 변경 (동작)
공유 링크엔 `sccContentId`만 싣고 라우팅으로 해결:
- 모바일+앱설치 → `stair-crusher://scc-content/{id}` 딥링크 → `ResolvingSccContentScreen`이 `getSccContent`로 원본 url 해석 → 인앱 WebView
- 모바일 미설치 / 데스크탑 → `web.staircrusher.club/scc-content/{id}` → 동일 resolver → 브라우저로 원본 컨텐츠
- `sccContentId` 없으면 트래킹링크 없이 원본 url 직접 공유

## 파일
- `ResolvingSccContentScreen` 신규 (id→getSccContent→`replace('Webview',{url,fixedTitle})`)
- `linkingConfig.ts` native+web 둘 다 `scc-content/:sccContentId`
- `webAccess.ts` NO_TOKEN_ALLOWED += `ResolvingSccContent`, `Webview` (익명 웹 사용자 resolve→Webview 시 Login 리다이렉트 방지)
- `ShareUtils.ts`/`.web.ts` `shareSccContent(sccContentId|null, url, title)`, 트래킹링크 슬러그 `scc-content`
- `SccContentFloatingBar` handleShare 정리
- scc-api submodule → `d3bfb802`, codegen 산출물

## 선행/링크
- API: Stair-Crusher-Club/scc-api#123
- 서버: Stair-Crusher-Club/scc-server#1005
- airbridge 트래킹링크 `link.staircrusher.club/scc-content` 발급 완료 (deeplink `scc-content/{id}` + web fallback)

## ⚠️ 머지 주의
scc-api submodule이 원래 미머지 `feat/region-toilet-search`를 가리키고 있었음 → main 기반으로 되돌림. tsc/lint 통과(회귀 없음)했으나 머지 전 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Resolve Content” screen that fetches by ID, then opens the resolved URL in a WebView.
  * Extended deep links to support the new resolve route (including tokenless access).
  * Updated sharing to support SCC content links, using tracking when an ID is available.
* **Bug Fixes**
  * Improved the failure experience: when resolution fails, users see a “content not found” toast and are returned to the previous screen (with safe handling during navigation changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->