### PR TITLE
fix(dev): 로컬 FLAVOR 에서 .env.local 의 BASE_URL 을 존중하도록

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -41,9 +41,13 @@ const getBaseURL = () => {
   // On web there is no localhost-emulator bridge; always use the configured
   // BASE_URL (the dev server origin must be CORS-allowed by that backend).
   if (Config.FLAVOR === 'local' && Platform.OS !== 'web') {
-    return Platform.OS === 'ios'
-      ? 'http://localhost:8080'
-      : 'http://10.0.2.2:8080';
+    // .env.local 의 BASE_URL 을 그대로 존중한다. 예전엔 8080 을 하드코딩해서, 포트를
+    // 바꿔 띄울 때(8080 점유 등)마다 이 파일을 임시로 고쳤다 되돌려야 했다.
+    const configured = Config.BASE_URL ?? 'http://localhost:8080';
+    // 안드로이드 에뮬레이터에서 localhost 는 호스트가 아니라 에뮬레이터 자신을 가리킨다.
+    return Platform.OS === 'android'
+      ? configured.replace('localhost', '10.0.2.2')
+      : configured;
   }
   return Config.BASE_URL;
 };


### PR DESCRIPTION
## 문제

`App.tsx` 의 `getBaseURL()` 이 `FLAVOR=local` 일 때 `.env.local` 의 `BASE_URL` 을 무시하고 8080 을 하드코딩하고 있었다.

8080 이 이미 점유돼 서버를 다른 포트(예: 8082)로 띄우면 `.env.local` 을 고쳐도 앱이 계속 8080 을 때린다. 그래서 포트를 바꿀 때마다 `App.tsx` 를 임시로 수정 → 빌드 → 원복하는 5단계를 반복해야 했고(원복을 잊으면 그대로 커밋될 위험), 실제로 이번에 구버전 서버를 때려 신규 엔드포인트가 404 나는 것으로 드러났다.

## 변경

`BASE_URL` 이 설정돼 있으면 그대로 쓰고, 안드로이드 에뮬레이터에서만 `localhost` → `10.0.2.2` 로 치환한다.

```ts
const configured = Config.BASE_URL ?? 'http://localhost:8080';
return Platform.OS === 'android'
  ? configured.replace('localhost', '10.0.2.2')
  : configured;
```

- `BASE_URL` 이 없을 때의 동작은 **기존과 동일** (iOS `localhost:8080` / Android `10.0.2.2:8080`).
- `FLAVOR !== 'local'` 및 웹 경로는 손대지 않았다.

## 검증

에뮬레이터에서 서버를 8082 로 띄우고 `.env.local` 에 `BASE_URL=http://10.0.2.2:8082` 를 준 상태로:

- logcat 에서 앱이 `10.0.2.2:8082` 로 요청하는 것 확인
- 홈 화면이 8082 서버 데이터로 정상 렌더 확인
- `tsc --noEmit` / `eslint` 0 error

일회성 우회 대신 디폴트 자체를 고치는 변경이라 별도 PR 로 분리했다.