### PR TITLE
feat(search): 자동완성 항목 클릭 = 그 장소 1건 검색

### DIFF
--- a/src/screens/SearchScreen/__tests__/useSearchRequest-pinnedPlace.test.tsx
+++ b/src/screens/SearchScreen/__tests__/useSearchRequest-pinnedPlace.test.tsx
@@ -1,0 +1,97 @@
+import {describe, it, expect, jest, beforeEach} from '@jest/globals';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react-native';
+import {Provider, createStore} from 'jotai';
+import React from 'react';
+
+import {
+  draftCameraRegionAtom,
+  pinnedPlaceAtom,
+  searchQueryAtom,
+  viewStateAtom,
+} from '@/screens/SearchScreen/atoms';
+
+jest.mock('@react-native-community/hooks', () => ({
+  useKeyboard: () => ({keyboardShown: false, keyboardHeight: 0}),
+}));
+
+const mockSearchPlacesPost = jest.fn();
+jest.mock('@/hooks/useAppComponents', () => () => ({
+  api: {searchPlacesPost: mockSearchPlacesPost},
+  toiletApi: {},
+}));
+jest.mock('@/logging/useLogger', () => ({
+  useLogger: () => ({logElementClick: jest.fn()}),
+}));
+jest.mock('@/components/DevTool/useDevTool', () => ({
+  useDevTool: () => ({
+    searchRegion: {trackCircle: jest.fn(), trackRectangle: jest.fn()},
+  }),
+}));
+jest.mock('@/utils/GeolocationUtils', () => ({
+  __esModule: true,
+  default: {getCurrentPosition: jest.fn()},
+}));
+jest.mock('@/utils/ToastUtils', () => ({
+  __esModule: true,
+  default: {show: jest.fn(), showOnApiError: jest.fn()},
+}));
+
+import useSearchRequest from '@/screens/SearchScreen/useSearchRequest';
+
+const PINNED = {
+  place: {
+    id: 'PLC_1',
+    name: '대한냉면 정자점',
+    location: {lat: 37.36, lng: 127.1},
+  },
+} as never;
+
+function renderWithPin(pinned: unknown) {
+  const store = createStore();
+  store.set(draftCameraRegionAtom, null);
+  store.set(searchQueryAtom, {
+    text: '대한냉면 정자점',
+    location: {lat: 37.36, lng: 127.1},
+    radiusMeter: null,
+  });
+  store.set(viewStateAtom, {type: 'map', inputMode: false});
+  store.set(pinnedPlaceAtom, pinned as never);
+
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false, gcTime: 0}},
+  });
+  return renderHook(() => useSearchRequest(), {
+    wrapper: ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>{children}</Provider>
+      </QueryClientProvider>
+    ),
+  });
+}
+
+describe('useSearchRequest - 자동완성에서 고른 장소 고정', () => {
+  beforeEach(() => {
+    mockSearchPlacesPost.mockReset();
+    mockSearchPlacesPost.mockResolvedValue({
+      data: {mode: 'PLACE', items: [{place: {id: 'OTHER'}}]},
+    } as never);
+  });
+
+  it('고정된 장소가 있으면 그 1건만 반환하고 서버에 검색하지 않는다', async () => {
+    const {result} = renderWithPin(PINNED);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual([PINNED]);
+    // 장소명으로 재검색하면 동명 장소가 섞인다 — 그래서 아예 묻지 않는다.
+    expect(mockSearchPlacesPost).not.toHaveBeenCalled();
+  });
+
+  it('고정이 없으면 평소대로 서버 검색을 한다', async () => {
+    const {result} = renderWithPin(null);
+
+    await waitFor(() => expect(mockSearchPlacesPost).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual([{place: {id: 'OTHER'}}]);
+  });
+});

--- a/src/screens/SearchScreen/atoms/index.ts
+++ b/src/screens/SearchScreen/atoms/index.ts
@@ -1,6 +1,7 @@
 import {atom} from 'jotai';
 
 import {Region} from '@/components/maps/Types.tsx';
+import {PlaceListItem} from '@/generated-sources/openapi';
 
 export type SearchMode = 'place' | 'toilet';
 export const searchModeAtom = atom<SearchMode>('place');
@@ -81,3 +82,9 @@ export const toiletLayerActiveAtom = atom(false);
 // 현재 검색 결과가 "주위 다른 OOO 확인하기"(대체 검색)로 얻어진 것인지.
 // true인 동안에는 대체 검색 CTA를 절대 노출하지 않는다 (대체 검색의 대체 검색 방지).
 export const isAlternativeSearchAtom = atom(false);
+
+// 자동완성 목록에서 특정 장소를 선택했을 때 그 장소. 세팅되어 있으면 검색 결과를
+// 이 장소 1건으로 고정한다(서버 재검색 없음) — 장소명으로 다시 검색하면 동명/유사명
+// 장소가 섞여 "내가 고른 그곳"이 아닌 목록이 나온다.
+// 새로운 검색 의도(onQueryUpdate)가 생기면 항상 해제된다.
+export const pinnedPlaceAtom = atom<PlaceListItem | null>(null);

--- a/src/screens/SearchScreen/index.tsx
+++ b/src/screens/SearchScreen/index.tsx
@@ -26,6 +26,7 @@ import {
   filterModalStateAtom,
   isAlternativeSearchAtom,
   isToiletSearchKeyword,
+  pinnedPlaceAtom,
   SearchMode,
   searchModeAtom,
   SearchQuery,
@@ -136,6 +137,7 @@ const SearchScreenContent = ({
   const [isAlternativeSearch, setIsAlternativeSearch] = useAtom(
     isAlternativeSearchAtom,
   );
+  const setPinnedPlace = useSetAtom(pinnedPlaceAtom);
   const {setIsFromLookup} = useSearchScreenContext();
   const tabBarStyle = useTabBarStyle();
 
@@ -148,6 +150,8 @@ const SearchScreenContent = ({
       mode?: SearchMode;
       /** 대체 검색("주위 다른 OOO 확인하기")으로 트리거된 검색인지. */
       isAlternativeSearch?: boolean;
+      /** 자동완성에서 고른 장소. 주면 결과를 그 1건으로 고정한다. */
+      pinnedPlace?: PlaceListItem;
     },
   ) => {
     const shouldRecordHistory = option.shouldRecordHistory ?? false;
@@ -157,6 +161,8 @@ const SearchScreenContent = ({
     if (queryUpdate.text !== undefined) {
       setIsAlternativeSearch(option.isAlternativeSearch ?? false);
     }
+    // 어떤 형태든 새 검색 의도가 생기면 장소 고정은 풀린다("이 지역 재검색" 포함).
+    setPinnedPlace(option.pinnedPlace ?? null);
     const shouldRemainInInputMode = option.shouldRemainInInputMode ?? false;
 
     // 검색어가 화장실 키워드면 어느 경로(타이핑/히스토리/딥링크)든 칩과 동일하게 toilet 모드로.
@@ -197,16 +203,18 @@ const SearchScreenContent = ({
       setOnFetchCompleted(_ => {});
     }
   };
-  const onItemSelect = (item: SearchResultItem) => {
-    setViewState({type: 'map', inputMode: false});
-    Keyboard.dismiss();
-    ref.current?.moveToItem(getItemId(item));
-    if (searchQuery.text) {
-      setSearchHistories(prev => {
-        const newHistories = prev.filter(h => h !== searchQuery.text);
-        return [searchQuery.text!, ...newHistories].slice(0, 10);
-      });
-    }
+  // 자동완성 목록에서 장소를 고른 경우. 입력한 글자("대한냉")가 아니라 **고른 장소의
+  // 이름**이 검색어가 되고(히스토리·검색바 모두), 결과는 그 장소 1건짜리 카드 뷰가 된다.
+  const onItemSelect = (item: PlaceListItem) => {
+    onQueryUpdate(
+      {text: item.place.name},
+      {
+        shouldRecordHistory: true,
+        shouldAnimate: true,
+        mode: 'place',
+        pinnedPlace: item,
+      },
+    );
   };
 
   // 검색 결과에 접근레벨 2 이하 장소가 하나도 없으면(부정경험) 대체 검색을 제안할 수 있다.
@@ -321,6 +329,7 @@ const SearchScreenContent = ({
       setSearchRequestId(null);
       setToiletLayerActive(false);
       setIsAlternativeSearch(false);
+      setPinnedPlace(null);
       resetHighlightAnimation();
     };
   }, []);

--- a/src/screens/SearchScreen/useSearchRequest.tsx
+++ b/src/screens/SearchScreen/useSearchRequest.tsx
@@ -18,6 +18,7 @@ import {
   SortOption,
   draftCameraRegionAtom,
   filterAtom,
+  pinnedPlaceAtom,
   SearchMode,
   searchModeAtom,
   searchQueryAtom,
@@ -59,6 +60,7 @@ export default function useSearchRequest() {
   const {text, location, radiusMeter, useCameraRegion} =
     useAtomValue(searchQueryAtom);
   const searchMode = useAtomValue(searchModeAtom);
+  const pinnedPlace = useAtomValue(pinnedPlaceAtom);
   const draftCameraRegion = useAtomValue(draftCameraRegionAtom);
   const viewState = useAtomValue(viewStateAtom);
   const setSearchRequestId = useSetAtom(searchRequestIdAtom);
@@ -85,11 +87,23 @@ export default function useSearchRequest() {
         hasReview,
         useCameraRegion,
         searchMode,
+        pinnedPlaceId: pinnedPlace?.place.id ?? null,
       },
     ],
     queryFn: async ({signal}): Promise<SearchResult | null> => {
       if (!text) {
         return null; // No search text -> Do not call API because it is landing page
+      }
+
+      // 자동완성에서 고른 장소는 그 1건만 보여준다. 서버에 다시 묻지 않는다 —
+      // 장소명으로 재검색하면 동명/유사명 장소가 섞여 "고른 그곳"이 아닌 목록이 된다.
+      // 검색 이벤트도 남기지 않는다: 서버 검색이 일어나지 않았고, 항목 클릭 자체는
+      // SearchItemSummary 가 이미 로깅한다(직전 검색의 search_request_id 로 조인된다).
+      if (pinnedPlace) {
+        const pinnedResult = [pinnedPlace];
+        onFetchCompleted.current?.(pinnedResult);
+        onFetchCompleted.current = () => {};
+        return {mode: 'place', items: pinnedResult};
       }
       let sort;
       let currentLocation;


### PR DESCRIPTION
## 무엇을

`SearchScreen` 입력 모드의 자동완성 목록에서 장소를 클릭했을 때의 동작을 바꿉니다.

| | 이전 | 이후 |
|---|---|---|
| 검색 히스토리 | 입력하던 글자(`대한냉`) | **고른 장소의 이름**(`대한냉면 정자점`) |
| 검색바 | 입력하던 글자 | **고른 장소의 이름** |
| 결과 화면 | 기존 결과 목록 그대로 + 지도만 해당 마커로 이동 | **그 장소 1건짜리 카드 뷰** |

사용자가 고른 것은 "대한냉"이라는 글자가 아니라 그 장소이므로, 검색어와 결과가 모두 그 장소를 가리키게 합니다.

## 어떻게

`pinnedPlaceAtom` 하나를 추가하고, 세팅되어 있으면 `useSearchRequest` 의 `queryFn` 이 **서버에 묻지 않고** 그 1건을 결과로 돌려줍니다.

장소명으로 서버 재검색을 하지 않는 이유: 동명/유사명 장소가 섞여 "내가 고른 그곳"이 아닌 목록이 나옵니다. 클릭한 객체를 그대로 쓰는 것이 유일하게 정확합니다.

## 갇히지 않는 보장

고정이 안 풀리면 "검색이 안 먹는 화면"이 되므로, 해제를 경로별로 나눠 두지 않고 **`onQueryUpdate` 진입점 한 곳에서 무조건** 풉니다. 호출부 9곳(헤더 타이핑/submit, 카테고리 칩, 히스토리·추천, 대체 검색 CTA, 이 지역 재검색, 딥링크, initKeyword, 뒤로가기) 전부가 이 함수를 지나므로 누락이 구조적으로 불가능합니다. 탭 이탈 시 reset 목록에도 추가했습니다.

## 검증

- `yarn tsc --noEmit` 0, `yarn lint` 0 error, `yarn jest` 120/120
- 신규 테스트 `useSearchRequest-pinnedPlace.test.tsx` 2건 — 고정 시 `searchPlacesPost` 가 **호출되지 않고** 결과가 그 1건인지 / 고정이 없으면 평소대로 서버 검색을 하는지(=mock 이 살아있다는 반증)

## 계측

로깅 호출부 변경 없음. 고정 경로는 서버 검색을 안 하므로 `place_search` 가 발생하지 않는데, **이전에도 항목 클릭은 검색을 트리거하지 않아 이벤트가 없었으므로 변화가 없습니다.** 항목 클릭 자체는 `search_item_summary`(`place_id`/`place_name`)로 계속 남고, 직전 검색의 `search_request_id` 로 조인됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)