### PR TITLE
release-1.3.11 → main

### DIFF
--- a/android/app/src/main/java/club/staircrusher/SccMapView.kt
+++ b/android/app/src/main/java/club/staircrusher/SccMapView.kt
@@ -82,6 +82,8 @@ class SccMapView(private val reactContext: ThemedReactContext) : MapView(
             // Fix logo at bottom-left so contentPadding changes don't move it
             it.uiSettings.logoGravity = Gravity.BOTTOM or Gravity.START
             it.uiSettings.setLogoMargin(0, 0, 0, 0)
+            // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+            it.uiSettings.isCompassEnabled = false
             it.addOnCameraChangeListener { reason, _ ->
                 lastCameraChangeReason = reason
             }

--- a/android/app/version.properties
+++ b/android/app/version.properties
@@ -1,1 +1,1 @@
-version=1.3.10
+version=1.3.11

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 210;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -840,7 +840,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 210;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -998,7 +998,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 210;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -1133,7 +1133,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 210;
+				CURRENT_PROJECT_VERSION = 212;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 212;
+				CURRENT_PROJECT_VERSION = 214;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -840,7 +840,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 212;
+				CURRENT_PROJECT_VERSION = 214;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -998,7 +998,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 212;
+				CURRENT_PROJECT_VERSION = 214;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -1133,7 +1133,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 212;
+				CURRENT_PROJECT_VERSION = 214;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative.xcodeproj/project.pbxproj
+++ b/ios/sccReactNative.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 208;
+				CURRENT_PROJECT_VERSION = 210;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -840,7 +840,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 208;
+				CURRENT_PROJECT_VERSION = 210;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -998,7 +998,7 @@
 				CODE_SIGN_ENTITLEMENTS = sccReactNative/sccReactNative.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 208;
+				CURRENT_PROJECT_VERSION = 210;
 				DEVELOPMENT_TEAM = ZYCW4V3VNY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sccReactNative/Info.plist;
@@ -1133,7 +1133,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 208;
+				CURRENT_PROJECT_VERSION = 210;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = ZYCW4V3VNY;
 				INFOPLIST_FILE = sccReactNative/Info.plist;

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.10</string>
+	<string>1.3.11</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>208</string>
+	<string>210</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>212</string>
+	<string>214</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/Info.plist
+++ b/ios/sccReactNative/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>210</string>
+	<string>212</string>
 	<key>GOOGLE_MAP_API_KEY</key>
 	<string>$(GOOGLE_MAP_API_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/sccReactNative/RNTSccMapViewImpl.mm
+++ b/ios/sccReactNative/RNTSccMapViewImpl.mm
@@ -100,8 +100,6 @@
     // Fix logo at bottom-left so contentInset changes don't move it
     self.logoAlign = NMFLogoAlignLeftBottom;
     self.logoMargin = UIEdgeInsetsZero;
-    // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
-    self.showCompass = NO;
 
   }
   return self;
@@ -120,8 +118,6 @@
     // Fix logo at bottom-left so contentInset changes don't move it
     self.logoAlign = NMFLogoAlignLeftBottom;
     self.logoMargin = UIEdgeInsetsZero;
-    // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
-    self.showCompass = NO;
 
   }
   return self;

--- a/ios/sccReactNative/RNTSccMapViewImpl.mm
+++ b/ios/sccReactNative/RNTSccMapViewImpl.mm
@@ -100,6 +100,8 @@
     // Fix logo at bottom-left so contentInset changes don't move it
     self.logoAlign = NMFLogoAlignLeftBottom;
     self.logoMargin = UIEdgeInsetsZero;
+    // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+    self.showCompass = NO;
 
   }
   return self;
@@ -118,6 +120,8 @@
     // Fix logo at bottom-left so contentInset changes don't move it
     self.logoAlign = NMFLogoAlignLeftBottom;
     self.logoMargin = UIEdgeInsetsZero;
+    // 앱에서 쓰지 않는 SDK 기본 나침반 위젯 비활성화 (지도 회전 시 노출되던 버그)
+    self.showCompass = NO;
 
   }
   return self;

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>210</string>
+	<string>212</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>212</string>
+	<string>214</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ios/sccReactNativeTests/Info.plist
+++ b/ios/sccReactNativeTests/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.10</string>
+	<string>1.3.11</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>208</string>
+	<string>210</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## 릴리스 1.3.11

### 포함 변경
- **fix(app): 지도 SDK 기본 나침반 위젯 비활성화 (Android)** — 지도 회전 시 이상한 위치에 나침반 버튼이 노출된다는 제보. `NaverMap.uiSettings.isCompassEnabled = false`. iOS는 bare `NMFMapView`를 써서 나침반 위젯이 렌더되지 않으므로 변경 없음.
- 1.3.11 버전범프 (CI: ios/android)

### 빌드
- Native Build Deployment: iOS ✅ / Android ✅ (run 29217909101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The map compass is now hidden during map rotation for a cleaner viewing experience.

* **Release**
  * Updated the app version to 1.3.11 on Android and iOS.
  * Updated the iOS build number to 214.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->