### PR TITLE
chore(articles): --offline + --force 조합 거부 (템플릿 미반영 함정 기계 강제)

### DIFF
--- a/.claude/skills/scc-web-articles-publish/SKILL.md
+++ b/.claude/skills/scc-web-articles-publish/SKILL.md
@@ -146,6 +146,8 @@ NOTION_TOKEN=... node scripts/build-articles.js --db <database_id>
 - `web-articles/{slug}/`(커밋본)과 `web-dist/articles/`(배포용) + 목록/sitemap/robots/llms 동시 갱신.
 - **빌드 후 에셋 유실을 반드시 확인한다** — `git status --porcelain web-articles | grep '^ D'` 가 비어야 커밋한다. 빌드 로그의 `⚠️ 다운로드 실패` / `♻️ 기존 에셋 유지` 도 함께 읽는다. (사고: `--force` 재빌드가 콜아웃 아이콘 2개를 prod 에서 지웠다. 지금은 `reuseExistingAsset` 가 막지만, 새 에셋 경로를 추가하면 이 확인이 유일한 그물이다.)
 - **렌더러/템플릿을 고쳤으면 `--force`(전체) 대신 `--only a,b,c`로 단계적 롤아웃**을 고려한다. 지정 slug만 재생성하고 나머지는 커밋된 HTML 그대로 두므로, 39개 전체를 한 번에 갈아엎지 않고 최근 글부터 검증할 수 있다. (`--only`에 DB에 없는 slug를 주면 경고를 찍는다.)
+- **`--offline` 은 템플릿을 안 탄다**(커밋된 HTML 복사만) → `--force`/`--only` 와의 조합은 스크립트가 거부한다. 템플릿 수정 반영은 로그가 아니라 산출물 grep 으로 판정한다: `grep -rl '<마커>' web-articles/ | wc -l` 이 상세페이지 수와 같아야 한다.
+- **Notion 붙은 빌드 전에 `--dry`**: `신규/변경 0` 이어야 남의 Notion 편집이 함께 발행되지 않는다.
 
 ### STEP 4 — 시각 검증 (E2E)
 ```bash

--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -63,6 +63,18 @@ const ONLY = (arg('only') || '')
 // → yarn web:build가 이걸 돌려, 앱 웹 배포 시에도 web-dist에 /articles가 항상 포함된다
 //   (web-deploy.sh의 `sync --delete`가 /articles를 지우지 않게 하는 구조적 안전장치).
 const OFFLINE = process.argv.includes('--offline');
+// --offline 은 article-template.js 를 호출하지 않고 커밋된 HTML 을 복사만 한다.
+// 따라서 --force/--only(= "템플릿 바꿨으니 다시 렌더해라") 와 조합하면 의미가 상충하고,
+// 성공 로그만 보고 "반영됐다"고 착각하게 된다. 조합 자체를 거부한다.
+// (2026-08-07: `--offline --force` 로 빌드하고 CTA 템플릿 변경이 반영된 줄 알았다)
+if (OFFLINE && (FORCE || ONLY.length) && require.main === module) {
+  console.error(
+    '❌ --offline 은 템플릿을 다시 타지 않습니다(커밋된 HTML 복사만) — ' +
+      `--${FORCE ? 'force' : 'only'} 와 함께 쓸 수 없습니다.\n` +
+      '   템플릿/CSS/인라인JS 를 고쳤다면 NOTION_TOKEN 을 주고 --offline 없이 실행하세요.',
+  );
+  process.exit(1);
+}
 // require.main 가드: 테스트에서 require 할 때 인자 검증으로 process.exit 하면 안 된다.
 if (!OFFLINE && require.main === module) {
   if (!TOKEN) {


### PR DESCRIPTION
--offline 은 article-template.js 를 호출하지 않고 커밋된 HTML 을 web-dist 로
복사만 한다. 그래서 템플릿을 고친 뒤 `--offline --force` 로 빌드하면
`📴 offline 재조립: 39건` 성공 로그가 떠도 변경이 산출물에 하나도 안 들어간다.
로그만 보고 반영됐다고 판단해 재빌드 1회를 통째로 날렸다(2026-08-07).

의미가 상충하는 조합이므로 스크립트가 거부한다 — skill prose 로 남기면
다음 사람이 또 밟는다. `--offline` 단독은 yarn web:build 가 쓰므로 그대로 둔다.

SKILL.md 는 같은 내용을 2줄로 줄였다(가드가 강제하므로 설명만 남긴다).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>