### PR TITLE
fix(webview): 인앱 웹뷰에서 트래킹 링크가 앱스토어로 가던 문제 수정

### DIFF
--- a/src/navigation/linkingConfig.ts
+++ b/src/navigation/linkingConfig.ts
@@ -1,5 +1,8 @@
+/** 앱 전용 커스텀 스킴. "이 URL 의 목적지는 이 앱의 화면" 이라는 확정 신호로 쓰인다. */
+export const APP_SCHEME_PREFIX = 'stair-crusher://';
+
 export const DEEP_LINK_PREFIXES = [
-  'stair-crusher://',
+  APP_SCHEME_PREFIX,
   'https://scc.airbridge.io/',
   'https://app.staircrusher.club/',
 ];

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -4,7 +4,10 @@ import {SccPressable} from '@/components/SccPressable';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Alert, StyleSheet, Text, View} from 'react-native';
 import WebView, {WebViewMessageEvent} from 'react-native-webview';
-import type {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes';
+import type {
+  ShouldStartLoadRequest,
+  WebViewOpenWindowEvent,
+} from 'react-native-webview/lib/WebViewTypes';
 import {useAtomValue} from 'jotai';
 import Config from 'react-native-config';
 
@@ -17,7 +20,11 @@ import {color} from '@/constant/color';
 import {font} from '@/constant/font';
 import {ScreenProps} from '@/navigation/Navigation.screens';
 import {resolveTemplatedExternalUrl} from '@/utils/externalUrlTemplating';
-import {handleWebViewShouldStartLoad} from '@/utils/webViewUtils';
+import {
+  handleWebViewOpenWindow,
+  handleWebViewShouldStartLoad,
+  isTrackingLinkUrl,
+} from '@/utils/webViewUtils';
 import SccContentFloatingBar from './WebViewScreen/components/SccContentFloatingBar';
 
 // 브리지(로그인 상태 주입 + 로그인 위임 메시지 수신)를 허용하는 origin.
@@ -299,13 +306,35 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
     return false;
   }, [canGoBack]);
 
+  // 딥링크를 앱에 넘긴 뒤, 웹뷰가 airbridge 랜딩 페이지에 남아 있으면 원래 페이지로 되돌린다.
+  // (안 되돌리면 띄운 화면을 닫고 웹뷰로 돌아왔을 때 빈 랜딩 페이지가 보인다)
+  // 트래킹 링크는 이제 로드 전에 목적지를 확인하므로 보통 이 경로를 타지 않는다 —
+  // 랜딩 페이지가 실제로 로드된 경우(직접 링크 등)만 정리한다.
+  const handleAppDeepLink = useCallback(() => {
+    if (isTrackingLinkUrl(currentUrl)) {
+      webViewRef.current?.goBack();
+    }
+  }, [currentUrl]);
+
+  const loadHandlerOptions = useMemo(
+    () => ({
+      userId: userInfo?.id,
+      webViewRef,
+      onAppDeepLink: handleAppDeepLink,
+    }),
+    [userInfo?.id, handleAppDeepLink],
+  );
+
   const handleShouldStartLoad = useCallback(
     (request: ShouldStartLoadRequest) =>
-      handleWebViewShouldStartLoad(request, {
-        userId: userInfo?.id,
-        webViewRef,
-      }),
-    [userInfo?.id],
+      handleWebViewShouldStartLoad(request, loadHandlerOptions),
+    [loadHandlerOptions],
+  );
+
+  const handleOpenWindow = useCallback(
+    (event: WebViewOpenWindowEvent) =>
+      handleWebViewOpenWindow(event.nativeEvent.targetUrl, loadHandlerOptions),
+    [loadHandlerOptions],
   );
 
   useBackHandler(handleBackPress);
@@ -360,6 +389,9 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
         onMessage={handleMessage}
         onLoadEnd={handleLoadEnd}
         onShouldStartLoadWithRequest={handleShouldStartLoad}
+        // target="_blank" 클릭도 같은 판정을 타게 한다 (없으면 안드로이드에서 화면에 붙지 않는
+        // 새 WebView 로 새서 클릭이 사라진다 — 상세는 handleWebViewOpenWindow 주석)
+        onOpenWindow={handleOpenWindow}
         onNavigationStateChange={navState => {
           setCanGoBack(navState.canGoBack);
           // 함수형 setter 로 atomic 하게 비교 + 갱신 — onNavigationStateChange 는 빠르게

--- a/src/utils/webViewUtils.test.ts
+++ b/src/utils/webViewUtils.test.ts
@@ -1,0 +1,288 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import {Linking} from 'react-native';
+import type WebView from 'react-native-webview';
+import type {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes';
+
+import {
+  extractDeclaredAppDeepLink,
+  extractEmbeddedAppDeepLink,
+  handleWebViewOpenWindow,
+  handleWebViewShouldStartLoad,
+  isTrackingLinkUrl,
+  resolveIntentUri,
+} from './webViewUtils';
+
+jest.mock('react-native', () => ({
+  Linking: {openURL: jest.fn(() => Promise.resolve(true))},
+}));
+
+const openURL = jest.mocked(Linking.openURL);
+
+/** airbridge 딥링크 페이지가 안드로이드에서 실제로 발사하는 형식. */
+const ANDROID_INTENT_URL =
+  'intent://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc' +
+  '#Intent;scheme=stair-crusher;package=club.staircrusher;S.browser_fallback_url=market%3A%2F%2Fdetails%3Fid%3Dclub.staircrusher;end;';
+const DEEP_LINK_URL =
+  'stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc';
+
+function shouldLoad(url: string, onAppDeepLink?: () => void): boolean {
+  return handleWebViewShouldStartLoad(
+    {url} as unknown as ShouldStartLoadRequest,
+    {
+      onAppDeepLink,
+    },
+  );
+}
+
+beforeEach(() => {
+  openURL.mockClear();
+});
+
+describe('resolveIntentUri', () => {
+  it('intent URI 를 원래 스킴 URL 로 되돌린다', () => {
+    expect(resolveIntentUri(ANDROID_INTENT_URL)).toBe(DEEP_LINK_URL);
+  });
+
+  it('앱 스킴을 하드코딩하지 않는다 (지도앱 등 다른 intent 링크도 복원)', () => {
+    expect(
+      resolveIntentUri('intent://route/public?a=1#Intent;scheme=nmap;end;'),
+    ).toBe('nmap://route/public?a=1');
+  });
+
+  it('intent:// 가 아니면 null', () => {
+    expect(resolveIntentUri(DEEP_LINK_URL)).toBeNull();
+    expect(
+      resolveIntentUri('https://link.staircrusher.club/ns539uk'),
+    ).toBeNull();
+  });
+
+  it('scheme 이 없는 intent URI 는 null', () => {
+    expect(resolveIntentUri('intent://foo#Intent;package=x;end;')).toBeNull();
+  });
+});
+
+// airbridge 가 안드로이드에서 실제로 발사하는 유일한 URL: 딥링크를 스토어 intent 에 실어보낸다.
+const ANDROID_STORE_INTENT_WITH_DEEP_LINK =
+  'intent://details?id=club.staircrusher&referrer=abc&url=' +
+  encodeURIComponent(DEEP_LINK_URL) +
+  '#Intent;scheme=market;package=com.android.vending;end;';
+
+describe('스토어 intent 에 실려온 딥링크', () => {
+  it('플레이스토어 intent 의 url= 파라미터에서 딥링크를 꺼내 앱에 넘긴다', () => {
+    const onAppDeepLink = jest.fn();
+    expect(shouldLoad(ANDROID_STORE_INTENT_WITH_DEEP_LINK, onAppDeepLink)).toBe(
+      false,
+    );
+    // 스토어(market://)를 그냥 삼키면 딥링크까지 사라져 "앱으로 이동" 버튼 페이지만 남는다.
+    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(onAppDeepLink).toHaveBeenCalled();
+  });
+
+  it('딥링크가 실려 있지 않은 스토어 URL 은 그대로 삼킨다', () => {
+    expect(
+      shouldLoad('market://details?id=club.staircrusher&referrer=abc'),
+    ).toBe(false);
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it('파라미터에 웹 URL 이 실려 있으면 딥링크로 취급하지 않는다', () => {
+    expect(
+      extractEmbeddedAppDeepLink(
+        'market://details?id=x&url=https%3A%2F%2Fweb.staircrusher.club%2Fa',
+      ),
+    ).toBeNull();
+  });
+
+  it('airbridge_deeplink 파라미터도 지원한다', () => {
+    expect(
+      extractEmbeddedAppDeepLink(
+        `market://details?id=x&airbridge_deeplink=${encodeURIComponent(DEEP_LINK_URL)}`,
+      ),
+    ).toBe(DEEP_LINK_URL);
+  });
+});
+
+describe('handleWebViewShouldStartLoad — 스토어 fallback', () => {
+  it.each([
+    'market://details?id=club.staircrusher&referrer=x',
+    'itms-apps://apps.apple.com/kr/app/id6444382843',
+    'itms-appss://apps.apple.com/kr/app/id6444382843',
+    'https://play.google.com/store/apps/details?id=club.staircrusher',
+    'https://apps.apple.com/kr/app/id6444382843',
+  ])('%s 은 로드하지도, OS 로 넘기지도 않는다', url => {
+    expect(shouldLoad(url)).toBe(false);
+    expect(openURL).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleWebViewShouldStartLoad — 앱 딥링크', () => {
+  it('stair-crusher:// 는 앱에 넘기고 웹뷰에서는 로드하지 않는다', () => {
+    const onAppDeepLink = jest.fn();
+    expect(shouldLoad(DEEP_LINK_URL, onAppDeepLink)).toBe(false);
+    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(onAppDeepLink).toHaveBeenCalled();
+  });
+
+  it('안드로이드 intent URI 도 스킴을 복원해서 앱에 넘긴다', () => {
+    const onAppDeepLink = jest.fn();
+    expect(shouldLoad(ANDROID_INTENT_URL, onAppDeepLink)).toBe(false);
+    // intent:// 를 그대로 넘기면 RN Linking 이 처리하지 못해 조용히 실패한다.
+    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(onAppDeepLink).toHaveBeenCalled();
+  });
+});
+
+describe('handleWebViewShouldStartLoad — 웹 목적지', () => {
+  it('일반 웹 링크는 그대로 로드한다', () => {
+    expect(shouldLoad('https://naver.me/5YSWYw6R')).toBe(true);
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it('앱 스킴이 아닌 커스텀 스킴은 네이티브로 위임한다', () => {
+    expect(shouldLoad('tel:021234567')).toBe(false);
+    expect(openURL).toHaveBeenCalledWith('tel:021234567');
+  });
+});
+
+describe('handleWebViewOpenWindow', () => {
+  function fakeWebViewRef() {
+    const injectJavaScript = jest.fn();
+    return {
+      ref: {
+        current: {injectJavaScript},
+      } as unknown as React.RefObject<WebView | null>,
+      injectJavaScript,
+    };
+  }
+
+  it('웹 링크는 현재 웹뷰에서 연다', () => {
+    const {ref, injectJavaScript} = fakeWebViewRef();
+    handleWebViewOpenWindow('https://naver.me/5YSWYw6R', {webViewRef: ref});
+    expect(injectJavaScript).toHaveBeenCalledWith(
+      'window.location.href = "https://naver.me/5YSWYw6R"; true;',
+    );
+  });
+
+  it('스토어 URL 은 열지 않는다', () => {
+    const {ref, injectJavaScript} = fakeWebViewRef();
+    handleWebViewOpenWindow('market://details?id=club.staircrusher', {
+      webViewRef: ref,
+    });
+    expect(injectJavaScript).not.toHaveBeenCalled();
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it('딥링크는 웹뷰에서 열지 않고 앱에 넘긴다', () => {
+    const {ref, injectJavaScript} = fakeWebViewRef();
+    handleWebViewOpenWindow(ANDROID_INTENT_URL, {webViewRef: ref});
+    expect(injectJavaScript).not.toHaveBeenCalled();
+    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+  });
+});
+
+describe('isTrackingLinkUrl', () => {
+  it('트래킹/랜딩 호스트만 true', () => {
+    expect(isTrackingLinkUrl('https://scc.airbridge.io/place-group/x')).toBe(
+      true,
+    );
+    expect(isTrackingLinkUrl('https://link.staircrusher.club/ns539uk')).toBe(
+      true,
+    );
+    expect(
+      isTrackingLinkUrl('https://web.staircrusher.club/bbucle-road/x'),
+    ).toBe(false);
+  });
+});
+
+// 실제 랜딩 페이지(scc.airbridge.io) HTML 의 메타 형태. content 는 HTML escape 되어 온다.
+const LANDING_HTML_APP = `<!doctype html><meta property="al:web:should_fallback" content="true">
+<meta property="al:ios:app_store_id" content="6444382843">
+<meta property="al:ios:url" content="stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc&amp;https_deeplink=true">
+<meta property="al:android:package" content="club.staircrusher">
+<meta property="al:android:url" content="stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc&amp;https_deeplink=true">`;
+
+const LANDING_HTML_WEB_ONLY = `<!doctype html><meta property="al:web:should_fallback" content="true">
+<meta property="al:web:url" content="https://web.staircrusher.club/articles/x">`;
+
+describe('extractDeclaredAppDeepLink', () => {
+  it('랜딩 페이지가 선언한 앱 딥링크를 꺼내고 &amp; 를 되돌린다', () => {
+    expect(extractDeclaredAppDeepLink(LANDING_HTML_APP)).toBe(
+      'stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc&https_deeplink=true',
+    );
+  });
+
+  it('웹 목적지 트래킹 링크는 null (앱 스킴 선언이 없다)', () => {
+    expect(extractDeclaredAppDeepLink(LANDING_HTML_WEB_ONLY)).toBeNull();
+  });
+
+  it('메타가 없어도 던지지 않는다', () => {
+    expect(extractDeclaredAppDeepLink('<html></html>')).toBeNull();
+  });
+});
+
+describe('트래킹 링크 목적지 확인', () => {
+  const TRACKING_URL = 'https://link.staircrusher.club/ns539uk';
+
+  function mockFetchHtml(html: string) {
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({text: () => Promise.resolve(html)}),
+    );
+    (globalThis as {fetch?: unknown}).fetch = fetchMock;
+    return fetchMock;
+  }
+
+  /** 비동기 확인이 끝나기를 기다린다. */
+  const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  it('트래킹 링크는 웹뷰에 로드하지 않는다 (목적지를 먼저 확인)', () => {
+    mockFetchHtml(LANDING_HTML_APP);
+    expect(shouldLoad(TRACKING_URL)).toBe(false);
+  });
+
+  it('목적지가 앱 화면이면 그 화면을 띄운다', async () => {
+    const fetchMock = mockFetchHtml(LANDING_HTML_APP);
+    const onAppDeepLink = jest.fn();
+    shouldLoad(TRACKING_URL, onAppDeepLink);
+    await flush();
+    // 브라우저 UA 를 안 보내면 airbridge 가 웹 fallback 을 주고 메타가 사라진다.
+    expect(fetchMock).toHaveBeenCalledWith(TRACKING_URL, {
+      headers: {
+        'User-Agent': expect.stringContaining(
+          'Mobile Safari',
+        ) as unknown as string,
+      },
+    });
+    expect(openURL).toHaveBeenCalledWith(
+      'stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc&https_deeplink=true',
+    );
+    expect(onAppDeepLink).toHaveBeenCalled();
+  });
+
+  it('목적지가 웹이면 기존대로 웹뷰에서 연다', async () => {
+    mockFetchHtml(LANDING_HTML_WEB_ONLY);
+    const injectJavaScript = jest.fn();
+    const ref = {
+      current: {injectJavaScript},
+    } as unknown as React.RefObject<WebView | null>;
+    handleWebViewOpenWindow(TRACKING_URL, {webViewRef: ref});
+    await flush();
+    expect(openURL).not.toHaveBeenCalled();
+    expect(injectJavaScript).toHaveBeenCalledWith(
+      `window.location.href = ${JSON.stringify(TRACKING_URL)}; true;`,
+    );
+  });
+
+  it('확인이 실패하면 기존 동작(웹뷰 로드)으로 폴백한다', async () => {
+    (globalThis as {fetch?: unknown}).fetch = jest.fn(() =>
+      Promise.reject(new Error('offline')),
+    );
+    const injectJavaScript = jest.fn();
+    const ref = {
+      current: {injectJavaScript},
+    } as unknown as React.RefObject<WebView | null>;
+    handleWebViewOpenWindow(TRACKING_URL, {webViewRef: ref});
+    await flush();
+    expect(injectJavaScript).toHaveBeenCalled();
+    expect(openURL).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/webViewUtils.test.ts
+++ b/src/utils/webViewUtils.test.ts
@@ -25,6 +25,19 @@ const ANDROID_INTENT_URL =
 const DEEP_LINK_URL =
   'stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc';
 
+function fakeWebViewRef(): {
+  ref: React.RefObject<WebView | null>;
+  injectJavaScript: jest.Mock;
+} {
+  const injectJavaScript = jest.fn();
+  return {
+    ref: {
+      current: {injectJavaScript},
+    } as unknown as React.RefObject<WebView | null>,
+    injectJavaScript,
+  };
+}
+
 function shouldLoad(url: string, onAppDeepLink?: () => void): boolean {
   return handleWebViewShouldStartLoad(
     {url} as unknown as ShouldStartLoadRequest,
@@ -142,19 +155,14 @@ describe('handleWebViewShouldStartLoad — 웹 목적지', () => {
     expect(shouldLoad('tel:021234567')).toBe(false);
     expect(openURL).toHaveBeenCalledWith('tel:021234567');
   });
+
+  it('대문자 스킴도 웹 링크로 본다 (네이티브로 넘기지 않는다)', () => {
+    expect(shouldLoad('HTTPS://naver.me/5YSWYw6R')).toBe(true);
+    expect(openURL).not.toHaveBeenCalled();
+  });
 });
 
 describe('handleWebViewOpenWindow', () => {
-  function fakeWebViewRef() {
-    const injectJavaScript = jest.fn();
-    return {
-      ref: {
-        current: {injectJavaScript},
-      } as unknown as React.RefObject<WebView | null>,
-      injectJavaScript,
-    };
-  }
-
   it('웹 링크는 현재 웹뷰에서 연다', () => {
     const {ref, injectJavaScript} = fakeWebViewRef();
     handleWebViewOpenWindow('https://naver.me/5YSWYw6R', {webViewRef: ref});
@@ -218,12 +226,20 @@ describe('extractDeclaredAppDeepLink', () => {
   it('메타가 없어도 던지지 않는다', () => {
     expect(extractDeclaredAppDeepLink('<html></html>')).toBeNull();
   });
+
+  it('속성 순서/따옴표 종류/추가 속성에 의존하지 않는다', () => {
+    expect(
+      extractDeclaredAppDeepLink(
+        `<meta content='stair-crusher://place-group/x' data-rh="true" property='al:android:url'>`,
+      ),
+    ).toBe('stair-crusher://place-group/x');
+  });
 });
 
 describe('트래킹 링크 목적지 확인', () => {
   const TRACKING_URL = 'https://link.staircrusher.club/ns539uk';
 
-  function mockFetchHtml(html: string) {
+  function mockFetchHtml(html: string): jest.Mock {
     const fetchMock = jest.fn(() =>
       Promise.resolve({text: () => Promise.resolve(html)}),
     );
@@ -232,17 +248,43 @@ describe('트래킹 링크 목적지 확인', () => {
   }
 
   /** 비동기 확인이 끝나기를 기다린다. */
-  const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+  const flush = (): Promise<void> =>
+    new Promise(resolve => setTimeout(resolve, 0));
 
   it('트래킹 링크는 웹뷰에 로드하지 않는다 (목적지를 먼저 확인)', () => {
     mockFetchHtml(LANDING_HTML_APP);
     expect(shouldLoad(TRACKING_URL)).toBe(false);
   });
 
+  it('확인이 끝나기 전에 다른 링크로 이동했으면 뒤늦은 결과를 버린다', async () => {
+    mockFetchHtml(LANDING_HTML_APP);
+    const {ref} = fakeWebViewRef();
+    handleWebViewOpenWindow(TRACKING_URL, {webViewRef: ref});
+    // 확인이 끝나기 전에 다음 네비게이션이 일어난다.
+    handleWebViewShouldStartLoad(
+      {url: 'https://naver.me/other'} as unknown as ShouldStartLoadRequest,
+      {webViewRef: ref},
+    );
+    await flush();
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it('화면이 닫힌 뒤 도착한 결과도 버린다', async () => {
+    mockFetchHtml(LANDING_HTML_APP);
+    const ref = {
+      current: {injectJavaScript: jest.fn()},
+    } as unknown as React.RefObject<WebView | null>;
+    handleWebViewOpenWindow(TRACKING_URL, {webViewRef: ref});
+    (ref as {current: unknown}).current = null; // 화면 unmount
+    await flush();
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
   it('목적지가 앱 화면이면 그 화면을 띄운다', async () => {
     const fetchMock = mockFetchHtml(LANDING_HTML_APP);
     const onAppDeepLink = jest.fn();
-    shouldLoad(TRACKING_URL, onAppDeepLink);
+    const {ref} = fakeWebViewRef();
+    handleWebViewOpenWindow(TRACKING_URL, {webViewRef: ref, onAppDeepLink});
     await flush();
     // 브라우저 UA 를 안 보내면 airbridge 가 웹 fallback 을 주고 메타가 사라진다.
     expect(fetchMock).toHaveBeenCalledWith(TRACKING_URL, {

--- a/src/utils/webViewUtils.ts
+++ b/src/utils/webViewUtils.ts
@@ -64,6 +64,11 @@ export interface WebViewLoadOptions {
   onAppDeepLink?: () => void;
 }
 
+// 마지막 네비게이션 판정 토큰. 비동기 목적지 확인 결과가 뒤늦게 도착했을 때 버릴지 판단한다.
+// ponytail: 웹뷰 화면이 동시에 여러 개 뜨는 구조가 아니라 모듈 전역 카운터로 충분하다.
+// 화면별로 독립돼야 하면 opts 로 토큰 소유자를 넘기는 형태로 승격.
+let latestNavigationToken = 0;
+
 function startsWithAny(url: string, prefixes: string[]): boolean {
   const lowerUrl = url.toLowerCase();
   return prefixes.some(prefix => lowerUrl.startsWith(prefix));
@@ -134,14 +139,21 @@ export function isTrackingLinkUrl(url: string): boolean {
  * 앱 스킴이 아니므로 null 이 되어 기존 동작(웹뷰에서 로드)으로 떨어진다.
  */
 export function extractDeclaredAppDeepLink(html: string): string | null {
-  const match = html.match(
-    /<meta\s+property="al:(?:android|ios):url"\s+content="([^"]*)"/i,
-  );
-  if (!match) {
-    return null;
+  // 속성 순서/따옴표 종류/추가 속성에 의존하지 않는다 — 여기서 못 읽으면 조용히 폴백되므로
+  // (스토어로 가진 않지만 딥링크도 안 뜬다) HTML 직렬화 형태에 결합시키지 않는다.
+  const metaTags = html.match(/<meta\b[^>]*>/gi) ?? [];
+  for (const tag of metaTags) {
+    const property = tag.match(/\bproperty\s*=\s*["']([^"']*)["']/i)?.[1];
+    if (!property || !/^al:(?:android|ios):url$/i.test(property)) {
+      continue;
+    }
+    const content = tag.match(/\bcontent\s*=\s*["']([^"']*)["']/i)?.[1];
+    const declared = content?.replace(/&amp;/g, '&');
+    if (declared?.toLowerCase().startsWith(APP_SCHEME_PREFIX)) {
+      return declared;
+    }
   }
-  const declared = match[1].replace(/&amp;/g, '&');
-  return declared.toLowerCase().startsWith(APP_SCHEME_PREFIX) ? declared : null;
+  return null;
 }
 
 /**
@@ -209,6 +221,13 @@ function decideWebViewLoad(
   requestUrl: string,
   opts?: WebViewLoadOptions,
 ): boolean {
+  // 이 판정이 최신임을 표시한다. 트래킹 링크 목적지 확인은 비동기라, 확인이 끝나기 전에
+  // 사용자가 다른 링크를 누르거나 화면을 닫으면 뒤늦게 도착한 결과가 엉뚱한 화면을 띄우거나
+  // 남의 페이지를 덮어쓴다. 마지막 네비게이션만 유효로 본다.
+  const navigationToken = ++latestNavigationToken;
+  const isStale = () =>
+    navigationToken !== latestNavigationToken || !opts?.webViewRef?.current;
+
   // Android intent URI 는 원래 스킴으로 되돌린 뒤 판정한다.
   const url = resolveIntentUri(requestUrl) ?? requestUrl;
 
@@ -238,17 +257,25 @@ function decideWebViewLoad(
   if (isTrackingLinkUrl(url)) {
     resolveTrackingLinkDeepLink(url)
       .then(deepLink => {
+        if (isStale()) {
+          return;
+        }
         if (deepLink) {
           handOffToApp(deepLink, opts);
         } else {
           loadInWebView(url, opts?.webViewRef);
         }
       })
-      .catch(() => loadInWebView(url, opts?.webViewRef));
+      .catch(() => {
+        if (!isStale()) {
+          loadInWebView(url, opts?.webViewRef);
+        }
+      });
     return false;
   }
 
-  if (url.startsWith('http://') || url.startsWith('https://')) {
+  const lowerUrl = url.toLowerCase();
+  if (lowerUrl.startsWith('http://') || lowerUrl.startsWith('https://')) {
     const resolved = resolveTemplatedExternalUrl(url, {userId: opts?.userId});
     if (resolved !== url && opts?.webViewRef?.current) {
       loadInWebView(resolved, opts.webViewRef);

--- a/src/utils/webViewUtils.ts
+++ b/src/utils/webViewUtils.ts
@@ -3,42 +3,300 @@ import {Linking} from 'react-native';
 import type WebView from 'react-native-webview';
 import type {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes';
 
+import {APP_SCHEME_PREFIX} from '@/navigation/linkingConfig';
+
 import {resolveTemplatedExternalUrl} from './externalUrlTemplating';
 
+const INTENT_SCHEME_PREFIX = 'intent://';
+
+// 앱 웹뷰 안에서 스토어로 보내는 URL 은 항상 오답이다 — 그 앱이 이미 실행 중이다.
+// airbridge 딥링크 페이지는 딥링크를 시도한 뒤 "앱이 안 열렸다" 고 판단되면 타이머로
+// 스토어 fallback 을 발사하는데, 우리 앱 웹뷰 안에서는 앱이 백그라운드로 가지 않으므로
+// 그 판단이 늘 틀린다. 이게 "웹뷰에서 트래킹 링크를 눌렀더니 앱스토어가 뜬다" 의 원인이다.
+// (앱 업데이트 유도용 스토어 이동은 네이티브 화면(HomeScreenV2/VersionRow)에만 있고
+//  웹뷰를 타지 않으므로 여기서 막아도 영향이 없다.)
+const STORE_URL_PREFIXES = [
+  'market://',
+  'itms-apps://',
+  'itms-appss://',
+  'https://play.google.com/store',
+  'https://apps.apple.com',
+];
+
+// airbridge 트래킹 링크 / 딥링크 랜딩 호스트.
+// 이 호스트는 웹뷰에 로드하지 않고 목적지를 먼저 확인한다(resolveTrackingLinkDeepLink).
+// **호스트로 "앱 목적지" 라고 판정하는 게 아니다** — 성과 추적만을 위해 웹 링크를 감싼 트래킹
+// 링크도 있으므로, 판정은 랜딩 페이지가 선언한 딥링크로만 한다.
+const TRACKING_LINK_HOSTS = [
+  'link.staircrusher.club',
+  'scc.airbridge.io',
+  'abr.ge',
+];
+
+/** 트래킹 링크 목적지 확인 타임아웃. 넘으면 기존 동작(웹뷰 로드)으로 폴백한다. */
+const TRACKING_LINK_RESOLVE_TIMEOUT_MS = 5000;
+
+// airbridge 는 UA 로 응답을 가른다. RN fetch 의 기본 UA(okhttp/…)로 요청하면 딥링크 페이지가
+// 아니라 **웹 fallback(마케팅 사이트)** 이 돌아와서 al:*:url 메타가 아예 없다(실측 확인:
+// okhttp → 336KB Framer 페이지 / 모바일 브라우저 UA → 5.6KB 딥링크 페이지).
+// 목적지를 읽으려면 모바일 브라우저 UA 로 요청해야 한다 — 이 헤더를 지우면 조용히 고장난다.
+const TRACKING_LINK_RESOLVE_USER_AGENT =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36';
+
+// airbridge 는 안드로이드에서 앱 딥링크를 단독으로 발사하지 않는다. fallback 이 google-play 면
+// **딥링크를 플레이스토어 intent 의 query param 에 실어서** 한 번만 발사한다
+// (deeplink_page SDK 의 openIntent 첫 분기 — `query:{url: <딥링크>}`):
+//   intent://details?id=club.staircrusher&url=stair-crusher%3A%2F%2Fplace-group%2Fx
+//     #Intent;scheme=market;package=com.android.vending;end;
+// 스토어가 "설치된 앱에 딥링크를 넘겨주는" 동작을 기대한 형식이다. 그래서 스토어 URL 을 그냥
+// 삼키면 딥링크까지 함께 사라져서 "앱으로 이동" 버튼만 남은 fallback 페이지가 그려진다.
+// 스토어 URL 에 실려온 앱 딥링크는 꺼내서 우리가 직접 처리한다.
+// (iOS 는 Md.default 의 scheme 전략으로 stair-crusher:// 를 그대로 발사하므로 이 경로가 아니다)
+const EMBEDDED_DEEP_LINK_PARAMS = ['url', 'airbridge_deeplink'];
+
+export interface WebViewLoadOptions {
+  userId?: string;
+  webViewRef?: RefObject<WebView | null>;
+  /**
+   * 딥링크를 앱에 넘겼을 때 호출된다. 웹뷰가 airbridge 랜딩 페이지에 남아 있으면
+   * 원래 페이지로 되돌리는 정리용 (안 하면 띄운 화면을 닫고 돌아왔을 때 빈 랜딩 페이지가 보인다).
+   */
+  onAppDeepLink?: () => void;
+}
+
+function startsWithAny(url: string, prefixes: string[]): boolean {
+  const lowerUrl = url.toLowerCase();
+  return prefixes.some(prefix => lowerUrl.startsWith(prefix));
+}
+
 /**
- * WebView의 onShouldStartLoadWithRequest 공통 핸들러.
- * http/https URL은 WebView에서 로드하고, 커스텀 스킴(intent://, stair-crusher:// 등)은
- * 네이티브 Linking으로 위임한다.
+ * Android 웹뷰가 넘겨주는 intent URI 를 원래 스킴 URL 로 되돌린다.
+ * `intent://place-group/x?a=1#Intent;scheme=stair-crusher;package=club.staircrusher;end;`
+ *   → `stair-crusher://place-group/x?a=1`
  *
- * `opts.userId` 와 `opts.webViewRef` 가 함께 전달되고, URL 이 화이트리스트 폼 도메인의
- * `{userId}` placeholder 를 포함하면 치환된 URL 로 webview 를 재진입시킨다.
- *
- * WebViewScreen과 PlaceDetailV2Screen의 BbucleRoad WebView 분기에서 공유한다.
+ * RN 의 Linking.openURL 은 Intent.parseUri 가 아니라 `Uri.parse` 로 ACTION_VIEW 를 만들기
+ * 때문에(IntentModule.kt) intent:// 를 그대로 넘기면 받을 액티비티가 없어 조용히 실패한다.
+ * airbridge 딥링크 페이지가 안드로이드에서 쓰는 형식이 정확히 이것이라, 복원하지 않으면
+ * 딥링크는 무조건 실패하고 스토어 fallback 만 살아남는다.
+ * (네이버지도 등 다른 intent:// 링크도 같은 이유로 실패했으므로 스킴을 하드코딩하지 않는다.)
  */
-export function handleWebViewShouldStartLoad(
-  request: ShouldStartLoadRequest,
-  opts?: {
-    userId?: string;
-    webViewRef?: RefObject<WebView | null>;
-  },
+export function resolveIntentUri(url: string): string | null {
+  if (!url.toLowerCase().startsWith(INTENT_SCHEME_PREFIX)) {
+    return null;
+  }
+  const fragmentIndex = url.indexOf('#');
+  if (fragmentIndex === -1) {
+    return null;
+  }
+  const fragment = url.slice(fragmentIndex + 1);
+  if (!fragment.toLowerCase().startsWith('intent;')) {
+    return null;
+  }
+  const scheme = fragment.match(/(?:^|;)scheme=([^;]+)/i)?.[1];
+  if (!scheme) {
+    return null;
+  }
+  return `${scheme}://${url.slice(INTENT_SCHEME_PREFIX.length, fragmentIndex)}`;
+}
+
+/**
+ * 스토어 URL 의 query param 에 실려온 앱 딥링크를 꺼낸다 (위 EMBEDDED_DEEP_LINK_PARAMS 주석).
+ * 값이 앱 스킴일 때만 반환한다 — 파라미터에 웹 URL 이 실려 있으면 딥링크가 아니다.
+ */
+export function extractEmbeddedAppDeepLink(url: string): string | null {
+  const queryIndex = url.indexOf('?');
+  if (queryIndex === -1) {
+    return null;
+  }
+  const params = new URLSearchParams(url.slice(queryIndex + 1).split('#')[0]);
+  for (const name of EMBEDDED_DEEP_LINK_PARAMS) {
+    const value = params.get(name);
+    if (value?.toLowerCase().startsWith(APP_SCHEME_PREFIX)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/** airbridge 트래킹 링크 / 랜딩 페이지 URL 인지. */
+export function isTrackingLinkUrl(url: string): boolean {
+  const lowerUrl = url.toLowerCase();
+  return TRACKING_LINK_HOSTS.some(host =>
+    lowerUrl.startsWith(`https://${host}/`),
+  );
+}
+
+/**
+ * airbridge 랜딩 페이지 HTML 이 선언한 앱 딥링크를 꺼낸다.
+ *
+ * 랜딩 페이지는 `al:android:url` / `al:ios:url` 메타에 목적지 딥링크를 그대로 박아둔다.
+ * 이게 "목적지가 앱 화면" 이라는 확정 신호다 — 웹 목적지 트래킹 링크에는 이 메타가 없거나
+ * 앱 스킴이 아니므로 null 이 되어 기존 동작(웹뷰에서 로드)으로 떨어진다.
+ */
+export function extractDeclaredAppDeepLink(html: string): string | null {
+  const match = html.match(
+    /<meta\s+property="al:(?:android|ios):url"\s+content="([^"]*)"/i,
+  );
+  if (!match) {
+    return null;
+  }
+  const declared = match[1].replace(/&amp;/g, '&');
+  return declared.toLowerCase().startsWith(APP_SCHEME_PREFIX) ? declared : null;
+}
+
+/**
+ * 트래킹 링크의 목적지가 앱 화면인지 확인한다 (302 를 따라가 랜딩 페이지 HTML 을 읽는다).
+ *
+ * 왜 웹뷰에 로드하지 않고 우리가 확인하는가: 랜딩 페이지를 웹뷰에서 실행시키면 딥링크를
+ * 어떻게 발사할지가 브라우저 UA 별 전략 테이블에 따라 갈린다. 우리 인앱 웹뷰는 airbridge 의
+ * 전략 테이블에 없어서 default 로 떨어지고, 그 경로는 딥링크를 **플레이스토어 intent 에
+ * 감싸서** 던진 뒤 실패로 간주하고 "앱으로 이동" 버튼 페이지를 그린다 — 우리 앱 안에서는
+ * 무엇도 성공할 수 없는 흐름이다. 목적지만 우리가 읽어서 직접 띄우면 이 흐름 전체가 빠진다.
+ */
+async function resolveTrackingLinkDeepLink(
+  url: string,
+): Promise<string | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const html = await Promise.race([
+      fetch(url, {
+        headers: {'User-Agent': TRACKING_LINK_RESOLVE_USER_AGENT},
+      }).then(response => response.text()),
+      new Promise<null>(resolve => {
+        timeoutId = setTimeout(
+          () => resolve(null),
+          TRACKING_LINK_RESOLVE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    return html ? extractDeclaredAppDeepLink(html) : null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function openExternalUrl(url: string): void {
+  try {
+    Linking.openURL(url).catch(() => {});
+  } catch (_e) {
+    // URL을 열 수 없는 경우 무시
+  }
+}
+
+/**
+ * 앱 딥링크를 OS 딥링크 경로에 넘긴다. RootScreen 의 linking subscribe 가 받아서
+ * 현재 웹뷰 위로 해당 화면을 띄운다 (authDeferred 게이트, airbridge trackDeeplink 재사용).
+ */
+function handOffToApp(deepLinkUrl: string, opts?: WebViewLoadOptions): void {
+  openExternalUrl(deepLinkUrl);
+  opts?.onAppDeepLink?.();
+}
+
+function loadInWebView(
+  url: string,
+  webViewRef?: RefObject<WebView | null>,
+): void {
+  webViewRef?.current?.injectJavaScript(
+    `window.location.href = ${JSON.stringify(url)}; true;`,
+  );
+}
+
+/**
+ * 웹뷰가 이 URL 을 자기 안에서 로드해야 하는지 판정한다. 로드하지 않는 경우의 처리
+ * (앱 화면 띄우기 / 네이티브 위임 / 무시)는 이 함수 안에서 끝낸다.
+ */
+function decideWebViewLoad(
+  requestUrl: string,
+  opts?: WebViewLoadOptions,
 ): boolean {
-  const reqUrl = request.url;
-  if (reqUrl.startsWith('http://') || reqUrl.startsWith('https://')) {
-    const resolved = resolveTemplatedExternalUrl(reqUrl, {
-      userId: opts?.userId,
-    });
-    if (resolved !== reqUrl && opts?.webViewRef?.current) {
-      opts.webViewRef.current.injectJavaScript(
-        `window.location.href = ${JSON.stringify(resolved)}; true;`,
-      );
+  // Android intent URI 는 원래 스킴으로 되돌린 뒤 판정한다.
+  const url = resolveIntentUri(requestUrl) ?? requestUrl;
+
+  // 스토어 URL 은 삼킨다. 단 안드로이드는 딥링크가 스토어 intent 의 query param 에 실려오므로,
+  // 실려 있으면 그걸 꺼내 앱으로 넘긴다 (위 EMBEDDED_DEEP_LINK_PARAMS 주석).
+  if (startsWithAny(url, STORE_URL_PREFIXES)) {
+    const embeddedDeepLink = extractEmbeddedAppDeepLink(url);
+    if (embeddedDeepLink) {
+      handOffToApp(embeddedDeepLink, opts);
+    }
+    return false;
+  }
+
+  // 앱 커스텀 스킴 = "목적지는 이 앱의 화면" 이라는 확정 신호. airbridge 랜딩 페이지가
+  // 발사한 것이든 페이지가 직접 링크한 것이든 동일하게 OS 딥링크 경로로 넘긴다.
+  // RootScreen 의 linking subscribe 가 이걸 받아 현재 웹뷰 위로 해당 화면을 띄운다 —
+  // authDeferred 게이트, airbridge trackDeeplink 까지 기존 파이프라인을 그대로 재사용한다.
+  // 트래킹 링크의 목적지가 웹이면 이 URL 이 나오지 않으므로 아래 http(s) 분기로 떨어져
+  // 기존과 동일하게 웹뷰에서 열린다.
+  if (url.toLowerCase().startsWith(APP_SCHEME_PREFIX)) {
+    handOffToApp(url, opts);
+    return false;
+  }
+
+  // 트래킹 링크는 웹뷰에 로드하지 않고 목적지를 먼저 확인한다. 앱 화면이면 그 화면을 띄우고,
+  // 웹 목적지면 그때 웹뷰에서 연다 (확인 실패/타임아웃도 웹뷰 로드로 폴백 — 기존 동작).
+  if (isTrackingLinkUrl(url)) {
+    resolveTrackingLinkDeepLink(url)
+      .then(deepLink => {
+        if (deepLink) {
+          handOffToApp(deepLink, opts);
+        } else {
+          loadInWebView(url, opts?.webViewRef);
+        }
+      })
+      .catch(() => loadInWebView(url, opts?.webViewRef));
+    return false;
+  }
+
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    const resolved = resolveTemplatedExternalUrl(url, {userId: opts?.userId});
+    if (resolved !== url && opts?.webViewRef?.current) {
+      loadInWebView(resolved, opts.webViewRef);
       return false;
     }
     return true;
   }
-  try {
-    Linking.openURL(reqUrl).catch(() => {});
-  } catch (_e) {
-    // URL을 열 수 없는 경우 무시
-  }
+
+  // 그 외 커스텀 스킴(tel:, mailto:, 지도앱 등)은 네이티브로 위임.
+  openExternalUrl(url);
   return false;
+}
+
+/**
+ * WebView의 onShouldStartLoadWithRequest 공통 핸들러.
+ *
+ * - airbridge 트래킹 링크는 웹뷰에 로드하지 않고 목적지를 먼저 확인한다. 앱 화면이면 그 화면을
+ *   띄우고, 웹 목적지면 웹뷰에서 연다.
+ * - 앱 딥링크는 앱에 넘겨 현재 웹뷰 위로 해당 화면을 띄운다. `stair-crusher://…`,
+ *   Android `intent://…#Intent;scheme=stair-crusher;…`, 스토어 intent 의 `url=` 파라미터에
+ *   실려온 것 모두 (랜딩 페이지가 웹뷰에서 실행되는 경로가 남아 있을 때의 안전망).
+ * - 딥링크가 실려 있지 않은 스토어 URL 은 삼킨다 — 앱 안에서 스토어는 항상 오답.
+ * - 그 외 http/https 는 WebView 에서 로드하고, 나머지 커스텀 스킴은 Linking 으로 위임한다.
+ *
+ * `opts.userId` 와 `opts.webViewRef` 가 함께 전달되고, URL 이 화이트리스트 폼 도메인의
+ * `{userId}` placeholder 를 포함하면 치환된 URL 로 webview 를 재진입시킨다.
+ */
+export function handleWebViewShouldStartLoad(
+  request: ShouldStartLoadRequest,
+  opts?: WebViewLoadOptions,
+): boolean {
+  return decideWebViewLoad(request.url, opts);
+}
+
+/**
+ * WebView의 onOpenWindow(`target="_blank"` 클릭) 공통 핸들러.
+ *
+ * 안드로이드는 setSupportMultipleWindows 기본값(true) 때문에 _blank 클릭이
+ * onCreateWindow 로 가고, RNCWebChromeClient 가 **뷰 트리에 붙지 않는 새 WebView** 에서
+ * 그 URL 을 로드한다 — 사용자에겐 아무 일도 일어나지 않고 onShouldStartLoadWithRequest 도
+ * 그 URL 을 보지 못한다. onOpenWindow 를 붙이면 URL 이 JS 로 넘어오므로,
+ * 같은 판정을 태우고 웹뷰가 열어야 하는 URL 이면 현재 웹뷰에서 연다(iOS 기본 동작과 동일).
+ */
+export function handleWebViewOpenWindow(
+  targetUrl: string,
+  opts?: WebViewLoadOptions,
+): void {
+  if (decideWebViewLoad(targetUrl, opts)) {
+    loadInWebView(targetUrl, opts?.webViewRef);
+  }
 }


### PR DESCRIPTION
## 문제

앱 인앱 웹뷰로 뿌클로드(`web.staircrusher.club/bbucle-road/<slug>`)가 떴을 때, 안에 있는 airbridge 트래킹 링크("더 많은 장소 확인하기")를 누르면 해당 앱 화면이 웹뷰 위로 뜨는 게 아니라 **앱스토어가 열렸다**.

## 원인 (추측 아님 — 실측 + SDK 소스 확인)

1. `link.staircrusher.club/ns539uk` → 302 → `scc.airbridge.io/place-group/…` 랜딩 페이지가 **웹뷰 안에서** 로드된다. 앱링크/유니버설링크는 웹뷰 내부 내비게이션엔 개입하지 못한다.
2. 랜딩 페이지 JS는 UA별 전략 테이블(`Nd`)을 쓰는데 **인앱 웹뷰는 테이블에 없어 `default`로 떨어진다.** 안드로이드 default 경로(`za`)는 fallback이 google-play면 딥링크를 단독 발사하지 않고 **플레이스토어 intent에 감싸서** 한 번만 던진다:
   `intent://details?id=club.staircrusher&url=<딥링크>#Intent;scheme=market;package=com.android.vending;end;`
   그 뒤 실패로 간주하고 스토어 fallback을 발사한다 — 우리 앱 안에서는 앱이 백그라운드로 가지 않으니 그 판단이 **항상** 틀린다.
3. RN `Linking.openURL`은 Android에서 `Intent.parseUri`가 아니라 `Uri.parse`로 ACTION_VIEW를 만들어(`IntentModule.kt:117`) `intent://`를 그대로 넘기면 조용히 실패한다.
4. `setSupportMultipleWindows` 기본값이 true라(`RNCWebViewManagerImpl.kt:79`) `target="_blank"` 클릭이 `onCreateWindow`에서 **뷰 트리에 붙지 않는 새 WebView**로 새고(`RNCWebChromeClient.java:89-115`), 우리 `onShouldStartLoadWithRequest`는 그 URL을 보지도 못했다.
5. airbridge는 **UA로 응답을 가른다**: okhttp(RN fetch 기본) → 336KB 마케팅 페이지(`al:*` 메타 없음) / 모바일 브라우저 UA → 5.6KB 딥링크 페이지(메타 있음).

## 수정

**랜딩 페이지를 웹뷰에서 실행시키는 것 자체를 그만둔다.** airbridge가 웹뷰 UA에서 딥링크를 어떻게 발사할지는 우리가 통제할 수 없다.

- 트래킹 링크는 웹뷰에 로드하지 않고, 302를 따라가 랜딩 페이지가 **선언한** 딥링크(`al:android:url`/`al:ios:url`)를 읽어 목적지를 확정한다. 앱 스킴이면 그 화면을 웹뷰 위로 띄우고, 웹 목적지면 기존대로 웹뷰에서 연다. 확인 실패/타임아웃(5s)도 웹뷰 로드로 폴백.
  - **호스트로 판정하지 않는다** — 성과추적만을 위해 웹 링크를 감싼 트래킹 링크도 있으므로, 판정은 선언된 딥링크로만 한다.
  - fetch에 모바일 브라우저 UA를 명시 (위 5번. 지우면 조용히 고장나므로 주석 + 테스트로 고정)
- `onOpenWindow`를 붙여 `target="_blank"` 클릭도 같은 판정을 타게 한다. 덤으로 안드로이드에서 유령 웹뷰로 새던 다른 외부 링크(naver.me 등)도 같이 고쳐진다.
- 안전망(랜딩 페이지가 어떤 경로로든 웹뷰에서 실행될 때): `intent://` 스킴 복원, 스토어 intent의 `url=`에 실린 딥링크 추출, 딥링크가 없는 스토어 URL은 삼킴.

네이티브 파일 변경 0 → **OTA 범위**. `onOpenWindow`는 이미 배포된 바이너리에 컴파일되어 있는 prop이다(`react-native-webview@^13.15.0`, initial commit부터 고정).

## 검증

- 유닛테스트 28개 신규 (실측된 URL/랜딩 HTML 형태, UA 헤더, 웹 목적지 → null, 폴백 경로)
- `yarn tsc --noEmit` / `yarn lint` 0 error
- 에뮬레이터: `stair-crusher://place-group/…` 핸드오프가 실제로 웹뷰 위에 화면을 띄우는 것 확인 (`singleTask → onNewIntent → Linking → RootScreen subscribe` 체인)
- 실기기 확인 완료 (리포터 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of app deep links from web content, including Android intent links and links embedded in app-store URLs.
  * Added support for links opened in new windows within the in-app browser.
  * External links now open appropriately in the app, browser, or app store.
* **Bug Fixes**
  * Prevented unsupported store links from loading incorrectly in the in-app browser.
  * Improved tracking-link resolution and fallback behavior when destinations cannot be reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->