### PR TITLE
fix(app): 지도 SDK 기본 나침반 위젯 비활성화 (Android)

### DIFF
--- a/android/app/src/main/java/club/staircrusher/SccMapView.kt
+++ b/android/app/src/main/java/club/staircrusher/SccMapView.kt
@@ -82,6 +82,8 @@ class SccMapView(private val reactContext: ThemedReactContext) : MapView(
             // Fix logo at bottom-left so contentPadding changes don't move it
             it.uiSettings.logoGravity = Gravity.BOTTOM or Gravity.START
             it.uiSettings.setLogoMargin(0, 0, 0, 0)
+            // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+            it.uiSettings.isCompassEnabled = false
             it.addOnCameraChangeListener { reason, _ ->
                 lastCameraChangeReason = reason
             }


### PR DESCRIPTION
## 문제
앱에 나침반 버튼을 넣은 적이 없는데, 지도를 회전하면 이상한 위치에 나침반 버튼이 보인다는 제보.

## 원인 / 범위
네이버 지도 SDK 기본 나침반 위젯(회전 시 자동 노출).
- **Android**: `NaverMap.uiSettings`의 compass 기본값(on)이 그대로 노출 → 이번 수정 대상.
- **iOS**: 앱은 bare `NMFMapView`를 사용하며 이 클래스엔 나침반 위젯 자체가 렌더되지 않음(`showCompass`는 `NMFNaverMapView` 컨테이너 전용). 따라서 iOS는 변경 불필요.

## 수정
- `SccMapView.kt`: `uiSettings.isCompassEnabled = false`

> 이전 PR #211은 iOS에 존재하지 않는 `showCompass` 프로퍼티를 추가해 iOS 아카이브가 깨졌음(exit 65). 이 PR로 대체.

🤖 Generated with [Claude Code](https://claude.com/claude-code)