### PR TITLE
fix(search): 필터/정렬을 바꾸면 장소 고정도 함께 풀린다

### DIFF
--- a/src/screens/SearchScreen/__tests__/useSearchRequest-pinnedPlace.test.tsx
+++ b/src/screens/SearchScreen/__tests__/useSearchRequest-pinnedPlace.test.tsx
@@ -102,17 +102,19 @@ describe('useSearchRequest - 자동완성에서 고른 장소 고정', () => {
       store.set(filterAtom, prev => ({...prev, scoreUnder: ScoreUnder.TWO}));
     });
 
-    await waitFor(() => expect(mockSearchPlacesPost).toHaveBeenCalledTimes(1));
+    // 결과가 확정된 뒤에 호출 수를 본다 — 먼저 세면 첫 요청이 시작된 순간 통과해서
+    // 뒤따르는 중복 요청을 놓친다.
     await waitFor(() =>
       expect(result.current.data).toEqual([{place: {id: 'OTHER'}}]),
     );
+    expect(mockSearchPlacesPost).toHaveBeenCalledTimes(1);
   });
 
   it('고정이 없으면 평소대로 서버 검색을 한다', async () => {
     const {result} = renderWithPin(null);
 
-    await waitFor(() => expect(mockSearchPlacesPost).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.data).toEqual([{place: {id: 'OTHER'}}]);
+    expect(mockSearchPlacesPost).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/screens/SearchScreen/__tests__/useSearchRequest-pinnedPlace.test.tsx
+++ b/src/screens/SearchScreen/__tests__/useSearchRequest-pinnedPlace.test.tsx
@@ -1,12 +1,14 @@
 import {describe, it, expect, jest, beforeEach} from '@jest/globals';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {renderHook, waitFor} from '@testing-library/react-native';
+import {act, renderHook, waitFor} from '@testing-library/react-native';
 import {Provider, createStore} from 'jotai';
 import React from 'react';
 
 import {
   draftCameraRegionAtom,
+  filterAtom,
   pinnedPlaceAtom,
+  ScoreUnder,
   searchQueryAtom,
   viewStateAtom,
 } from '@/screens/SearchScreen/atoms';
@@ -61,13 +63,16 @@ function renderWithPin(pinned: unknown) {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false, gcTime: 0}},
   });
-  return renderHook(() => useSearchRequest(), {
-    wrapper: ({children}: {children: React.ReactNode}) => (
-      <QueryClientProvider client={queryClient}>
-        <Provider store={store}>{children}</Provider>
-      </QueryClientProvider>
-    ),
-  });
+  return {
+    store,
+    ...renderHook(() => useSearchRequest(), {
+      wrapper: ({children}: {children: React.ReactNode}) => (
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store}>{children}</Provider>
+        </QueryClientProvider>
+      ),
+    }),
+  };
 }
 
 describe('useSearchRequest - 자동완성에서 고른 장소 고정', () => {
@@ -85,6 +90,22 @@ describe('useSearchRequest - 자동완성에서 고른 장소 고정', () => {
     expect(result.current.data).toEqual([PINNED]);
     // 장소명으로 재검색하면 동명 장소가 섞인다 — 그래서 아예 묻지 않는다.
     expect(mockSearchPlacesPost).not.toHaveBeenCalled();
+  });
+
+  it('필터를 바꾸면 고정이 풀리고 서버 검색을 한다', async () => {
+    // 안 풀리면 "필터를 바꿨는데 결과가 그대로인" 고장 난 화면이 된다.
+    const {result, store} = renderWithPin(PINNED);
+
+    await waitFor(() => expect(result.current.data).toEqual([PINNED]));
+
+    act(() => {
+      store.set(filterAtom, prev => ({...prev, scoreUnder: ScoreUnder.TWO}));
+    });
+
+    await waitFor(() => expect(mockSearchPlacesPost).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(result.current.data).toEqual([{place: {id: 'OTHER'}}]),
+    );
   });
 
   it('고정이 없으면 평소대로 서버 검색을 한다', async () => {

--- a/src/screens/SearchScreen/atoms/index.ts
+++ b/src/screens/SearchScreen/atoms/index.ts
@@ -1,4 +1,5 @@
 import {atom} from 'jotai';
+import type {SetStateAction} from 'react';
 
 import {Region} from '@/components/maps/Types.tsx';
 import {PlaceListItem} from '@/generated-sources/openapi';
@@ -41,13 +42,36 @@ export enum ScoreUnder {
 
 export type FilterType = keyof FilterOptions;
 
-export const filterAtom = atom<FilterOptions>({
+// 자동완성 목록에서 특정 장소를 선택했을 때 그 장소. 세팅되어 있으면 검색 결과를
+// 이 장소 1건으로 고정한다(서버 재검색 없음) — 장소명으로 다시 검색하면 동명/유사명
+// 장소가 섞여 "내가 고른 그곳"이 아닌 목록이 나온다.
+//
+// 해제 조건은 두 가지고, 둘 다 호출부가 아니라 **진입점 한 곳**에서 강제한다:
+//   1. 새로운 검색 의도 → SearchScreen 의 onQueryUpdate (검색 호출부 9곳이 전부 경유)
+//   2. 필터/정렬 변경   → 아래 [filterAtom] 의 writer (setFilter 호출부가 전부 경유)
+export const pinnedPlaceAtom = atom<PlaceListItem | null>(null);
+
+const filterStateAtom = atom<FilterOptions>({
   sortOption: SortOption.LOW_SCORE,
   scoreUnder: null,
   hasSlope: null,
   isRegistered: null,
   hasReview: null,
 });
+
+/**
+ * 검색 필터/정렬. 값이 바뀌면 [pinnedPlaceAtom] 고정도 함께 풀린다 — 고정된 채로는
+ * 결과가 1건 그대로라 "필터가 안 먹는 화면"이 되기 때문이다.
+ * 해제를 setFilter 호출부(필터 모달·프리뷰 칩·추천 칩·대체 검색·초기 정렬)에 맡기면
+ * 반드시 하나가 샌다. 여기 한 곳에서 강제한다.
+ */
+export const filterAtom = atom(
+  get => get(filterStateAtom),
+  (_get, set, update: SetStateAction<FilterOptions>) => {
+    set(filterStateAtom, update);
+    set(pinnedPlaceAtom, null);
+  },
+);
 
 // 기본 상태: Map 탭 진입 시의 empty view (input focus 없음).
 // 검색 바를 눌러 진입할 때는 TextInput onFocus가 inputMode=true로 전환한다.
@@ -82,9 +106,3 @@ export const toiletLayerActiveAtom = atom(false);
 // 현재 검색 결과가 "주위 다른 OOO 확인하기"(대체 검색)로 얻어진 것인지.
 // true인 동안에는 대체 검색 CTA를 절대 노출하지 않는다 (대체 검색의 대체 검색 방지).
 export const isAlternativeSearchAtom = atom(false);
-
-// 자동완성 목록에서 특정 장소를 선택했을 때 그 장소. 세팅되어 있으면 검색 결과를
-// 이 장소 1건으로 고정한다(서버 재검색 없음) — 장소명으로 다시 검색하면 동명/유사명
-// 장소가 섞여 "내가 고른 그곳"이 아닌 목록이 나온다.
-// 새로운 검색 의도(onQueryUpdate)가 생기면 항상 해제된다.
-export const pinnedPlaceAtom = atom<PlaceListItem | null>(null);


### PR DESCRIPTION
자동완성에서 고른 장소로 결과가 1건 고정된 상태에서 필터나 정렬을 바꾸면 결과가 그대로라 **"필터가 안 먹는 화면"** 이 됐습니다.

## 왜 이렇게 고쳤나

해제를 `setFilter` 호출부마다 넣는 방법도 있지만, 호출부가 5곳(필터 모달, 추천 칩, 대체 검색, 초기 정렬, 언마운트 리셋)이고 앞으로 늘어납니다. 하나만 빠져도 같은 증상이 되돌아옵니다.

그래서 `filterAtom` 을 writer 가 있는 atom 으로 바꿔 **쓰기 진입점 한 곳**에서 고정을 풉니다. 검색 쪽 해제를 `onQueryUpdate` 한 곳에 몰아넣은 것과 같은 구조라, 호출부는 아무것도 몰라도 됩니다.

```ts
export const filterAtom = atom(
  get => get(filterStateAtom),
  (_get, set, update: SetStateAction<FilterOptions>) => {
    set(filterStateAtom, update);
    set(pinnedPlaceAtom, null);
  },
);
```

읽기/쓰기 시그니처가 그대로라 `useAtomValue` / `useSetAtom` / `useAtom` 호출부는 한 줄도 안 바뀝니다.

## 검증

- `yarn tsc --noEmit` 0, `yarn lint` 0 error, `yarn jest` 121/121
- 테스트 추가: `필터를 바꾸면 고정이 풀리고 서버 검색을 한다` — 고정 상태에서 `scoreUnder` 를 바꾸면 `searchPlacesPost` 가 호출되고 결과가 고정 1건에서 서버 응답으로 바뀌는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing search filters or sorting now clears any previously pinned autocomplete place.
  * Search results refresh correctly with a single server request after filter changes.
  * Updated results now reflect the server response consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->