### PR TITLE
fix(articles): --dry가 변경된 문서 목록과 변경 사유를 출력

### DIFF
--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -1282,7 +1282,28 @@ async function main() {
     );
 
   if (DRY) {
-    console.log('   (--dry: 변경 없음)');
+    // 어떤 글이 왜 잡혔는지 안 찍으면 STEP 2 대상을 역추적하는 데 별도 스크립트가 필요하다
+    if (changed.length)
+      console.log(
+        `   📝 신규/변경 문서:\n` +
+          changed
+            .map(c => {
+              const prev = manifest[c.meta.rowId];
+              const why = !prev
+                ? '신규'
+                : prev.slug !== c.meta.slug
+                  ? `slug 변경 ${prev.slug} → ${c.meta.slug}`
+                  : `수정 ${prev.editedTime} → ${c.times.editedTime}`;
+              return `      - ${c.meta.slug}  (${c.meta.title})\n        ${why} · rowId=${c.meta.rowId}`;
+            })
+            .join('\n'),
+      );
+    if (deleted.length)
+      console.log(
+        `   🗑️  삭제 대상:\n` +
+          deleted.map(id => `      - ${manifest[id].slug}`).join('\n'),
+      );
+    console.log('   (--dry: 파일 변경 없음)');
     return;
   }
 


### PR DESCRIPTION
## 문제
`--dry`는 `신규/변경 N` 카운트와 **메타미비 문서 이름만** 출력했다. 이미 메타가 있는 글이 수정된 경우(어제 발행한 글의 본문이 오늘 수정된 케이스) 어떤 글인지 알 수 없어, STEP 2 대상을 잡으려면 manifest↔Notion을 대조하는 일회용 스크립트를 매번 짜야 했다.

## 수정
변경 문서를 slug·제목과 함께 **사유**까지 출력:
- `신규` / `slug 변경 A → B` / `수정 <before> → <after>`
- 삭제 대상 목록도 함께 출력

```
   📝 신규/변경 문서:
      - wheelchair-accessible-saved-lists  (휠체어로 갈 수 있는 새로운 곳, 더 알고 싶다면)
        수정 2000-01-01T00:00:00.000Z → 2026-06-09T04:53:00.000Z · rowId=383c…
      - powered-wheelchair-air-travel-guide  ([뿌클로드] 전동휠체어로 비행기 탈 때…)
        신규 · rowId=383c…
```

## 검증
manifest를 임시 조작해 `신규`·`수정` 두 분기 출력을 확인하고 복원. `yarn lint` / `tsc --noEmit` 0 error.

로깅 경로만 바뀌어 생성 HTML은 무변경 → 웹 재배포 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)