### PR TITLE
fix(share): 데스크톱 공유 링크가 홈으로 튕기는 버그

### DIFF
--- a/src/navigation/webAccess.ts
+++ b/src/navigation/webAccess.ts
@@ -16,10 +16,10 @@ const NO_TOKEN_ALLOWED = new Set<string>([
   'AppleCallback',
   'BbucleRoad',
   'BbucleRoadList',
+  // 공유 링크 랜딩. web 변형(index.web.tsx)이 getSccContent(public) 로 resolve 후
+  // window.location.replace 로 현재 탭을 원본 컨텐츠로 직접 보낸다 — Webview 라우트를
+  // 거치지 않으므로 'Webview' 를 여기 넣을 필요가 없다(기존 Webview 진입점의 토큰 게이트 보존).
   'ResolvingSccContent',
-  // getSccContent 는 Anonymous 허용 API. ResolvingSccContent 가 resolve 후
-  // replace 하는 목적지도 token 없이 열려야 R2/R3(미설치/데스크탑 브라우저) 가 성립한다.
-  'Webview',
 ]);
 
 // Camera / photo capture flows — not possible on web → app install prompt.

--- a/src/screens/ResolvingSccContentScreen/index.web.tsx
+++ b/src/screens/ResolvingSccContentScreen/index.web.tsx
@@ -1,0 +1,65 @@
+import React, {useEffect} from 'react';
+import {ActivityIndicator, StyleSheet, Text, View} from 'react-native';
+
+import {ScreenLayout} from '@/components/ScreenLayout';
+import useAppComponents from '@/hooks/useAppComponents';
+import {ScreenProps} from '@/navigation/Navigation.screens';
+import ToastUtils from '@/utils/ToastUtils';
+
+type Props = ScreenProps<'ResolvingSccContent'>;
+
+/**
+ * Web 전용 resolver. sccContentId → 원본 url 로 **현재 탭을 통째로** 이동한다.
+ *
+ * native 변형(index.tsx)처럼 `navigation.replace('Webview', ...)` 로 가지 않는 이유:
+ * WebViewScreen.web 은 외부 도메인(con.staircrusher.club/notion 등) url 을
+ * `window.open(_blank)` 로 새 탭에 열고 `goBack()` 한다. 공유 링크 랜딩은 사용자 제스처
+ * 없는 effect 라 데스크톱에서 새 탭이 팝업 차단되고, goBack 은 히스토리가 없어 초기
+ * 라우트(홈)로 떨어진다("/scc-content → /home" 버그). 랜딩은 현재 탭을 그대로 컨텐츠로
+ * 보내야 하므로 `window.location.replace` 를 쓴다(외부·동일출처 모두 정상 이동).
+ */
+export default function ResolvingSccContentScreen({route}: Props) {
+  const {sccContentId} = route.params;
+  const {api} = useAppComponents();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolve() {
+      try {
+        const {data} = await api.getSccContent({sccContentId});
+        if (cancelled) {
+          return;
+        }
+        window.location.replace(data.url);
+      } catch {
+        if (cancelled) {
+          return;
+        }
+        ToastUtils.show('컨텐츠를 찾지 못했어요');
+        window.location.replace('/');
+      }
+    }
+
+    resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, [sccContentId, api]);
+
+  return (
+    <ScreenLayout isHeaderVisible={false}>
+      <View style={styles.container}>
+        <ActivityIndicator size="large" />
+        <Text style={styles.message}>
+          {'컨텐츠를 불러오는 중입니다\n잠시만 기다려주세요...'}
+        </Text>
+      </View>
+    </ScreenLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16},
+  message: {fontSize: 15, color: '#666', textAlign: 'center', lineHeight: 22},
+});


### PR DESCRIPTION
## 증상
데스크톱(웹)에서 `/scc-content/<sccContentId>` 진입 시 컨텐츠가 아니라 `/home`으로 리다이렉트. (모바일 앱은 정상 — 네이티브 resolver가 인앱 웹뷰로 띄움)

## 근본 원인
web resolver가 `navigation.replace('Webview', {url})` → `WebViewScreen.web`이 **외부 도메인**(con.staircrusher.club/notion) url을 `window.open(_blank)` + `goBack()` 처리. 공유 링크 랜딩은 사용자 제스처 없는 effect라 데스크톱 팝업 차단으로 새 탭이 막히고, goBack이 히스토리가 없어 초기 라우트(홈)로 떨어짐.

## 수정
- **`ResolvingSccContentScreen/index.web.tsx`**(신규, web 전용): getSccContent resolve 후 `window.location.replace(url)`로 **현재 탭을 원본 컨텐츠로 직접 이동**(외부·동일출처 모두 정상). native(index.tsx)는 그대로 인앱 웹뷰.
- **`webAccess.ts`**: web resolver가 더는 Webview 라우트를 안 거치므로 NO_TOKEN_ALLOWED의 과도한 `'Webview'` 제거(기존 15+ Webview 진입점의 토큰 게이트 원복 — 셀프리뷰 gap #1 해소).

## 검증
- tsc/lint 0
- Playwright 목킹으로 getSccContent→`{url}` 응답 시 `/scc-content/x`가 그 url로 이동함을 확인(홈 아님)
- 골든패스 3표면 정상

web 전용 변경(native 번들 불변) → 웹만 재배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new web screen that resolves shared content and automatically opens the target page.
  * Users now see a loading state while the content link is being prepared.

* **Bug Fixes**
  * Improved handling for missing or unavailable content by showing a message and returning users to the home page.
  * Updated web route access rules so the new content flow works without a token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->