### PR TITLE
feat(home): 홈 최하단 공지사항 진입점 추가 (IMPACT_SURVEY)

### DIFF
--- a/src/screens/HomeScreenV2/sections/FooterButtonsSection.tsx
+++ b/src/screens/HomeScreenV2/sections/FooterButtonsSection.tsx
@@ -25,6 +25,8 @@ const DONATION_URL = 'https://staircrusher.club/donation';
 // `{userId}` 는 WebViewScreen 진입 시 실제 userId 로 자동 치환된다 (externalUrlTemplating).
 const CONTENT_REPORT_URL =
   'https://forms.staircrusher.club/app-feedback?userId={userId}';
+const NOTICE_URL =
+  'https://staircrusherclub.notion.site/1d5c9499b0608059994dcebcf13bb53f?v=1d5c9499b06080968da7000c18db4868&source=copy_link';
 
 const FOOTER_ROW_HEIGHT = 48;
 const FOOTER_ROW_RADIUS = 8;
@@ -53,6 +55,9 @@ export default function FooterButtonsSection({
   // featureFlags === null (아직 로딩 중) 이면 버튼 노출 보류.
   const isTutorialEnabled =
     featureFlags?.enabledFlags.has('USER_TUTORIAL') ?? false;
+  // IMPACT_SURVEY flag 가 켜진 사용자에게만 공지사항 진입 버튼을 노출 (동일 패턴).
+  const isImpactSurveyEnabled =
+    featureFlags?.enabledFlags.has('IMPACT_SURVEY') ?? false;
 
   if (isLoading) {
     return (
@@ -98,6 +103,14 @@ export default function FooterButtonsSection({
 
   const goToLongReview = () => {
     Linking.openURL('https://forms.gle/UZzVBhjZbPaexerR9');
+  };
+
+  const goToNotice = () => {
+    navigation.navigate('Webview', {
+      fixedTitle: '공지사항',
+      url: NOTICE_URL,
+      hideFloatingBar: true,
+    });
   };
 
   return (
@@ -156,6 +169,19 @@ export default function FooterButtonsSection({
               <RowContent>
                 <FooterLongReviewIcon width={16} height={16} />
                 <FooterText>[크루전용] 롱리뷰 작성하기</FooterText>
+              </RowContent>
+            </FooterRow>
+          </SccPressable>
+        )}
+
+        {isImpactSurveyEnabled && (
+          <SccPressable
+            elementName="home_v2_footer_notice"
+            onPress={goToNotice}>
+            <FooterRow>
+              <RowContent>
+                <FooterInfoIcon width={16} height={16} />
+                <FooterText>공지사항</FooterText>
               </RowContent>
             </FooterRow>
           </SccPressable>

--- a/src/screens/HomeScreenV2/sections/FooterButtonsSection.tsx
+++ b/src/screens/HomeScreenV2/sections/FooterButtonsSection.tsx
@@ -55,9 +55,6 @@ export default function FooterButtonsSection({
   // featureFlags === null (아직 로딩 중) 이면 버튼 노출 보류.
   const isTutorialEnabled =
     featureFlags?.enabledFlags.has('USER_TUTORIAL') ?? false;
-  // IMPACT_SURVEY flag 가 켜진 사용자에게만 공지사항 진입 버튼을 노출 (동일 패턴).
-  const isImpactSurveyEnabled =
-    featureFlags?.enabledFlags.has('IMPACT_SURVEY') ?? false;
 
   if (isLoading) {
     return (
@@ -109,7 +106,7 @@ export default function FooterButtonsSection({
     navigation.navigate('Webview', {
       fixedTitle: '공지사항',
       url: NOTICE_URL,
-      hideFloatingBar: true,
+      forceHideFloatingBar: true,
     });
   };
 
@@ -174,18 +171,14 @@ export default function FooterButtonsSection({
           </SccPressable>
         )}
 
-        {isImpactSurveyEnabled && (
-          <SccPressable
-            elementName="home_v2_footer_notice"
-            onPress={goToNotice}>
-            <FooterRow>
-              <RowContent>
-                <FooterInfoIcon width={16} height={16} />
-                <FooterText>공지사항</FooterText>
-              </RowContent>
-            </FooterRow>
-          </SccPressable>
-        )}
+        <SccPressable elementName="home_v2_footer_notice" onPress={goToNotice}>
+          <FooterRow>
+            <RowContent>
+              <FooterInfoIcon width={16} height={16} />
+              <FooterText>공지사항</FooterText>
+            </RowContent>
+          </FooterRow>
+        </SccPressable>
       </Container>
     </LogParamsProvider>
   );

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -28,6 +28,8 @@ export interface WebViewScreenParams {
   // (web 전용) 외부 url을 열 때 브라우저 target. '_blank'=새 탭(기본, 앱 내부 링크
   // 클릭용), '_self'=현재 탭 이동. 미지정 시 '_blank'. (native는 인앱 웹뷰라 무시)
   webLinkTarget?: '_self' | '_blank';
+  // true 면 SccContentFloatingBar(좋아요/저장 등) 를 강제로 숨긴다 (공지사항 등 콘텐츠 도메인이라도).
+  hideFloatingBar?: boolean;
 }
 
 const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
@@ -36,6 +38,7 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     url,
     headerVariant = 'navigation',
     confirmOnClose = true,
+    hideFloatingBar,
   } = route.params;
   const webViewRef = useRef<WebView>(null);
   const {userInfo} = useMe();
@@ -58,10 +61,11 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     imageUrls: string[];
   } | null>(null);
 
-  // SCC 콘텐츠 도메인이면 floating bar 노출
+  // SCC 콘텐츠 도메인이면 floating bar 노출 (hideFloatingBar 로 강제 opt-out 가능)
   const shouldShowFloatingBar =
-    currentUrl.startsWith('https://con.staircrusher.club') ||
-    currentUrl.startsWith('https://staircrusherclub.notion.site');
+    !hideFloatingBar &&
+    (currentUrl.startsWith('https://con.staircrusher.club') ||
+      currentUrl.startsWith('https://staircrusherclub.notion.site'));
 
   // BBUCLE_ROAD 좋아요용 path id (기존 흐름과 동일).
   // 좋아요는 SccContent 저장 여부와 무관하게 path id 기준으로 누적/조회된다.

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -29,7 +29,7 @@ export interface WebViewScreenParams {
   // 클릭용), '_self'=현재 탭 이동. 미지정 시 '_blank'. (native는 인앱 웹뷰라 무시)
   webLinkTarget?: '_self' | '_blank';
   // true 면 SccContentFloatingBar(좋아요/저장 등) 를 강제로 숨긴다 (공지사항 등 콘텐츠 도메인이라도).
-  hideFloatingBar?: boolean;
+  forceHideFloatingBar?: boolean;
 }
 
 const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
@@ -38,7 +38,7 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     url,
     headerVariant = 'navigation',
     confirmOnClose = true,
-    hideFloatingBar,
+    forceHideFloatingBar,
   } = route.params;
   const webViewRef = useRef<WebView>(null);
   const {userInfo} = useMe();
@@ -61,9 +61,9 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     imageUrls: string[];
   } | null>(null);
 
-  // SCC 콘텐츠 도메인이면 floating bar 노출 (hideFloatingBar 로 강제 opt-out 가능)
+  // SCC 콘텐츠 도메인이면 floating bar 노출 (forceHideFloatingBar 로 강제 opt-out 가능)
   const shouldShowFloatingBar =
-    !hideFloatingBar &&
+    !forceHideFloatingBar &&
     (currentUrl.startsWith('https://con.staircrusher.club') ||
       currentUrl.startsWith('https://staircrusherclub.notion.site'));
 


### PR DESCRIPTION
## Summary
- `FooterButtonsSection`: `IMPACT_SURVEY` feature flag가 켜진 사용자에게만 홈 최하단 '공지사항' 행을 노출. 탭 시 Notion 공지 페이지(추첨/당첨 공지용)를 in-app WebView로 연다.
- `WebViewScreen`: `hideFloatingBar?: boolean` 파라미터 추가. 공지사항 웹뷰는 `staircrusherclub.notion.site` 도메인이라 기본적으로 `SccContentFloatingBar`(좋아요/저장) 가 뜨는 대상이지만, 이 파라미터로 강제로 숨긴다.

## Dependency
서버가 `IMPACT_SURVEY` flag를 아직 내려주지 않으므로, scc-server PR [#1010](https://github.com/Stair-Crusher-Club/scc-server/pull/1010) 이 머지·배포되기 전까지는 이 행이 계속 숨겨진 상태로 안전하게 대기한다 (flag 값이 없으면 노출 보류, `USER_TUTORIAL` 게이트와 동일 패턴).

## Test plan
- [x] `yarn lint` — 0 errors
- [x] `yarn tsc --noEmit` — 0 errors
- [ ] sandbox 빌드에서 scc-server PR #1010 배포 후 flag ON 상태로 홈 최하단 '공지사항' 진입 → floating bar 없이 Notion 페이지 렌더 확인
- [ ] flag OFF 상태에서 행 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “공지사항” (Notices) button to the Home screen.
  * Notices now open in a dedicated WebView screen.
* **Improvements**
  * WebViews can now suppress the floating navigation bar on selected pages via a new screen option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->