### PR TITLE
fix(dev): metro blockList 에 .claude/worktrees 추가

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -8,14 +8,32 @@ const {withNativeWind} = require('nativewind/metro');
  * @type {import('metro-config').MetroConfig}
  */
 
+const path = require('node:path');
+
 const config = getDefaultConfig(__dirname);
 const {transformer, resolver} = config;
+
+// 에이전트 git worktree 는 프로젝트 루트 안(.claude/worktrees/*)에 생기고 자체 node_modules 를
+// 가진다. 막지 않으면 Metro 가 react-native 를 두 벌 스캔해서 TurboModule 이 중복 등록되고,
+// 앱이 "'PlatformConstants' could not be found" 레드박스로 죽는다.
+const worktreesDir = path.join(__dirname, '.claude', 'worktrees');
+const worktreeBlockList = new RegExp(
+  `^${worktreesDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[/\\\\].*`,
+);
 config.transformer = {
   ...transformer,
   babelTransformerPath: require.resolve('./textFileTransformer.js'),
 };
 config.resolver = {
   ...resolver,
+  blockList: [
+    ...(Array.isArray(resolver.blockList)
+      ? resolver.blockList
+      : resolver.blockList
+        ? [resolver.blockList]
+        : []),
+    worktreeBlockList,
+  ],
   assetExts: [
     ...resolver.assetExts
       .filter(ext => ext !== 'svg')


### PR DESCRIPTION
## 문제

에이전트 git worktree 는 프로젝트 루트 안(`.claude/worktrees/*`)에 생기고 자체 `node_modules` 를 가진다. Metro 가 이걸 같이 스캔하면 `react-native` 가 두 벌 로드돼 TurboModule 이 중복 등록되고, 앱이 실행 즉시 `'PlatformConstants' could not be found` 레드박스로 죽는다.

이번 세션에서 실제로 발생했다 — 병렬 워커가 만든 worktree 때문에 에뮬레이터 앱이 부팅 불가 상태가 됐고, 원인을 찾는 데 시간이 걸렸다.

## 변경

`config.resolver.blockList` 에 `.claude/worktrees/**` 를 추가. 기존 blockList(배열/단일 RegExp/미설정) 를 모두 보존하도록 병합한다.

## 영향 반경

빌드 산출물 무변경 — 스캔 대상에서 프로젝트 밖 디렉토리 하나를 뺄 뿐이다. worktree 가 없는 환경에서는 no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)