### PR TITLE
feat(articles): A′ 버킷 5개 글에 저장리스트 CTA 연결

### DIFF
--- a/web-articles/bts-accessible-restaurants-seoul/index.html
+++ b/web-articles/bts-accessible-restaurants-seoul/index.html
@@ -285,7 +285,7 @@ body.has-cta{padding-bottom:96px;}
 <button type="button" class="cta-icon" id="cta-heart" aria-pressed="false" aria-label="도움이 돼요"><img id="cta-heart-off" src="/articles/assets/ic-heart.svg" alt="" width="24" height="24"><img id="cta-heart-on" src="/articles/assets/ic-heart-fill.svg" alt="" width="24" height="24" hidden></button>
 <button type="button" class="cta-icon" id="cta-share" aria-label="공유하기"><img src="/articles/assets/ic-share.svg" alt="" width="24" height="24"></button>
 <a class="cta-main cta-kakao" data-cta-variant="kakao" href="https://link.staircrusher.club/articles_footer_kakao?campaign=articles-cta&amp;ad_group=bts-accessible-restaurants-seoul&amp;ad_creative=cta-kakao" target="_blank" rel="noopener noreferrer"><img src="/articles/assets/cta-kakao-logo.png" alt="" width="52" height="32">새로운 컨텐츠 알림받기</a>
-<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/articles_cta_home?campaign=articles-cta&amp;ad_group=bts-accessible-restaurants-seoul&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">다른 콘텐츠 더 보기</a>
+<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/bts_save?campaign=articles-cta&amp;ad_group=bts-accessible-restaurants-seoul&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">소개된 곳 모아보기</a>
 </div><div class="cta-toast" id="cta-toast" role="status" aria-live="polite"></div></div>
 <script>
 (function(){

--- a/web-articles/culinary-class-wars-2-accessible-restaurants/index.html
+++ b/web-articles/culinary-class-wars-2-accessible-restaurants/index.html
@@ -285,7 +285,7 @@ body.has-cta{padding-bottom:96px;}
 <button type="button" class="cta-icon" id="cta-heart" aria-pressed="false" aria-label="도움이 돼요"><img id="cta-heart-off" src="/articles/assets/ic-heart.svg" alt="" width="24" height="24"><img id="cta-heart-on" src="/articles/assets/ic-heart-fill.svg" alt="" width="24" height="24" hidden></button>
 <button type="button" class="cta-icon" id="cta-share" aria-label="공유하기"><img src="/articles/assets/ic-share.svg" alt="" width="24" height="24"></button>
 <a class="cta-main cta-kakao" data-cta-variant="kakao" href="https://link.staircrusher.club/articles_footer_kakao?campaign=articles-cta&amp;ad_group=culinary-class-wars-2-accessible-restaurants&amp;ad_creative=cta-kakao" target="_blank" rel="noopener noreferrer"><img src="/articles/assets/cta-kakao-logo.png" alt="" width="52" height="32">새로운 컨텐츠 알림받기</a>
-<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/articles_cta_home?campaign=articles-cta&amp;ad_group=culinary-class-wars-2-accessible-restaurants&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">다른 콘텐츠 더 보기</a>
+<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/culinary2_save?campaign=articles-cta&amp;ad_group=culinary-class-wars-2-accessible-restaurants&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">소개된 곳 모아보기</a>
 </div><div class="cta-toast" id="cta-toast" role="status" aria-live="polite"></div></div>
 <script>
 (function(){

--- a/web-articles/culinary-class-wars-accessible-restaurants/index.html
+++ b/web-articles/culinary-class-wars-accessible-restaurants/index.html
@@ -285,7 +285,7 @@ body.has-cta{padding-bottom:96px;}
 <button type="button" class="cta-icon" id="cta-heart" aria-pressed="false" aria-label="도움이 돼요"><img id="cta-heart-off" src="/articles/assets/ic-heart.svg" alt="" width="24" height="24"><img id="cta-heart-on" src="/articles/assets/ic-heart-fill.svg" alt="" width="24" height="24" hidden></button>
 <button type="button" class="cta-icon" id="cta-share" aria-label="공유하기"><img src="/articles/assets/ic-share.svg" alt="" width="24" height="24"></button>
 <a class="cta-main cta-kakao" data-cta-variant="kakao" href="https://link.staircrusher.club/articles_footer_kakao?campaign=articles-cta&amp;ad_group=culinary-class-wars-accessible-restaurants&amp;ad_creative=cta-kakao" target="_blank" rel="noopener noreferrer"><img src="/articles/assets/cta-kakao-logo.png" alt="" width="52" height="32">새로운 컨텐츠 알림받기</a>
-<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/articles_cta_home?campaign=articles-cta&amp;ad_group=culinary-class-wars-accessible-restaurants&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">다른 콘텐츠 더 보기</a>
+<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/culinary1_save?campaign=articles-cta&amp;ad_group=culinary-class-wars-accessible-restaurants&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">소개된 곳 모아보기</a>
 </div><div class="cta-toast" id="cta-toast" role="status" aria-live="polite"></div></div>
 <script>
 (function(){

--- a/web-articles/goyang-stadium-accessibility/index.html
+++ b/web-articles/goyang-stadium-accessibility/index.html
@@ -286,7 +286,7 @@ body.has-cta{padding-bottom:96px;}
 <button type="button" class="cta-icon" id="cta-heart" aria-pressed="false" aria-label="도움이 돼요"><img id="cta-heart-off" src="/articles/assets/ic-heart.svg" alt="" width="24" height="24"><img id="cta-heart-on" src="/articles/assets/ic-heart-fill.svg" alt="" width="24" height="24" hidden></button>
 <button type="button" class="cta-icon" id="cta-share" aria-label="공유하기"><img src="/articles/assets/ic-share.svg" alt="" width="24" height="24"></button>
 <a class="cta-main cta-kakao" data-cta-variant="kakao" href="https://link.staircrusher.club/articles_footer_kakao?campaign=articles-cta&amp;ad_group=goyang-stadium-accessibility&amp;ad_creative=cta-kakao" target="_blank" rel="noopener noreferrer"><img src="/articles/assets/cta-kakao-logo.png" alt="" width="52" height="32">새로운 컨텐츠 알림받기</a>
-<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/articles_cta_home?campaign=articles-cta&amp;ad_group=goyang-stadium-accessibility&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">다른 콘텐츠 더 보기</a>
+<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/goyang_save?campaign=articles-cta&amp;ad_group=goyang-stadium-accessibility&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">소개된 곳 모아보기</a>
 </div><div class="cta-toast" id="cta-toast" role="status" aria-live="polite"></div></div>
 <script>
 (function(){

--- a/web-articles/manifest.json
+++ b/web-articles/manifest.json
@@ -216,8 +216,8 @@
     "categories": [
       "맛집/카페"
     ],
-    "ctaUrl": "",
-    "ctaLabel": "",
+    "ctaUrl": "https://link.staircrusher.club/culinary1_save",
+    "ctaLabel": "소개된 곳 모아보기",
     "thumbnail": "/articles/culinary-class-wars-accessible-restaurants/assets/thumb-0.webp"
   },
   "38fc9499-b060-8176-b32a-e9dcba83b4d3": {
@@ -251,8 +251,8 @@
       "맛집/카페",
       "여행/나들이"
     ],
-    "ctaUrl": "",
-    "ctaLabel": "",
+    "ctaUrl": "https://link.staircrusher.club/nationwide_save",
+    "ctaLabel": "소개된 곳 모아보기",
     "thumbnail": "/articles/nationwide-accessible-places/assets/thumb-0.webp"
   },
   "38fc9499-b060-8186-9aff-dc604dbf1fb4": {
@@ -268,8 +268,8 @@
     "categories": [
       "맛집/카페"
     ],
-    "ctaUrl": "",
-    "ctaLabel": "",
+    "ctaUrl": "https://link.staircrusher.club/bts_save",
+    "ctaLabel": "소개된 곳 모아보기",
     "thumbnail": "/articles/bts-accessible-restaurants-seoul/assets/thumb-0.webp"
   },
   "38fc9499-b060-8117-aabf-fc25f2992e19": {
@@ -285,8 +285,8 @@
     "categories": [
       "맛집/카페"
     ],
-    "ctaUrl": "",
-    "ctaLabel": "",
+    "ctaUrl": "https://link.staircrusher.club/culinary2_save",
+    "ctaLabel": "소개된 곳 모아보기",
     "thumbnail": "/articles/culinary-class-wars-2-accessible-restaurants/assets/thumb-0.webp"
   },
   "38fc9499-b060-8155-aae3-f205c87b9c63": {
@@ -302,8 +302,8 @@
     "categories": [
       "공연/행사"
     ],
-    "ctaUrl": "",
-    "ctaLabel": "",
+    "ctaUrl": "https://link.staircrusher.club/goyang_save",
+    "ctaLabel": "소개된 곳 모아보기",
     "thumbnail": "/articles/goyang-stadium-accessibility/assets/thumb-0.webp"
   },
   "38fc9499-b060-8003-ac61-dd4a92cc31bd": {

--- a/web-articles/nationwide-accessible-places/index.html
+++ b/web-articles/nationwide-accessible-places/index.html
@@ -294,7 +294,7 @@ body.has-cta{padding-bottom:96px;}
 <button type="button" class="cta-icon" id="cta-heart" aria-pressed="false" aria-label="도움이 돼요"><img id="cta-heart-off" src="/articles/assets/ic-heart.svg" alt="" width="24" height="24"><img id="cta-heart-on" src="/articles/assets/ic-heart-fill.svg" alt="" width="24" height="24" hidden></button>
 <button type="button" class="cta-icon" id="cta-share" aria-label="공유하기"><img src="/articles/assets/ic-share.svg" alt="" width="24" height="24"></button>
 <a class="cta-main cta-kakao" data-cta-variant="kakao" href="https://link.staircrusher.club/articles_footer_kakao?campaign=articles-cta&amp;ad_group=nationwide-accessible-places&amp;ad_creative=cta-kakao" target="_blank" rel="noopener noreferrer"><img src="/articles/assets/cta-kakao-logo.png" alt="" width="52" height="32">새로운 컨텐츠 알림받기</a>
-<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/articles_cta_home?campaign=articles-cta&amp;ad_group=nationwide-accessible-places&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">다른 콘텐츠 더 보기</a>
+<a class="cta-main cta-browse" data-cta-variant="browse" href="https://link.staircrusher.club/nationwide_save?campaign=articles-cta&amp;ad_group=nationwide-accessible-places&amp;ad_creative=cta-browse" target="_blank" rel="noopener noreferrer">소개된 곳 모아보기</a>
 </div><div class="cta-toast" id="cta-toast" role="status" aria-live="polite"></div></div>
 <script>
 (function(){


### PR DESCRIPTION
아티클 표에서 소개된 장소를 추출해 prod 저장리스트(LINK_ONLY)를 만들고,
트래킹링크를 Notion ctaUrl/ctaLabel 에 배정했다. 코드 변경은 없고 렌더 산출물만 바뀐다.

| 글 | 저장리스트 | 트래킹링크 | 장소 |
|---|---|---|---|
| bts-accessible-restaurants-seoul | PL_XLzzyZK9 | bts_save | 10/22 |
| culinary-class-wars-accessible-restaurants | PL_T2puMhdm | culinary1_save | 8/10 |
| culinary-class-wars-2-accessible-restaurants | PL_YWoh5zvJ | culinary2_save | 21/46 |
| nationwide-accessible-places | PL_414cFELu | nationwide_save | 21/41 |
| goyang-stadium-accessibility | PL_HcEbJREi | goyang_save | 6/9 |

장소 확정은 /searchPlaces 로 하고 **단일 확정만 채택**했다. 이름 정규화 일치 +
지역 일치 + 통과 후보 유일성을 모두 만족해야 채택하고, 하나라도 어긋나면 버렸다
(전체 136곳 중 채택 70 / AMBIG 37 / 이름·지역 불일치 20 / SCC 미등록 9).
이름 유사도로 밀어붙이면 잘못된 지점이 리스트에 들어가므로 의도적으로 버린 것이다.
예: '명동교자' 는 본점·분점·1호점이 모두 서울 중구 명동10길에 있어 표의
'서울 중구' 만으로는 실사 대상을 특정할 수 없다.

제외한 글:
- wheelchair-solo-culture-spaces-seoul (확정 3/5), diaspora-film-festival-accessibility (1/3)
  → 5곳 미만이면 "소개된 곳 모아보기" 가 글을 오해시킨다. 콘텐츠홈 폴백 유지.
- kspo-dome-concert-hall-accessibility → 표 52행이 올림픽프라자 상가 편의시설
  전수(편의점·떡집·분식)라 큐레이션이 아니다. 범위가 편집 결정이므로 제외.
- wheelchair-accessible-saved-lists → 저장리스트 17개를 소개하는 허브 글이라
  단일 CTA 가 개념적으로 안 맞는다.

검증: 5개 리스트 전부 accessControl=LINK_ONLY, 익명 토큰으로 /getPlaceList 열람 가능,
listPublicPlaceLists 에는 미노출, 트래킹링크 5개 모두 302 → 해당 place-list.
'뜨라또리아샘킴'·'스페샬맥주' 2곳은 어드민이 받았지만 유저 엔드포인트가 걸러내
리스트에는 20곳으로 보인다(서버측 노출 제외 장소).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>