### PR TITLE
fix: 관심 주제 태그 '휠체어 찐후기' → '휠체어 방문리뷰' 변경

### DIFF
--- a/src/screens/InterestedRegionAndThemesFormScreen/constants.ts
+++ b/src/screens/InterestedRegionAndThemesFormScreen/constants.ts
@@ -17,7 +17,7 @@ export interface ThemeOption {
 }
 
 export const THEME_OPTIONS: ThemeOption[] = [
-  {value: UserInterestedThemeDto.WheelchairReview, label: '🧑‍🦽 휠체어 방문리뷰'},
+  {value: UserInterestedThemeDto.WheelchairReview, label: '🧑‍🦽 휠체어 찐방문기'},
   {value: UserInterestedThemeDto.MediaHotspot, label: '🔥 방송·SNS 핫플'},
   {value: UserInterestedThemeDto.FoodCafeTour, label: '🍕 맛집·카페 투어'},
   {value: UserInterestedThemeDto.EmotionalView, label: '📸 감성·뷰 맛집'},

--- a/src/screens/InterestedRegionAndThemesFormScreen/constants.ts
+++ b/src/screens/InterestedRegionAndThemesFormScreen/constants.ts
@@ -17,7 +17,7 @@ export interface ThemeOption {
 }
 
 export const THEME_OPTIONS: ThemeOption[] = [
-  {value: UserInterestedThemeDto.WheelchairReview, label: '🧑‍🦽 휠체어 찐후기'},
+  {value: UserInterestedThemeDto.WheelchairReview, label: '🧑‍🦽 휠체어 방문리뷰'},
   {value: UserInterestedThemeDto.MediaHotspot, label: '🔥 방송·SNS 핫플'},
   {value: UserInterestedThemeDto.FoodCafeTour, label: '🍕 맛집·카페 투어'},
   {value: UserInterestedThemeDto.EmotionalView, label: '📸 감성·뷰 맛집'},


### PR DESCRIPTION
## Summary
- 윌리의 외출 미션 1단계 '관심 주제를 선택해주세요' 화면에서 노출되는 관심 테마 태그 텍스트 수정
- `🧑‍🦽 휠체어 찐후기` → `🧑‍🦽 휠체어 방문리뷰`

## 변경 파일
- `src/screens/InterestedRegionAndThemesFormScreen/constants.ts`
  - `THEME_OPTIONS` 배열의 `WheelchairReview` 항목 라벨 변경
  - `THEME_LABEL_BY_VALUE`는 `THEME_OPTIONS`에서 자동 생성되므로 별도 수정 불필요

## Test plan
- [ ] 앱 실행 후 윌리의 외출 미션 1단계 진입
- [ ] '관심 주제를 선택해주세요' 화면에서 '🧑‍🦽 휠체어 방문리뷰' 태그가 노출되는지 확인
- [ ] 프로필 화면 등 `THEME_LABEL_BY_VALUE`를 참조하는 다른 화면에서도 변경된 텍스트가 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the Korean label for wheelchair-accessible location reviews from “찐후기” to “방문리뷰” in the interest selection form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->