### PR TITLE
feat(ui): 바텀시트 슬라이드업/드래그 닫기 인터랙션

### DIFF
--- a/src/modals/BottomSheet/BottomSheet.tsx
+++ b/src/modals/BottomSheet/BottomSheet.tsx
@@ -1,10 +1,15 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {
+  Animated,
+  Dimensions,
+  Easing,
   Keyboard,
   KeyboardAvoidingView,
   Modal,
+  PanResponder,
   Platform,
+  StyleSheet,
   View,
 } from 'react-native';
 
@@ -18,6 +23,15 @@ import {
   SafeAreaView,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+// 시트 상단 중 이 높이(px) 안에서 시작된 아래 방향 드래그만 "핸들을 잡고 끈다"로 인정한다.
+// 자체 handle/grabber 가 없는 시트(FilterModal 등)는 이 영역이 스크롤 가능 영역과 겹칠 수 있다 —
+// ScrollView 뷰포트 상단 44px 안에서 시작하는 드래그에 한해서만 발생하는 알려진 트레이드오프.
+const DRAG_HANDLE_HEIGHT = 44;
+const CLOSE_DRAG_RATIO = 0.25;
+const CLOSE_VELOCITY_THRESHOLD = 0.5;
+const SLIDE_DOWN_DURATION_MS = 280;
 
 type Props = React.PropsWithChildren<{
   isVisible: boolean;
@@ -59,11 +73,137 @@ export default function BottomSheet({
     };
   }, []);
 
+  // ── 슬라이드업 등장 / 슬라이드다운 퇴장 / 드래그로 닫기 ──────────────
+  // translateY 는 0(완전히 펼쳐짐) ~ sheetHeight(화면 밖으로 내려감) 사이를 움직인다.
+  // dim 투명도는 translateY 에서 interpolate 로 파생시켜 등장/퇴장/드래그를 한 값으로 통일한다.
+  const [isRendered, setIsRendered] = useState(isVisible);
+  const [sheetHeight, setSheetHeight] = useState(SCREEN_HEIGHT);
+  const sheetHeightRef = useRef(SCREEN_HEIGHT);
+  const translateY = useRef(
+    new Animated.Value(isVisible ? 0 : SCREEN_HEIGHT),
+  ).current;
+  const translateYValueRef = useRef(isVisible ? 0 : SCREEN_HEIGHT);
+  const dragStartRef = useRef(0);
+  const topMarkerRef = useRef<View>(null);
+  const containerTopRef = useRef<number | null>(null);
+
+  const remeasureContainerTop = () => {
+    topMarkerRef.current?.measureInWindow((_x, y) => {
+      containerTopRef.current = y;
+    });
+  };
+
+  useEffect(() => {
+    const id = translateY.addListener(({value}) => {
+      translateYValueRef.current = value;
+    });
+    return () => translateY.removeListener(id);
+  }, [translateY]);
+
+  useEffect(() => {
+    if (isVisible) {
+      setIsRendered(true);
+    }
+  }, [isVisible]);
+
+  useEffect(() => {
+    if (!isRendered) {
+      return;
+    }
+    translateY.stopAnimation();
+    if (isVisible) {
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        bounciness: 4,
+        speed: 14,
+      }).start(({finished}) => {
+        if (finished) {
+          remeasureContainerTop();
+        }
+      });
+    } else {
+      Animated.timing(translateY, {
+        toValue: sheetHeightRef.current,
+        duration: SLIDE_DOWN_DURATION_MS,
+        easing: Easing.in(Easing.cubic),
+        useNativeDriver: true,
+      }).start(({finished}) => {
+        if (finished) {
+          setIsRendered(false);
+        }
+      });
+    }
+  }, [isVisible, isRendered]);
+
+  const dimOpacity = useMemo(
+    () =>
+      translateY.interpolate({
+        inputRange: [0, sheetHeight],
+        outputRange: [1, 0],
+        extrapolate: 'clamp',
+      }),
+    [translateY, sheetHeight],
+  );
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => false,
+      // Capture 단계에서 먼저 확인해야 children(ScrollView/SccPressable 등)이 터치를 선점하기 전에
+      // 시트 핸들 드래그를 가로챌 수 있다 (MainBannerSection.tsx 의 스와이프 캡처와 동일한 이유).
+      onMoveShouldSetPanResponderCapture: (_evt, gestureState) => {
+        const top = containerTopRef.current;
+        if (top == null) {
+          return false;
+        }
+        const startedInHandleArea = gestureState.y0 - top <= DRAG_HANDLE_HEIGHT;
+        return (
+          startedInHandleArea &&
+          gestureState.dy > 6 &&
+          Math.abs(gestureState.dy) > Math.abs(gestureState.dx)
+        );
+      },
+      onPanResponderGrant: () => {
+        dragStartRef.current = translateYValueRef.current;
+      },
+      onPanResponderMove: (_evt, gestureState) => {
+        const next = Math.max(0, dragStartRef.current + gestureState.dy);
+        translateY.setValue(next);
+      },
+      onPanResponderRelease: (_evt, gestureState) => {
+        const threshold = sheetHeightRef.current * CLOSE_DRAG_RATIO;
+        const shouldClose =
+          gestureState.dy > threshold ||
+          gestureState.vy > CLOSE_VELOCITY_THRESHOLD;
+        if (shouldClose) {
+          Keyboard.dismiss();
+          onPressBackground?.();
+        } else {
+          Animated.spring(translateY, {
+            toValue: 0,
+            useNativeDriver: true,
+            bounciness: 4,
+            speed: 14,
+          }).start();
+        }
+      },
+      onPanResponderTerminate: () => {
+        Animated.spring(translateY, {
+          toValue: 0,
+          useNativeDriver: true,
+          bounciness: 4,
+          speed: 14,
+        }).start();
+      },
+      onPanResponderTerminationRequest: () => false,
+    }),
+  ).current;
+
   const modalContent = (
     <Modal
-      visible={isVisible}
+      visible={isRendered}
       transparent
-      animationType="fade"
+      animationType="none"
       statusBarTranslucent={true}
       onRequestClose={() => {
         onPressBackground?.();
@@ -72,8 +212,16 @@ export default function BottomSheet({
         <KeyboardAvoidingView
           behavior={'padding'}
           style={{flexGrow: 1}}
-          keyboardVerticalOffset={keyboardVerticalOffset}>
+          keyboardVerticalOffset={keyboardVerticalOffset}
+          onLayout={remeasureContainerTop}>
           <DimmedBackground>
+            <Animated.View
+              pointerEvents="none"
+              style={[
+                StyleSheet.absoluteFillObject,
+                {backgroundColor: color.blacka50, opacity: dimOpacity},
+              ]}
+            />
             <SccTouchableOpacity
               elementName="bottom_sheet_background"
               activeOpacity={1}
@@ -87,20 +235,37 @@ export default function BottomSheet({
                 onPressBackground?.();
               }}
             />
-            <Container
+            <Animated.View
+              onLayout={e => {
+                const height = e.nativeEvent.layout.height;
+                setSheetHeight(height);
+                sheetHeightRef.current = height;
+                remeasureContainerTop();
+              }}
               style={{
-                paddingBottom: temporalContainerPaddingBottom,
-              }}>
-              <SafeAreaView edges={['bottom']}>{children}</SafeAreaView>
-            </Container>
+                transform: [{translateY}],
+              }}
+              {...panResponder.panHandlers}>
+              <Container
+                style={{
+                  paddingBottom: temporalContainerPaddingBottom,
+                }}>
+                <View
+                  ref={topMarkerRef}
+                  style={{height: 0}}
+                  onLayout={remeasureContainerTop}
+                />
+                <SafeAreaView edges={['bottom']}>{children}</SafeAreaView>
+              </Container>
+            </Animated.View>
           </DimmedBackground>
         </KeyboardAvoidingView>
       </SafeAreaProvider>
     </Modal>
   );
 
-  // LogView는 Modal이 실제로 보일 때만 렌더링
-  if (isVisible) {
+  // LogView는 Modal이 실제로 보일 때만 렌더링 (퇴장 애니메이션 중에도 보이므로 isRendered 기준)
+  if (isRendered) {
     return <LogView elementName="bottom_sheet">{modalContent}</LogView>;
   }
 
@@ -110,7 +275,7 @@ export default function BottomSheet({
 const DimmedBackground = styled(View)({
   flex: 1,
   flexDirection: 'column-reverse',
-  backgroundColor: color.blacka50,
+  backgroundColor: 'transparent',
 });
 
 const Container = styled(View)({


### PR DESCRIPTION
## 요약
- 공용 `BottomSheet`(`src/modals/BottomSheet/BottomSheet.tsx`)를 fade-in/out → **아래서 위로 슬라이드업 등장 / 위에서 아래로 슬라이드다운 퇴장**으로 개선
- **상단 핸들 영역(44px)을 잡고 아래로 끌면 실시간으로 따라 내려가고**, 이동량이 시트 높이의 25%를 넘거나 아래 방향 속도(vy>0.5)가 있으면 그대로 닫힘, 아니면 스프링백
- dim 투명도를 `translateY`에서 `interpolate`로 파생시켜 등장/퇴장/드래그 진행도를 하나의 값으로 통일

## 영향 반경
- **공개 API 무변경**: `{isVisible, onPressBackground?, children}` 그대로 → 소비처 19곳(`FormExitConfirmBottomSheet`, `FilterModal`, `ThemeSelectBottomSheet`, `AiSummaryDownvoteBottomSheet` 등) 수정 0, `yarn tsc --noEmit` 0 error
- 안드로이드 키보드/translucent statusbar 워크어라운드 코드(`keyboardVerticalOffset`/`temporalContainerPaddingBottom`/`keyboardDidShow`/`keyboardDidHide`)는 **완전히 그대로 유지** (git diff 0줄 변경 확인 — 과거 3회 회귀 이력이 있는 코드라 건드리지 않음)
- 새 grabber(손잡이 UI)는 추가하지 않음 — 30개 화면 디자인이 한꺼번에 바뀌는 것을 피하기 위해 상단 44px을 **보이지 않는** 드래그 인식 영역으로만 사용

## 코어 Animated 선택 근거 (reanimated/gesture-handler 미사용)
1. RN `Modal` 내부에는 루트 `GestureHandlerRootView`가 미치지 않아 RNGH 제스처가 Modal 안에서 동작하지 않는다.
2. 웹(`web.staircrusher.club`)이 실서비스이고, `babel.config.web.js`에 `react-native-worklets/plugin`이 없어 reanimated worklet이 웹에서 컴파일되지 않는다 (ts-loader transpileOnly).
3. 앱의 기존 스와이프 인터랙션(`MainBannerSection.tsx`)도 이미 코어 `Animated` + `PanResponder` 패턴 — 일관성 유지.

드래그 캡처는 `onMoveShouldSetPanResponderCapture`(캡처 단계)로 처리해 `MainBannerSection`과 동일한 방식으로 children(SccPressable/ScrollView)이 터치를 선점하기 전에 가로챈다. `onStartShouldSetPanResponder: false`라 순수 탭(이동 없음)은 영향받지 않는다.

## 검증
- `yarn tsc --noEmit`, `yarn lint` 0 error
- 에뮬레이터에서 슬라이드업 등장(정지 상태 레이아웃/dim/rounded corner), 배경 탭 닫힘, **상단 핸들 드래그 → 캡처 로그 확인 후 실제 닫힘(속도 기반)** 을 스크린샷으로 확인
- 알려진 한계: 세션 중 로컬 디스크 공간 이슈(격리 빌드 산출물 정리로 해소)로 "핸들 영역 밖 드래그가 스크롤을 방해하지 않는지"의 반복 재현을 깨끗하게 완료하지 못함 — 코드상 zone(44px) 밖은 `false` 반환으로 게이팅되나, 병합 전 `FilterModal`류 리스트 스크롤 + 안드로이드 키보드 회귀는 재확인 권장 (self-review 핸드오프 체크리스트 참조)

## 테스트 체크리스트 (핸드오프)
- [ ] 안드로이드에서 textarea 있는 시트(붐따/붐업 downvote 등) 포커스 시 키보드가 시트를 안 가리는지
- [ ] `FilterModal`/`PlaceListFilterModal`에서 리스트 스크롤이 중간~하단 및 상단 근처에서도 정상 동작하는지
- [ ] 상단을 살짝(임계 미만) 끌었다 놓았을 때 스프링백
- [ ] 상단을 크게 끌거나 빠르게 튕겼을 때 닫힘, 제출 완료 등 프로그램적 닫힘도 슬라이드다운되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth slide-in and slide-out animations for bottom sheets.
  * Added drag-to-dismiss gestures with distance and swipe-speed detection.
  * Added animated background dimming during presentation and dismissal.
  * Bottom sheets now return to their original position when a dismissal gesture is not completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->