### PR TITLE
fix(webview): 웹뷰에서 띄운 화면이 iOS에서 모달 뒤에 깔리던 문제 수정

### DIFF
--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -15,33 +15,12 @@ import {
   ScreenParams,
 } from './Navigation.screens';
 import {webOnlyScreens} from './webScreens';
+import {withModalPresentation} from './withModalPresentation';
 import * as S from './Navigation.style';
 
 const AllNavigationScreens = [...MainNavigationScreens, ...webOnlyScreens];
 
 const Stack = createNativeStackNavigator<ScreenParams>();
-
-type ScreenOptions = (typeof AllNavigationScreens)[number]['options'];
-
-/**
- * `asModal` 파라미터로 진입한 화면은 **어떤 화면이든** 네이티브 모달로 띄운다.
- *
- * Webview 는 `presentation: 'fullScreenModal'` 이라, 그 위에 기본 push 로 화면을 올리면
- * iOS 에서 네이티브 모달이 위에 남아 새 화면이 가려진다 → 유저에겐 "눌러도 무반응" 이고,
- * 그 상태에서 X 를 누르면 가려진 화면이 먼저 pop 돼 **닫기를 두 번** 눌러야 한다.
- *
- * 웹뷰 안 링크(딥링크/트래킹 링크)가 띄울 수 있는 화면은 linkingConfig 에 있는 전부이므로
- * 화면마다 옵션을 붙이지 않고 등록 지점에서 일괄 처리한다 — 새 화면이 추가돼도 자동 적용된다.
- */
-function withModalPresentation(options: ScreenOptions) {
-  return (props: {route: any; navigation: any}): CustomNavigationOptions => {
-    const resolved = typeof options === 'function' ? options(props) : options;
-    if (!props.route.params?.asModal) {
-      return resolved ?? {};
-    }
-    return {...resolved, presentation: 'fullScreenModal'};
-  };
-}
 
 export const NavigationHeader = ({
   navigation,

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -21,6 +21,28 @@ const AllNavigationScreens = [...MainNavigationScreens, ...webOnlyScreens];
 
 const Stack = createNativeStackNavigator<ScreenParams>();
 
+type ScreenOptions = (typeof AllNavigationScreens)[number]['options'];
+
+/**
+ * `asModal` 파라미터로 진입한 화면은 **어떤 화면이든** 네이티브 모달로 띄운다.
+ *
+ * Webview 는 `presentation: 'fullScreenModal'` 이라, 그 위에 기본 push 로 화면을 올리면
+ * iOS 에서 네이티브 모달이 위에 남아 새 화면이 가려진다 → 유저에겐 "눌러도 무반응" 이고,
+ * 그 상태에서 X 를 누르면 가려진 화면이 먼저 pop 돼 **닫기를 두 번** 눌러야 한다.
+ *
+ * 웹뷰 안 링크(딥링크/트래킹 링크)가 띄울 수 있는 화면은 linkingConfig 에 있는 전부이므로
+ * 화면마다 옵션을 붙이지 않고 등록 지점에서 일괄 처리한다 — 새 화면이 추가돼도 자동 적용된다.
+ */
+function withModalPresentation(options: ScreenOptions) {
+  return (props: {route: any; navigation: any}): CustomNavigationOptions => {
+    const resolved = typeof options === 'function' ? options(props) : options;
+    if (!props.route.params?.asModal) {
+      return resolved ?? {};
+    }
+    return {...resolved, presentation: 'fullScreenModal'};
+  };
+}
+
 export const NavigationHeader = ({
   navigation,
   title,
@@ -106,7 +128,7 @@ export const Navigation = () => {
           key={screen.name}
           name={screen.name}
           component={screen.component}
-          options={screen.options}
+          options={withModalPresentation(screen.options)}
         />
       ))}
     </Stack.Navigator>

--- a/src/navigation/withModalPresentation.test.ts
+++ b/src/navigation/withModalPresentation.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from '@jest/globals';
+
+import {withModalPresentation} from './withModalPresentation';
+
+const navigation = {};
+const optionsFor = (
+  params: unknown,
+  options?: Parameters<typeof withModalPresentation>[0],
+) => withModalPresentation(options)({route: {params}, navigation});
+
+describe('withModalPresentation', () => {
+  it('asModal 없으면 기존 options 를 그대로 반환한다 (전 화면 동작 변화 없음)', () => {
+    expect(optionsFor(undefined, {headerShown: false})).toEqual({
+      headerShown: false,
+    });
+    expect(optionsFor({placeListId: 'x'}, {headerShown: false})).toEqual({
+      headerShown: false,
+    });
+  });
+
+  it('options 가 없던 화면도 안전하다', () => {
+    expect(optionsFor(undefined)).toEqual({});
+  });
+
+  it('코드에서 navigate 한 boolean true 는 모달', () => {
+    expect(optionsFor({asModal: true})).toEqual({
+      presentation: 'fullScreenModal',
+    });
+  });
+
+  // 딥링크는 쿼리스트링이라 값이 문자열로 들어온다.
+  it("딥링크의 문자열 'true' 도 모달", () => {
+    expect(optionsFor({asModal: 'true'}, {headerShown: false})).toEqual({
+      headerShown: false,
+      presentation: 'fullScreenModal',
+    });
+  });
+
+  it("문자열 'false' 는 모달이 아니다 (truthy 라서 오탐하기 쉬운 지점)", () => {
+    expect(optionsFor({asModal: 'false'}, {headerShown: false})).toEqual({
+      headerShown: false,
+    });
+  });
+
+  it('함수형 options 도 평가해서 합친다', () => {
+    const options = ({route}: {route: any; navigation: any}) => ({
+      headerTitle: route.params?.title as string,
+    });
+    expect(optionsFor({asModal: true, title: '장소 리스트'}, options)).toEqual({
+      headerTitle: '장소 리스트',
+      presentation: 'fullScreenModal',
+    });
+  });
+});

--- a/src/navigation/withModalPresentation.ts
+++ b/src/navigation/withModalPresentation.ts
@@ -1,0 +1,39 @@
+import {CustomNavigationOptions} from './Navigation.screens';
+
+type ScreenOptions =
+  | CustomNavigationOptions
+  | ((props: {route: any; navigation: any}) => CustomNavigationOptions)
+  | undefined;
+
+/**
+ * `asModal` 로 진입한 화면인지. 값이 들어오는 경로가 둘이라 타입이 두 가지다.
+ * - 코드에서 `navigate('Login', {asModal: true})` → boolean
+ * - 딥링크 쿼리스트링(`stair-crusher://place-group/x?asModal=true`) → 문자열
+ *
+ * 문자열 `'false'` 는 truthy 라 단순 truthy 검사로는 모달이 돼버린다 → 값을 명시 비교한다.
+ */
+function isAsModal(params: unknown): boolean {
+  const asModal = (params as {asModal?: unknown} | undefined)?.asModal;
+  return asModal === true || asModal === 'true';
+}
+
+/**
+ * `asModal` 파라미터로 진입한 화면은 **어떤 화면이든** 네이티브 모달로 띄운다.
+ *
+ * Webview 는 `presentation: 'fullScreenModal'` 이라, 그 위에 기본 push 로 화면을 올리면
+ * iOS 에서 네이티브 모달이 위에 남아 새 화면이 가려진다 → 유저에겐 "눌러도 무반응" 이고,
+ * 그 상태에서 X 를 누르면 가려진 화면이 먼저 pop 돼 **닫기를 두 번** 눌러야 한다.
+ *
+ * 웹뷰 안 링크(딥링크/트래킹 링크)가 띄울 수 있는 화면은 linkingConfig 에 있는 전부이므로
+ * 화면마다 옵션을 붙이지 않고 등록 지점(Navigation.tsx)에서 일괄 적용한다 —
+ * 새 화면이 추가돼도 자동으로 적용된다.
+ */
+export function withModalPresentation(options: ScreenOptions) {
+  return (props: {route: any; navigation: any}): CustomNavigationOptions => {
+    const resolved = typeof options === 'function' ? options(props) : options;
+    if (!isAsModal(props.route?.params)) {
+      return resolved ?? {};
+    }
+    return {...resolved, presentation: 'fullScreenModal'};
+  };
+}

--- a/src/utils/webViewUtils.test.ts
+++ b/src/utils/webViewUtils.test.ts
@@ -87,7 +87,7 @@ describe('스토어 intent 에 실려온 딥링크', () => {
       false,
     );
     // 스토어(market://)를 그냥 삼키면 딥링크까지 사라져 "앱으로 이동" 버튼 페이지만 남는다.
-    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(openURL).toHaveBeenCalledWith(`${DEEP_LINK_URL}&asModal=true`);
     expect(onAppDeepLink).toHaveBeenCalled();
   });
 
@@ -132,15 +132,40 @@ describe('handleWebViewShouldStartLoad — 앱 딥링크', () => {
   it('stair-crusher:// 는 앱에 넘기고 웹뷰에서는 로드하지 않는다', () => {
     const onAppDeepLink = jest.fn();
     expect(shouldLoad(DEEP_LINK_URL, onAppDeepLink)).toBe(false);
-    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(openURL).toHaveBeenCalledWith(`${DEEP_LINK_URL}&asModal=true`);
     expect(onAppDeepLink).toHaveBeenCalled();
+  });
+
+  // 웹뷰는 항상 fullScreenModal 이라, 그 위에 뜨려면 목적지 화면도 모달이어야 한다
+  // (asModal 판단은 Navigation.tsx 의 withModalPresentation — 전 화면 공통).
+  it('쿼리가 없는 딥링크에도 asModal 을 붙인다', () => {
+    expect(shouldLoad('stair-crusher://place-group/x')).toBe(false);
+    expect(openURL).toHaveBeenCalledWith(
+      'stair-crusher://place-group/x?asModal=true',
+    );
+  });
+
+  it('이미 asModal 이 있으면 중복으로 붙이지 않는다', () => {
+    expect(shouldLoad('stair-crusher://place-group/x?asModal=true')).toBe(
+      false,
+    );
+    expect(openURL).toHaveBeenCalledWith(
+      'stair-crusher://place-group/x?asModal=true',
+    );
+  });
+
+  it('fragment 가 있어도 쿼리 위치를 지킨다', () => {
+    expect(shouldLoad('stair-crusher://place/x#section')).toBe(false);
+    expect(openURL).toHaveBeenCalledWith(
+      'stair-crusher://place/x?asModal=true#section',
+    );
   });
 
   it('안드로이드 intent URI 도 스킴을 복원해서 앱에 넘긴다', () => {
     const onAppDeepLink = jest.fn();
     expect(shouldLoad(ANDROID_INTENT_URL, onAppDeepLink)).toBe(false);
     // intent:// 를 그대로 넘기면 RN Linking 이 처리하지 못해 조용히 실패한다.
-    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(openURL).toHaveBeenCalledWith(`${DEEP_LINK_URL}&asModal=true`);
     expect(onAppDeepLink).toHaveBeenCalled();
   });
 });
@@ -184,7 +209,7 @@ describe('handleWebViewOpenWindow', () => {
     const {ref, injectJavaScript} = fakeWebViewRef();
     handleWebViewOpenWindow(ANDROID_INTENT_URL, {webViewRef: ref});
     expect(injectJavaScript).not.toHaveBeenCalled();
-    expect(openURL).toHaveBeenCalledWith(DEEP_LINK_URL);
+    expect(openURL).toHaveBeenCalledWith(`${DEEP_LINK_URL}&asModal=true`);
   });
 });
 
@@ -295,7 +320,7 @@ describe('트래킹 링크 목적지 확인', () => {
       },
     });
     expect(openURL).toHaveBeenCalledWith(
-      'stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc&https_deeplink=true',
+      'stair-crusher://place-group/bbucle-road-gocheok-skydome?airbridge_referrer=abc&https_deeplink=true&asModal=true',
     );
     expect(onAppDeepLink).toHaveBeenCalled();
   });

--- a/src/utils/webViewUtils.test.ts
+++ b/src/utils/webViewUtils.test.ts
@@ -161,6 +161,22 @@ describe('handleWebViewShouldStartLoad — 앱 딥링크', () => {
     );
   });
 
+  it("'#' 가 여러 개인 fragment 도 통째로 보존한다", () => {
+    expect(shouldLoad('stair-crusher://place/x#a#b')).toBe(false);
+    expect(openURL).toHaveBeenCalledWith(
+      'stair-crusher://place/x?asModal=true#a#b',
+    );
+  });
+
+  it('asModal=false 로 push 를 원한 링크는 값을 보존한다', () => {
+    expect(shouldLoad('stair-crusher://place-group/x?asModal=false')).toBe(
+      false,
+    );
+    expect(openURL).toHaveBeenCalledWith(
+      'stair-crusher://place-group/x?asModal=false',
+    );
+  });
+
   it('안드로이드 intent URI 도 스킴을 복원해서 앱에 넘긴다', () => {
     const onAppDeepLink = jest.fn();
     expect(shouldLoad(ANDROID_INTENT_URL, onAppDeepLink)).toBe(false);

--- a/src/utils/webViewUtils.ts
+++ b/src/utils/webViewUtils.ts
@@ -203,12 +203,15 @@ function openExternalUrl(url: string): void {
  * 목적지 화면을 가리지 않는다 — 웹뷰가 띄울 수 있는 모든 화면에 동일하게 적용된다.
  */
 function withAsModalParam(url: string): string {
-  if (/[?&]asModal=/i.test(url)) {
+  // fragment 는 통째로 보존한다 ('#' 가 여러 개일 수 있다).
+  const fragmentIndex = url.indexOf('#');
+  const base = fragmentIndex === -1 ? url : url.slice(0, fragmentIndex);
+  const fragment = fragmentIndex === -1 ? '' : url.slice(fragmentIndex);
+  // 이미 지정돼 있으면 값을 보존한다 (asModal=false 로 push 를 원한 링크도 존중).
+  if (/[?&]asModal=/i.test(base)) {
     return url;
   }
-  const [base, fragment] = url.split('#');
-  const withParam = `${base}${base.includes('?') ? '&' : '?'}asModal=true`;
-  return fragment === undefined ? withParam : `${withParam}#${fragment}`;
+  return `${base}${base.includes('?') ? '&' : '?'}asModal=true${fragment}`;
 }
 
 /**

--- a/src/utils/webViewUtils.ts
+++ b/src/utils/webViewUtils.ts
@@ -196,11 +196,27 @@ function openExternalUrl(url: string): void {
 }
 
 /**
+ * 딥링크에 `asModal` 을 붙인다. 웹뷰(=항상 `presentation: 'fullScreenModal'`)에서 띄우는
+ * 화면은 모달로 표시해야 iOS 에서 웹뷰 모달 위에 올라간다. 안 붙이면 모달 뒤에 깔려
+ * "눌러도 무반응 + 닫기 두 번" 이 된다. 표시 판단은 Navigation.tsx 의 withModalPresentation.
+ *
+ * 목적지 화면을 가리지 않는다 — 웹뷰가 띄울 수 있는 모든 화면에 동일하게 적용된다.
+ */
+function withAsModalParam(url: string): string {
+  if (/[?&]asModal=/i.test(url)) {
+    return url;
+  }
+  const [base, fragment] = url.split('#');
+  const withParam = `${base}${base.includes('?') ? '&' : '?'}asModal=true`;
+  return fragment === undefined ? withParam : `${withParam}#${fragment}`;
+}
+
+/**
  * 앱 딥링크를 OS 딥링크 경로에 넘긴다. RootScreen 의 linking subscribe 가 받아서
  * 현재 웹뷰 위로 해당 화면을 띄운다 (authDeferred 게이트, airbridge trackDeeplink 재사용).
  */
 function handOffToApp(deepLinkUrl: string, opts?: WebViewLoadOptions): void {
-  openExternalUrl(deepLinkUrl);
+  openExternalUrl(withAsModalParam(deepLinkUrl));
   opts?.onAppDeepLink?.();
 }
 


### PR DESCRIPTION
## 문제 (iOS)

#232 로 트래킹 링크 목적지 확인은 동작하는데, iOS 에서 **화면이 웹뷰 아래에 열린다**:
- 트래킹 링크를 눌러도 무반응으로 보인다
- 그 상태에서 웹뷰 X 를 누르면 가려져 있던 화면이 먼저 pop 돼서 **닫기를 두 번** 눌러야 한다

## 원인

`Webview` 는 `presentation: 'fullScreenModal'` 로 등록돼 있다(`Navigation.screens.ts:265`). 그 위에 기본 push 로 화면을 올리면 iOS 에선 네이티브 모달이 위에 남아 새 화면이 가려진다. 딥링크가 띄우는 `PlaceGroupMap` 등에는 `presentation` 이 없었다.

**Login/Signup 에서 이미 같은 버그를 겪고 화면별 `asModal` 옵션으로 고친 패턴이다** (`Navigation.screens.ts:120-142` 주석에 증상까지 그대로 적혀 있다). 안드로이드는 `fullScreenModal` 이 네이티브 모달 윈도우가 아니라 증상이 없었다.

## 수정

웹뷰 안 링크가 띄울 수 있는 화면은 `linkingConfig` 에 있는 **전부**다. 화면마다 옵션을 붙이면 빠지는 화면이 생기므로 **등록 지점 한 곳에서 일괄 처리**한다 — 새 화면이 추가돼도 자동 적용된다.

- `Navigation.tsx`: `withModalPresentation` — `asModal` 파라미터로 진입한 화면은 **어떤 화면이든** 모달로 표시. `asModal` 이 없으면 기존 options 를 그대로 반환해 동작 변화가 없다.
- `webViewUtils`: 웹뷰에서 넘기는 딥링크에 `asModal` 을 붙인다(목적지 화면을 가리지 않음, 중복 방지, fragment 보존).

## 영향 반경

| 화면군 | 수정 전 | 수정 후 |
|---|---|---|
| `asModal` 없는 전 화면 | 기존 options | 기존 options 그대로 (변화 0) |
| Login/Signup `asModal:true` (checkAuth, 웹뷰 로그인 위임) | 화면별 options 로 모달 | 동일 결과 |
| Login `asModal` 없는 진입 (Intro/Main replace, 로그아웃 reset) | push | 기존 push 유지 |
| 웹뷰 딥링크가 띄우는 모든 화면 | iOS 에서 모달 뒤에 깔림 | 모달로 웹뷰 위에 |

## 검증

- 유닛테스트 35개 (asModal 부착/중복 방지/fragment 보존 포함), `yarn tsc --noEmit` / `yarn lint` 0 error
- iOS 실기기 확인은 리포터에게 핸드오프

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App links opened from web content now launch in a full-screen modal presentation when requested.
  * Deep links automatically include the required modal setting while preserving existing parameters and URL fragments.

* **Bug Fixes**
  * Improved handling of app links with existing query parameters, fragments, embedded store links, and Android intents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->