### PR TITLE
fix(app): 지도 SDK 기본 나침반 위젯 비활성화

### DIFF
--- a/android/app/src/main/java/club/staircrusher/SccMapView.kt
+++ b/android/app/src/main/java/club/staircrusher/SccMapView.kt
@@ -82,6 +82,8 @@ class SccMapView(private val reactContext: ThemedReactContext) : MapView(
             // Fix logo at bottom-left so contentPadding changes don't move it
             it.uiSettings.logoGravity = Gravity.BOTTOM or Gravity.START
             it.uiSettings.setLogoMargin(0, 0, 0, 0)
+            // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+            it.uiSettings.isCompassEnabled = false
             it.addOnCameraChangeListener { reason, _ ->
                 lastCameraChangeReason = reason
             }

--- a/ios/sccReactNative/RNTSccMapViewImpl.mm
+++ b/ios/sccReactNative/RNTSccMapViewImpl.mm
@@ -100,6 +100,8 @@
     // Fix logo at bottom-left so contentInset changes don't move it
     self.logoAlign = NMFLogoAlignLeftBottom;
     self.logoMargin = UIEdgeInsetsZero;
+    // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+    self.showCompass = NO;
 
   }
   return self;
@@ -118,6 +120,8 @@
     // Fix logo at bottom-left so contentInset changes don't move it
     self.logoAlign = NMFLogoAlignLeftBottom;
     self.logoMargin = UIEdgeInsetsZero;
+    // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+    self.showCompass = NO;
 
   }
   return self;


### PR DESCRIPTION
## 문제
앱에 나침반 버튼을 넣은 적이 없는데, 지도를 회전하면 이상한 위치에 나침반 버튼이 보인다는 제보.

## 원인
네이버 지도 SDK의 기본 나침반 위젯(회전 시 자동 노출)이 켜져 있음. Android/iOS 네이티브 모두 compass를 명시적으로 끄지 않아 SDK 기본값(on)이 그대로 노출됨.

## 수정
- Android `SccMapView.kt`: `uiSettings.isCompassEnabled = false`
- iOS `RNTSccMapViewImpl.mm`: `showCompass = NO` (initWithFrame/initWithCoder 양쪽)

순수 추가 6줄, 네이티브 프로퍼티 대입만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the default map compass from Android and iOS.
  * Prevented the compass from appearing unexpectedly when rotating the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->