### PR TITLE
fix(search): 대체 검색도 검색어 히스토리에 남긴다

### DIFF
--- a/src/screens/SearchScreen/index.tsx
+++ b/src/screens/SearchScreen/index.tsx
@@ -264,7 +264,9 @@ const SearchScreenContent = ({
       },
       {
         shouldAnimate: true,
-        shouldRecordHistory: false,
+        // 버튼으로 트리거됐을 뿐 결과적으로 "한식"을 검색한 것과 같다.
+        // 검색바에도 그 검색어가 남으므로 히스토리에도 남아야 일관된다.
+        shouldRecordHistory: true,
         mode: 'place',
         isAlternativeSearch: true,
       },


### PR DESCRIPTION
"주위 다른 한식 확인하기" CTA 를 누르면 검색바에는 `한식` 이 남는데 최근 검색어에는 안 남아 있었습니다(`shouldRecordHistory: false`).

버튼으로 트리거됐을 뿐 결과적으로 `한식` 을 검색한 것과 같고, 검색바에도 그 검색어가 남으므로 다른 검색 경로와 동일하게 기록합니다.

기록 로직 자체는 기존 `onQueryUpdate` 것을 그대로 씁니다 — 같은 텍스트를 제거한 뒤 맨 앞에 넣고 10개로 자릅니다.

**변화 없는 경로**: "이 지역 재검색"(검색어가 그대로라 이미 히스토리에 있음), 뒤로가기의 빈 검색어, 타이핑 중 프리뷰 검색.

검증: `yarn tsc --noEmit` 0, `yarn lint` 0 error, `yarn jest` 120/120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)