### PR TITLE
fix(articles): CTA 바 피드백 3건 — 하트 테두리·공유 URL·웹뷰 스크롤 관성

### DIFF
--- a/scripts/__tests__/article-cta-bar.test.js
+++ b/scripts/__tests__/article-cta-bar.test.js
@@ -57,13 +57,13 @@ describe('withCampaign', () => {
 });
 
 describe('CTA 바 렌더', () => {
-  test('좋아요 누른 상태는 하트와 테두리가 같은 빨강이다', () => {
+  // 사용자 피드백(2026-08-07): 하트 아이콘만 빨강, 버튼 네모 테두리는 기본 회색 유지.
+  // 테두리까지 빨강이면 버튼이 에러 상태처럼 보인다.
+  test('좋아요 누른 상태는 하트만 빨강이고 테두리는 그대로다', () => {
     const html = article();
-    expect(html).toContain('--red:#db0b24');
-    // aria-pressed 로 테두리 색이 바뀌고, 아이콘 자체도 같은 값이어야 한다
-    expect(html).toContain(
-      '.cta-icon[aria-pressed="true"]{border-color:var(--red);}',
-    );
+    expect(html).not.toContain('aria-pressed="true"]{border-color');
+    // 쓰이지 않는 --red 토큰이 되살아나면(= 테두리 규칙 복귀) 실패한다
+    expect(html).not.toContain('--red:');
     const svg = require('fs').readFileSync(
       require('path').join(
         __dirname,
@@ -137,6 +137,26 @@ describe('CTA 바 렌더', () => {
     expect(article()).toContain(
       "var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG",
     );
+  });
+
+  // 사용자 피드백(2026-08-07): 공유는 그냥 URL 이 아니라 유입 집계가 되는 URL 이어야 한다.
+  // 에어브릿지 트래킹링크는 자기 OG 를 서빙해 카톡 미리보기를 깨므로 canonical+campaign 을 쓴다.
+  test('공유는 campaign 파라미터가 붙은 canonical 을 쓴다', () => {
+    const html = article();
+    const shareUrl = /var SHARE_URL="([^"]+)"/.exec(html)[1];
+    expect(shareUrl).toBe(
+      'https://web.staircrusher.club/articles/test-slug' +
+        '?campaign=articles-share&ad_group=test-slug&ad_creative=cta-share',
+    );
+    // Web Share·클립보드 폴백 **둘 다** SHARE_URL 이어야 한다 (한쪽만 바꾸는 실수 방지)
+    const body = html.slice(html.indexOf("log('article_share'"));
+    expect(body).toContain(
+      'navigator.share({title:document.title,url:SHARE_URL})',
+    );
+    expect(body).toContain('writeText(SHARE_URL)');
+    // 좋아요 target 은 파라미터 없는 canonical 이어야 한다 — 둘을 섞으면 카운터가 갈린다
+    expect(body).not.toContain('writeText(PAGE_URL)');
+    expect(shareUrl).not.toContain('link.staircrusher.club');
   });
 
   test('SPA 로그인 토큰 키에는 절대 쓰지 않는다', () => {

--- a/scripts/article-template.js
+++ b/scripts/article-template.js
@@ -62,12 +62,14 @@ const CTA = {
 };
 
 /**
- * 트래킹링크에 campaign 파라미터를 붙인다.
+ * URL 에 campaign 파라미터를 붙인다.
  * airbridge 링크는 생성 시 campaignParams 를 비워둬야 재사용이 가능하므로(넣으면 URL 파라미터를
  * 덮어써버린다 — make_links.py 실측) 링크별 구분값은 이렇게 호출 시점에 붙인다.
  * **이미 있는 키는 덮어쓰지 않는다** — Notion 에 파라미터가 박힌 URL 이 들어와도 안전하게.
+ *
+ * CTA 버튼(트래킹링크)은 `articles-cta`, 공유하기(아티클 canonical)는 `articles-share` 를 쓴다.
  */
-function withCampaign(url, slug, creative) {
+function withCampaign(url, slug, creative, campaign = 'articles-cta') {
   const hashAt = url.indexOf('#');
   const hash = hashAt >= 0 ? url.slice(hashAt) : '';
   const [base, existing = ''] = (
@@ -77,7 +79,7 @@ function withCampaign(url, slug, creative) {
     existing ? existing.split('&').map(p => p.split('=')[0]) : [],
   );
   const added = [
-    ['campaign', 'articles-cta'],
+    ['campaign', campaign],
     ['ad_group', slug],
     ['ad_creative', creative],
   ]
@@ -107,9 +109,7 @@ const escapeAttr = escapeHtml;
 const BASE_CSS = `
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -241,10 +241,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -416,6 +416,18 @@ const articleJs = slug => `<script>
   var SLUG=${JSON.stringify(slug).replace(/</g, '\\u003c')};
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='${SITE.baseUrl}/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL=${JSON.stringify(
+    withCampaign(
+      `${SITE.baseUrl}/articles/${slug}`,
+      slug,
+      'cta-share',
+      'articles-share',
+    ),
+  ).replace(/</g, '\\u003c')};
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -512,10 +524,10 @@ const articleJs = slug => `<script>
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -408,6 +408,13 @@ const WebViewScreen = ({route, navigation}: ScreenProps<'Webview'>) => {
             return navState.url;
           });
         }}
+        // 스크롤 관성을 iOS 기본값으로 되돌린다 — **New Architecture 에서는 필수다.**
+        // react-native-webview 의 Fabric codegen spec 은 `decelerationRate?: Double` 을
+        // WithDefault 없이 선언해서, 생성된 Props.h 가 `double decelerationRate{0.0}` 이 된다
+        // (ios/build/generated/.../RNCWebViewSpec/Props.h). prop 을 안 넘기면 0 이 그대로
+        // scrollView.decelerationRate 에 박혀 손을 떼는 순간 스크롤이 멈춘다.
+        // 구 아키텍처 경로(RNCWebViewManager.mm)는 nil 일 때 Normal 로 폴백하므로 이 함정이 없다.
+        decelerationRate="normal"
         contentInset={shouldShowFloatingBar ? {bottom: 80} : undefined}
       />
       {shouldShowFloatingBar && (

--- a/web-articles/anguk-station-wheelchair-accessible-cafes/index.html
+++ b/web-articles/anguk-station-wheelchair-accessible-cafes/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="anguk-station-wheelchair-accessible-cafes";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/anguk-station-wheelchair-accessible-cafes?campaign=articles-share&ad_group=anguk-station-wheelchair-accessible-cafes&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/bts-accessible-restaurants-seoul/index.html
+++ b/web-articles/bts-accessible-restaurants-seoul/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="bts-accessible-restaurants-seoul";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/bts-accessible-restaurants-seoul?campaign=articles-share&ad_group=bts-accessible-restaurants-seoul&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/coex-kiaf-art-fair-accessibility/index.html
+++ b/web-articles/coex-kiaf-art-fair-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="coex-kiaf-art-fair-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/coex-kiaf-art-fair-accessibility?campaign=articles-share&ad_group=coex-kiaf-art-fair-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/culinary-class-wars-2-accessible-restaurants/index.html
+++ b/web-articles/culinary-class-wars-2-accessible-restaurants/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="culinary-class-wars-2-accessible-restaurants";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/culinary-class-wars-2-accessible-restaurants?campaign=articles-share&ad_group=culinary-class-wars-2-accessible-restaurants&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/culinary-class-wars-accessible-restaurants/index.html
+++ b/web-articles/culinary-class-wars-accessible-restaurants/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="culinary-class-wars-accessible-restaurants";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/culinary-class-wars-accessible-restaurants?campaign=articles-share&ad_group=culinary-class-wars-accessible-restaurants&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/ddp-magazine-library-accessibility/index.html
+++ b/web-articles/ddp-magazine-library-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="ddp-magazine-library-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/ddp-magazine-library-accessibility?campaign=articles-share&ad_group=ddp-magazine-library-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/diaspora-film-festival-accessibility/incheon-aegwan-theater-accessibility/index.html
+++ b/web-articles/diaspora-film-festival-accessibility/incheon-aegwan-theater-accessibility/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -305,6 +303,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="diaspora-film-festival-accessibility/incheon-aegwan-theater-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/diaspora-film-festival-accessibility/incheon-aegwan-theater-accessibility?campaign=articles-share&ad_group=diaspora-film-festival-accessibility%2Fincheon-aegwan-theater-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -401,10 +404,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/diaspora-film-festival-accessibility/incheon-art-platform-accessibility/index.html
+++ b/web-articles/diaspora-film-festival-accessibility/incheon-art-platform-accessibility/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="diaspora-film-festival-accessibility/incheon-art-platform-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/diaspora-film-festival-accessibility/incheon-art-platform-accessibility?campaign=articles-share&ad_group=diaspora-film-festival-accessibility%2Fincheon-art-platform-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/diaspora-film-festival-accessibility/incheon-hanjung-cultural-center-accessibility/index.html
+++ b/web-articles/diaspora-film-festival-accessibility/incheon-hanjung-cultural-center-accessibility/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="diaspora-film-festival-accessibility/incheon-hanjung-cultural-center-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/diaspora-film-festival-accessibility/incheon-hanjung-cultural-center-accessibility?campaign=articles-share&ad_group=diaspora-film-festival-accessibility%2Fincheon-hanjung-cultural-center-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/diaspora-film-festival-accessibility/index.html
+++ b/web-articles/diaspora-film-festival-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -302,6 +300,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="diaspora-film-festival-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/diaspora-film-festival-accessibility?campaign=articles-share&ad_group=diaspora-film-festival-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -398,10 +401,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/busan-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/busan-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/busan-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/busan-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fbusan-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/daegu-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/daegu-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/daegu-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/daegu-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fdaegu-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/daejeon-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/daejeon-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/daejeon-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/daejeon-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fdaejeon-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/gangwon-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/gangwon-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/gangwon-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/gangwon-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fgangwon-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/gwangju-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/gwangju-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/gwangju-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/gwangju-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fgwangju-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/gyeonggi-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/gyeonggi-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/gyeonggi-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/gyeonggi-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fgyeonggi-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/gyeongju-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/gyeongju-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/gyeongju-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/gyeongju-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fgyeongju-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/incheon-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/incheon-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/incheon-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/incheon-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fincheon-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/index.html
+++ b/web-articles/disabled-call-taxi-guide/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide?campaign=articles-share&ad_group=disabled-call-taxi-guide&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/jeju-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/jeju-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/jeju-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/jeju-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fjeju-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/jeonju-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/jeonju-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/jeonju-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/jeonju-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fjeonju-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/seoul-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/seoul-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/seoul-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/seoul-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fseoul-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/disabled-call-taxi-guide/sokcho-disabled-call-taxi/index.html
+++ b/web-articles/disabled-call-taxi-guide/sokcho-disabled-call-taxi/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="disabled-call-taxi-guide/sokcho-disabled-call-taxi";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/disabled-call-taxi-guide/sokcho-disabled-call-taxi?campaign=articles-share&ad_group=disabled-call-taxi-guide%2Fsokcho-disabled-call-taxi&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/goyang-stadium-accessibility/index.html
+++ b/web-articles/goyang-stadium-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="goyang-stadium-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/goyang-stadium-accessibility?campaign=articles-share&ad_group=goyang-stadium-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/gyeongbokgung-wheelchair-accessible-cafes/index.html
+++ b/web-articles/gyeongbokgung-wheelchair-accessible-cafes/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="gyeongbokgung-wheelchair-accessible-cafes";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/gyeongbokgung-wheelchair-accessible-cafes?campaign=articles-share&ad_group=gyeongbokgung-wheelchair-accessible-cafes&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/haengjusanseong-history-park-accessibility/index.html
+++ b/web-articles/haengjusanseong-history-park-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="haengjusanseong-history-park-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/haengjusanseong-history-park-accessibility?campaign=articles-share&ad_group=haengjusanseong-history-park-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/hwadamsup-forest-accessibility/index.html
+++ b/web-articles/hwadamsup-forest-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="hwadamsup-forest-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/hwadamsup-forest-accessibility?campaign=articles-share&ad_group=hwadamsup-forest-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/jeonbuk-museum-of-art-accessibility/index.html
+++ b/web-articles/jeonbuk-museum-of-art-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="jeonbuk-museum-of-art-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/jeonbuk-museum-of-art-accessibility?campaign=articles-share&ad_group=jeonbuk-museum-of-art-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/kim-young-sam-library-accessibility/index.html
+++ b/web-articles/kim-young-sam-library-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="kim-young-sam-library-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/kim-young-sam-library-accessibility?campaign=articles-share&ad_group=kim-young-sam-library-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/kspo-dome-concert-hall-accessibility/index.html
+++ b/web-articles/kspo-dome-concert-hall-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="kspo-dome-concert-hall-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/kspo-dome-concert-hall-accessibility?campaign=articles-share&ad_group=kspo-dome-concert-hall-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/nationwide-accessible-places/index.html
+++ b/web-articles/nationwide-accessible-places/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -309,6 +307,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="nationwide-accessible-places";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/nationwide-accessible-places?campaign=articles-share&ad_group=nationwide-accessible-places&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -405,10 +408,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/powered-wheelchair-air-travel-guide/index.html
+++ b/web-articles/powered-wheelchair-air-travel-guide/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="powered-wheelchair-air-travel-guide";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/powered-wheelchair-air-travel-guide?campaign=articles-share&ad_group=powered-wheelchair-air-travel-guide&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/seocho-audeum-museum-accessibility/index.html
+++ b/web-articles/seocho-audeum-museum-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="seocho-audeum-museum-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/seocho-audeum-museum-accessibility?campaign=articles-share&ad_group=seocho-audeum-museum-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/seocho-yangjae-library-accessibility/index.html
+++ b/web-articles/seocho-yangjae-library-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="seocho-yangjae-library-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/seocho-yangjae-library-accessibility?campaign=articles-share&ad_group=seocho-yangjae-library-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/seochon-wheelchair-accessible-restaurants-cafes/index.html
+++ b/web-articles/seochon-wheelchair-accessible-restaurants-cafes/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="seochon-wheelchair-accessible-restaurants-cafes";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/seochon-wheelchair-accessible-restaurants-cafes?campaign=articles-share&ad_group=seochon-wheelchair-accessible-restaurants-cafes&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/war-memorial-archive-accessibility/index.html
+++ b/web-articles/war-memorial-archive-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="war-memorial-archive-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/war-memorial-archive-accessibility?campaign=articles-share&ad_group=war-memorial-archive-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/wheelchair-accessible-saved-lists/index.html
+++ b/web-articles/wheelchair-accessible-saved-lists/index.html
@@ -24,9 +24,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -158,10 +156,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -300,6 +298,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="wheelchair-accessible-saved-lists";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/wheelchair-accessible-saved-lists?campaign=articles-share&ad_group=wheelchair-accessible-saved-lists&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -396,10 +399,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/wheelchair-solo-culture-spaces-seoul/index.html
+++ b/web-articles/wheelchair-solo-culture-spaces-seoul/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="wheelchair-solo-culture-spaces-seoul";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/wheelchair-solo-culture-spaces-seoul?campaign=articles-share&ad_group=wheelchair-solo-culture-spaces-seoul&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}

--- a/web-articles/yeonghee-festival-mapo-art-center-accessibility/index.html
+++ b/web-articles/yeonghee-festival-mapo-art-center-accessibility/index.html
@@ -25,9 +25,7 @@
 <style>
 :root{--fg:#2c2c2b;--muted:#787774;--line:#e9e9e7;--soft:#f7f6f3;
 /* 목록/푸터 디자인 토큰 (Figma) */
---g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;
-/* 좋아요 활성 색 — 앱 팔레트 color.red (src/constant/color.ts) */
---red:#db0b24;}
+--g90:#16181c;--g80:#24262b;--g60:#585a64;--g25:#d8d8df;--g15:#f2f2f5;--g10:#f7f8fa;--blue:#0c76f7;}
 *{box-sizing:border-box;}
 [hidden]{display:none!important;}
 html{-webkit-text-size-adjust:100%;}
@@ -159,10 +157,10 @@ details.htoggle[open]>summary::before{content:"▾ ";}
 .cta-inner{max-width:720px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:12px;}
 .cta-icon{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:60px;height:60px;padding:0;appearance:none;-webkit-appearance:none;background:#fff;border:1px solid var(--g25);border-radius:4px;cursor:pointer;}
 .cta-icon img{display:block;width:24px;height:24px;}
-/* 좋아요 누른 상태: 하트와 테두리를 같은 빨강으로 (앱 팔레트 color.red).
-   Figma 에 active 상태 디자인이 없어 디자인시스템 fill variant 기본색(#0C76F7 파랑)을
-   앱 팔레트 red 로 바꿔 쓴다 — ic-heart-fill.svg 의 fill/stroke 도 같은 값이다. */
-.cta-icon[aria-pressed="true"]{border-color:var(--red);}
+/* 좋아요 누른 상태는 **하트 아이콘만** 빨강으로 바뀐다 (ic-heart-fill.svg 의 fill/stroke =
+   #DB0B24, 앱 팔레트 color.red). Figma 에 active 상태가 없어 디자인시스템 fill variant 기본색
+   (#0C76F7 파랑)을 앱 red 로 바꿔 썼다. 버튼 테두리는 눌려도 기본 회색 그대로 둔다 — 테두리까지
+   빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다. (사용자 피드백 2026-08-07) */
 .cta-main{flex:1 1 0;min-width:0;display:none;align-items:center;justify-content:center;gap:6px;height:60px;border-radius:4px;padding:12px 32px;font-family:inherit;font-size:18px;line-height:26px;font-weight:700;letter-spacing:-0.36px;white-space:nowrap;text-decoration:none;overflow:hidden;}
 .cta-main img{display:block;width:52px;height:32px;}
 /* 기본(파라미터 없음/JS 없음) = 플친 가입 CTA. ?from=kakao 면 head 스크립트가 html[data-cta=list] 를 심는다 */
@@ -301,6 +299,11 @@ body.has-cta{padding-bottom:96px;}
   var SLUG="yeonghee-festival-mapo-art-center-accessibility";
   // canonical 을 slug 로 조립한다 — ?from=kakao 나 로컬 서버 주소에 영향받지 않아야 한다.
   var PAGE_URL='https://web.staircrusher.club/articles/'+SLUG;
+  // 공유는 canonical + campaign 파라미터로 내보낸다(GA 유입 집계용). 에어브릿지 트래킹링크를
+  // 쓰지 않는 이유: 링크가 자기 OG 를 직접 서빙해서(302 아님, 실측) 카톡 미리보기가 아티클
+  // 원본이 아니라 링크에 복제해둔 값이 된다 — 제목·썸네일이 바뀌면 그대로 stale 해진다.
+  // PAGE_URL 은 좋아요 target 조회용이라 파라미터가 붙으면 안 되므로 별도 상수로 둔다.
+  var SHARE_URL="https://web.staircrusher.club/articles/yeonghee-festival-mapo-art-center-accessibility?campaign=articles-share&ad_group=yeonghee-festival-mapo-art-center-accessibility&ad_creative=cta-share";
   var upvoted=false, busy=false, spaTokenBad=false;
   function log(name,params){if(typeof gtag==='function'){gtag('event',name,params);}}
   function showToast(msg){
@@ -397,10 +400,10 @@ body.has-cta{padding-bottom:96px;}
   });
   share.addEventListener('click',function(){
     log('article_share',{slug:SLUG});
-    if(navigator.share){navigator.share({title:document.title,url:PAGE_URL}).catch(function(){});return;}
+    if(navigator.share){navigator.share({title:document.title,url:SHARE_URL}).catch(function(){});return;}
     // 안드로이드 WebView 등 Web Share 미지원 → 링크 복사로 폴백
     if(navigator.clipboard&&navigator.clipboard.writeText){
-      navigator.clipboard.writeText(PAGE_URL)
+      navigator.clipboard.writeText(SHARE_URL)
         .then(function(){showToast('링크를 복사했어요');})
         .catch(function(){showToast('링크 복사에 실패했어요');});
     }else{showToast('링크 복사를 지원하지 않는 브라우저예요');}


### PR DESCRIPTION
배포된 CTA 바에 대한 사용자 피드백 3건을 반영한다.

## ① 눌린 하트의 버튼 테두리 빨강 제거

아이콘만 `#DB0B24`로 바뀌고 버튼 네모 테두리는 기본 회색(`--g25`)을 유지한다.
테두리까지 빨강이면 아이콘 강조가 죽고 버튼 자체가 에러 상태처럼 보인다.

`--red` 토큰은 이 규칙이 유일한 소비처였어서 함께 제거했다 (SVG는 hex를 직접 갖고 있다).
테스트를 반대 방향(테두리 규칙·`--red` 재등장 시 실패)으로 교체해 회귀를 막았다.

## ② 공유하기를 campaign 파라미터 붙은 canonical 로

기존에는 파라미터 없는 canonical 을 그대로 공유해 유입이 집계되지 않았다.

```
https://web.staircrusher.club/articles/<slug>
  ?campaign=articles-share&ad_group=<slug>&ad_creative=cta-share
```

**에어브릿지 트래킹링크를 쓰지 않은 이유**: 트래킹링크는 크롤러에게 302가 아니라
**자기 OG 를 200으로 직접 서빙한다**(실측 — `articles_cta_home` 을 카톡 UA로 조회하니
링크에 심어둔 OG가 나오고 `og:image` 는 빈 값이었다). 즉 트래킹링크로 공유하면 카톡
미리보기가 아티클 원본이 아니라 링크에 복제해둔 값이 되고, 제목·썸네일을 바꿀 때마다
stale 해진다. `withCampaign()` 에 `campaign` 인자를 추가해 CTA(`articles-cta`)와
공유(`articles-share`)를 구분한다.

`SHARE_URL` 은 `PAGE_URL` 과 **별도 상수**다 — `PAGE_URL` 은 좋아요 target 조회용이라
파라미터가 붙으면 같은 글의 카운터가 갈린다. Web Share·클립보드 폴백 양쪽 다 `SHARE_URL`
을 쓰는지 테스트로 고정했다.

## ③ 웹뷰 스크롤 관성 복구 (iOS / New Architecture)

앱 웹뷰에서 스크롤이 끈적하고 손을 떼면 관성 없이 곧바로 멈추는 문제.

react-native-webview 의 Fabric codegen spec 이 `decelerationRate?: Double` 을
**`WithDefault` 없이** 선언해서, 생성된 헤더가 `double decelerationRate{0.0}` 이 된다:

```
ios/Pods/Headers/Public/ReactCodegen/.../RNCWebViewSpec/Props.h
  double decelerationRate{0.0}        ← WithDefault 누락
  bool   bounces{true}                ← WithDefault 있음 → 정상 기본값
  bool   directionalLockEnabled{true}
```

`RNCWebView.mm:309` 의 `REMAP_WEBVIEW_PROP(decelerationRate)` 가 이 값을 그대로 받아
`RNCWebViewImpl.m:1027` 에서 `scrollView.decelerationRate = 0` 으로 박는다. 구 아키텍처
경로(`RNCWebViewManager.mm:154`)는 json 이 nil 이면 `UIScrollViewDecelerationRateNormal`
로 폴백하므로 이 함정이 없는데, 이 앱은 `newArchEnabled=true` 라 그 폴백을 타지 않는다.

`decelerationRate="normal"` 을 명시해 JS 레이어가 0.998 로 변환하게 한다.
`PanoramaCanvas` 는 `scrollEnabled={false}` 라 대상이 아니다.

## 배포 표면

- **웹** `web.staircrusher.club` — ①② (아티클 39개 재렌더)
- **sandbox 앱 OTA** — ③ (main push 자동)
- **prod 앱 OTA** — ③ (`v*` 태그)
- 원격 에셋: 이번 라운드 변경 없음

## 검증

- `yarn jest scripts/__tests__` 32 passed
- `yarn tsc --noEmit` / `yarn lint` 0 error
- `--dry` 로 Notion 변경 0건 확인 후 `--force` 재렌더 (템플릿 변경만 반영)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Article sharing now uses campaign-tagged canonical links for Web Share and clipboard fallback.
  - Sharing preserves existing URL parameters while keeping article actions linked to the standard page URL.
  - iOS web views regain native scroll momentum.

- **Bug Fixes**
  - Active like buttons now highlight only the heart icon; borders remain gray.
  - Sharing avoids untracked or unsuitable URLs.

- **Tests**
  - Added coverage for canonical sharing links, campaign parameters, and like-button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->