### PR TITLE
feat(articles): 템플릿만 고쳤을 때 쓰는 --rerender (Notion 무접속 재렌더)

### DIFF
--- a/.claude/skills/scc-web-articles-publish/SKILL.md
+++ b/.claude/skills/scc-web-articles-publish/SKILL.md
@@ -78,7 +78,7 @@ description: Notion에 작성한 콘텐츠를 web.staircrusher.club/articles 정
     채우는 3버킷 규칙은 STEP 2 참조.
     > **★ 재빌드 함정**: `featured`/`category`와 달리 CTA는 **상세 HTML 안에** 렌더된다. `reassembleDist`는
     > 이미 빌드된 `web-articles/<slug>/index.html`을 그대로 복사하므로, Notion에서 CTA만 고치면 **화면이
-    > 안 바뀐다**. `--only <slug>` 또는 `--force`로 그 글을 다시 렌더해야 한다. (manifest에는 감사용으로
+    > 안 바뀐다**. `--rerender`(캐시 있으면 수초) 또는 `--only <slug>`/`--force`로 그 글을 다시 렌더해야 한다. (manifest에는 감사용으로
     > 매번 동기화되므로, manifest 값과 HTML이 어긋나 있으면 재렌더가 안 된 것이다.)
 - **`published` 프로퍼티 없음** — 발행 여부 = `web-articles/manifest.json`에 존재하는지로 판단.
 
@@ -145,9 +145,16 @@ NOTION_TOKEN=... node scripts/build-articles.js --db <database_id>
 - 변경분만 블록 fetch + 이미지 다운로드(presigned 만료 대응 — 로컬 에셋으로 커밋) + HTML 생성.
 - `web-articles/{slug}/`(커밋본)과 `web-dist/articles/`(배포용) + 목록/sitemap/robots/llms 동시 갱신.
 - **빌드 후 에셋 유실을 반드시 확인한다** — `git status --porcelain web-articles | grep '^ D'` 가 비어야 커밋한다. 빌드 로그의 `⚠️ 다운로드 실패` / `♻️ 기존 에셋 유지` 도 함께 읽는다. (사고: `--force` 재빌드가 콜아웃 아이콘 2개를 prod 에서 지웠다. 지금은 `reuseExistingAsset` 가 막지만, 새 에셋 경로를 추가하면 이 확인이 유일한 그물이다.)
-- **렌더러/템플릿을 고쳤으면 `--force`(전체) 대신 `--only a,b,c`로 단계적 롤아웃**을 고려한다. 지정 slug만 재생성하고 나머지는 커밋된 HTML 그대로 두므로, 39개 전체를 한 번에 갈아엎지 않고 최근 글부터 검증할 수 있다. (`--only`에 DB에 없는 slug를 주면 경고를 찍는다.)
+- **템플릿/CSS/인라인JS만 고쳤으면 `--force`가 아니라 `--rerender`다.** 렌더 입력(Notion 응답·v3 레이아웃·북마크 OG)을 디스크 캐시에서 읽어 **Notion 무접속으로 템플릿만 다시 찍는다** — 실측 42페이지 **1.3초** (`--force`는 20분+). 토큰도 필요 없다. Notion **본문이** 바뀐 게 아니면 `--force`를 쓰지 않는다.
+  ```bash
+  node scripts/build-articles.js --db <id> --rerender    # NOTION_TOKEN 불필요
+  ```
+  - 캐시는 **gitignore**(`.articles-cache/`)다 — **새 클론에서는 `--force` 1회가 선행돼야 한다.** 캐시가 없으면 무엇을 하라고 안내하며 exit 1 한다.
+  - 캐시가 부분적이면 그 slug만 건너뛰고 **커밋본을 그대로 남긴다**(= 템플릿 변경 미반영). 끝에 `⚠️ --rerender 로 다시 찍지 못한 글 N건` + 복구 명령을 찍으므로 **그 경고가 뜨면 반영이 안 끝난 것이다.** 여기서도 판정은 로그가 아니라 산출물 grep으로 한다.
+  - `--offline`과 달리 **템플릿을 탄다.** 둘을 같이 주면 스크립트가 거부한다.
+- **`--force`가 정말 필요할 때만** — 위 `--rerender`가 안 되는 경우(캐시 없음)나 Notion 본문 변경 전체 반영. `--only a,b,c`로 단계적 롤아웃도 여전히 가능하다. (`--only`에 DB에 없는 slug를 주면 경고를 찍는다.)
 - **`--force` 전체 재생성은 20분 넘게 걸린다 → 반드시 `claude-bg`로 띄운다** (`bash ../.claude/hooks/lib/claude-bg.sh bash <script>` — cwd 가 `scc-app/` 이라 `../`). Bash 도구는 foreground/background 모두 10분에 kill 되는데, **중간에 죽으면 트리가 깨진 채로 남는다**: `pruneUnusedAssets`가 썸네일을 지운 뒤 `ensureThumbnails`가 다시 만들기 전 구간에서 끊기면 `assets/thumb-0.webp` 23개가 삭제 상태로 남는다. 복구는 같은 빌드를 끝까지 다시 돌리면 된다(멱등). (2026-08-14 실측)
-- **`--offline` 은 템플릿을 안 탄다**(커밋된 HTML 복사만) → `--force`/`--only` 와의 조합은 스크립트가 거부한다. 템플릿 수정 반영은 로그가 아니라 산출물 grep 으로 판정한다: `grep -rl '<마커>' web-articles/ | wc -l` 이 상세페이지 수와 같아야 한다.
+- **`--offline` 은 템플릿을 안 탄다**(커밋된 HTML 복사만) → `--force`/`--only`/`--rerender` 와의 조합은 스크립트가 거부한다. 템플릿을 태우면서 Notion 을 안 타려면 `--offline` 이 아니라 **`--rerender`** 다. 템플릿 수정 반영은 로그가 아니라 산출물 grep 으로 판정한다: `grep -rl '<마커>' web-articles/ | wc -l` 이 상세페이지 수와 같아야 한다.
 - **`--dry` 보다 `git fetch origin main` 이 먼저다.** 로컬이 뒤처져 있으면 dry-run 이 "신규"라고 찍는 글이 **이미 main·prod 에 나가 있는 글**일 수 있다. 그걸 남의 미발행 원고로 오해해 `--only` 로 빼면, 템플릿 수정이 그 글에만 반영 안 된 채 배포된다(2026-08-13 실제로 그렇게 판단해 7커밋 뒤처진 베이스로 빌드했다). 순서: `git fetch && git status` → 뒤처졌으면 pull → `--dry`.
 - **Notion 붙은 빌드 전에 `--dry`**: `신규/변경 0` 이어야 남의 Notion 편집이 함께 발행되지 않는다.
 

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ web-dist/
 .serena/
 
 .playwright-mcp/
+
+# /scc-web-articles-publish 의 --rerender 용 렌더 입력 캐시 (Notion 응답·v3 레이아웃·북마크 OG).
+# 커밋하지 않는다 — 새 클론에서는 --force 1회가 선행돼야 --rerender 가 동작한다.
+.articles-cache/

--- a/scripts/__tests__/build-articles-cache.test.js
+++ b/scripts/__tests__/build-articles-cache.test.js
@@ -1,0 +1,96 @@
+// --rerender 렌더 입력 캐시. 이 캐시가 조용히 미스를 삼키면 "성공 로그만 보고 반영됐다고
+// 착각"하는 --offline 함정(2026-08-07)이 그대로 재현되므로, **미스가 미스로 잡히는지**를
+// 고정한다. 미스 판정이 무너지면 낡은 HTML 이 배포된다.
+const fs = require('fs');
+
+const {
+  cacheRead,
+  cacheWrite,
+  cacheFile,
+  hasRenderCache,
+  CACHE_DIR,
+  CACHE_V,
+} = require('../build-articles');
+
+// 테스트가 실제 캐시를 오염시키지 않도록 쓰기 전 상태를 기억하고 끝나면 지운다.
+const written = [];
+const put = (kind, key, data) => {
+  written.push(cacheFile(kind, key));
+  cacheWrite(kind, key, data);
+};
+afterAll(() => {
+  for (const f of written) if (fs.existsSync(f)) fs.rmSync(f);
+  // 이 테스트가 캐시 디렉토리를 처음 만든 경우에만 정리한다
+  if (fs.existsSync(CACHE_DIR) && fs.readdirSync(CACHE_DIR).length === 0)
+    fs.rmdirSync(CACHE_DIR);
+});
+
+describe('--rerender 렌더 입력 캐시', () => {
+  test('쓴 값을 그대로 되읽는다', () => {
+    put('api', 'GET test/roundtrip ', {results: [{id: 'a'}]});
+    expect(cacheRead('api', 'GET test/roundtrip ')).toEqual({
+      results: [{id: 'a'}],
+    });
+  });
+
+  test('없는 키는 undefined (null 과 구분된다)', () => {
+    // null 은 "OG 조회했지만 카드 없음"이라는 유효한 캐시값이라 미스와 섞이면 안 된다
+    expect(cacheRead('api', 'GET test/definitely-absent ')).toBeUndefined();
+    put('og', 'https://example.com/no-og', null);
+    expect(cacheRead('og', 'https://example.com/no-og')).toBeNull();
+  });
+
+  test('스키마 버전이 다르면 미스로 취급한다', () => {
+    const f = cacheFile('api', 'GET test/stale-version ');
+    written.push(f);
+    fs.mkdirSync(CACHE_DIR, {recursive: true});
+    fs.writeFileSync(f, JSON.stringify({v: CACHE_V + 1, data: {old: true}}));
+    expect(cacheRead('api', 'GET test/stale-version ')).toBeUndefined();
+  });
+
+  test('깨진 JSON 은 미스로 취급한다 (빌드를 죽이지 않는다)', () => {
+    const f = cacheFile('api', 'GET test/corrupt ');
+    written.push(f);
+    fs.mkdirSync(CACHE_DIR, {recursive: true});
+    fs.writeFileSync(f, '{not json');
+    expect(cacheRead('api', 'GET test/corrupt ')).toBeUndefined();
+  });
+
+  test('kind 가 다르면 키가 충돌하지 않는다', () => {
+    put('api', 'same-key', 'from-api');
+    put('layout', 'same-key', 'from-layout');
+    expect(cacheRead('api', 'same-key')).toBe('from-api');
+    expect(cacheRead('layout', 'same-key')).toBe('from-layout');
+  });
+
+  describe('hasRenderCache — 디렉토리를 건드리기 전 사전 점검', () => {
+    // 왜 사전 점검인가: prepareArticleDir 가 렌더 시작 시 index.html 을 먼저 지운다.
+    // 렌더 도중 미스가 나면 그 페이지가 빈 채로 남으므로, 진입 전에 걸러야 커밋본이 산다.
+    const pid = '00000000-1111-2222-3333-444444444444';
+    const childrenKey = `GET blocks/${pid}/children?page_size=100 `;
+
+    test('둘 다 없으면 false', () => {
+      expect(hasRenderCache(pid)).toBe(false);
+    });
+
+    test('블록만 있고 레이아웃이 없으면 false', () => {
+      put('api', childrenKey, [{id: 'b1', type: 'paragraph'}]);
+      expect(hasRenderCache(pid)).toBe(false);
+    });
+
+    test('블록 + 레이아웃이 모두 있으면 true', () => {
+      put('api', childrenKey, [{id: 'b1', type: 'paragraph'}]);
+      put('layout', pid, {img: {}, db: {}});
+      expect(hasRenderCache(pid)).toBe(true);
+    });
+
+    test('레이아웃이 빈 객체여도(비공개 페이지 폴백) 캐시 히트다', () => {
+      // fetchPageLayout 는 페이지가 비공개면 {img:{},db:{}} 를 준다. 그것도 유효한 입력이라
+      // 미스로 잡히면 --rerender 가 영영 그 글을 건너뛴다.
+      put('api', childrenKey, [{id: 'b1'}]);
+      put('layout', pid, {img: {}, db: {}});
+      expect(cacheRead('layout', pid)).toEqual({img: {}, db: {}});
+      expect(hasRenderCache(pid)).toBe(true);
+    });
+  });
+});

--- a/scripts/build-articles.js
+++ b/scripts/build-articles.js
@@ -19,6 +19,7 @@
  * 사용: NOTION_TOKEN=secret node scripts/build-articles.js --db <database_id> [--dry]
  */
 
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -65,6 +66,9 @@ const ONLY = (arg('only') || '')
 // → yarn web:build가 이걸 돌려, 앱 웹 배포 시에도 web-dist에 /articles가 항상 포함된다
 //   (web-deploy.sh의 `sync --delete`가 /articles를 지우지 않게 하는 구조적 안전장치).
 const OFFLINE = process.argv.includes('--offline');
+// rerender: 템플릿을 다시 타지만 렌더 입력은 디스크 캐시에서만 읽는다(Notion 무접속).
+// 상세 근거는 아래 "렌더 입력 디스크 캐시" 블록 참조.
+const RERENDER = process.argv.includes('--rerender');
 // --offline 은 article-template.js 를 호출하지 않고 커밋된 HTML 을 복사만 한다.
 // 따라서 --force/--only(= "템플릿 바꿨으니 다시 렌더해라") 와 조합하면 의미가 상충하고,
 // 성공 로그만 보고 "반영됐다"고 착각하게 된다. 조합 자체를 거부한다.
@@ -77,11 +81,21 @@ if (OFFLINE && (FORCE || ONLY.length) && require.main === module) {
   );
   process.exit(1);
 }
+// --rerender 는 --offline 과 달리 템플릿을 다시 탄다(= 템플릿 수정 반영됨). 대신 렌더 입력을
+// 디스크 캐시에서만 읽어 Notion 을 안 탄다. 둘을 같이 주면 어느 쪽이 이기는지 불분명하다.
+if (OFFLINE && RERENDER && require.main === module) {
+  console.error(
+    '❌ --offline 과 --rerender 는 함께 쓸 수 없습니다.\n' +
+      '   --offline = 커밋된 HTML 복사만(템플릿 안 탐) / --rerender = 캐시로 템플릿만 재적용.',
+  );
+  process.exit(1);
+}
 // require.main 가드: 테스트에서 require 할 때 인자 검증으로 process.exit 하면 안 된다.
 if (!OFFLINE && require.main === module) {
-  if (!TOKEN) {
+  // --rerender 는 네트워크를 안 타므로 토큰이 필요 없다(--db 는 캐시 키를 만들 때 쓴다).
+  if (!TOKEN && !RERENDER) {
     console.error(
-      '❌ NOTION_TOKEN 환경변수가 필요합니다. (배포용 재조립만이면 --offline)',
+      '❌ NOTION_TOKEN 환경변수가 필요합니다. (배포용 재조립만이면 --offline, 템플릿만 다시 찍으려면 --rerender)',
     );
     process.exit(1);
   }
@@ -115,7 +129,75 @@ async function fetchWithTimeout(url, opts = {}, ms = 25000, tries = 3) {
   }
   throw lastErr;
 }
+// ---------- 렌더 입력 디스크 캐시 (--rerender 용) ----------
+// 왜: 템플릿/CSS/인라인JS 만 고쳐도 예전엔 --force 로 전 페이지 블록을 Notion 에서 다시
+// 받아야 했다(42페이지 20분+, 그동안 외부 OG/썸네일 transient 실패에 그대로 노출).
+// 렌더 입력(공식 API 응답·v3 레이아웃·북마크 OG)을 디스크에 남겨두면 Notion 무접속으로
+// 템플릿만 다시 찍을 수 있다. 캐시 경계를 네트워크 진입점 4곳에 두므로 렌더 코드는 그대로다.
+//
+// 캐시는 **gitignore** 다(2026-08-20 결정) — 레포 용량을 안 쓰는 대신, 새 클론에서는
+// --rerender 전에 --force 가 1회 선행돼야 한다. 캐시가 없으면 조용히 낡은 결과를 내지 않고
+// 그 slug 를 건너뛰고 --force 를 안내한다(--offline 착각 사고 2026-08-07 의 재발 방지).
+const CACHE_DIR = path.join(__dirname, '..', '.articles-cache');
+const CACHE_V = 1; // 렌더 입력 구조가 바뀌면 올려 캐시를 자동 무효화한다
+const cacheMisses = [];
+
+function cacheFile(kind, key) {
+  const h = crypto.createHash('sha1').update(key).digest('hex');
+  return path.join(CACHE_DIR, `${kind}-${h}.json`);
+}
+function cacheRead(kind, key) {
+  const f = cacheFile(kind, key);
+  if (!fs.existsSync(f)) return undefined;
+  try {
+    const j = JSON.parse(fs.readFileSync(f, 'utf8'));
+    return j.v === CACHE_V ? j.data : undefined;
+  } catch {
+    return undefined; // 깨진 캐시는 미스로 취급한다
+  }
+}
+function cacheWrite(kind, key, data) {
+  try {
+    fs.mkdirSync(CACHE_DIR, {recursive: true});
+    fs.writeFileSync(cacheFile(kind, key), JSON.stringify({v: CACHE_V, data}));
+  } catch (e) {
+    // 캐시 실패로 빌드를 죽이지 않는다 — 다음 --rerender 가 미스로 잡아 --force 를 안내한다
+    console.warn(`  ⚠️ 캐시 기록 실패(${kind}): ${e.message}`);
+  }
+}
+// --rerender 에서 캐시에 없는 입력을 만났을 때.
+// 렌더 도중에 터지면 prepareArticleDir 이 이미 index.html 을 지운 상태라 그 페이지가 빈 채로
+// 남는다. 그래서 아래 hasRenderCache 로 **디렉토리를 건드리기 전에** 걸러내고, 그래도 새는
+// 경우(중첩 블록·자식 DB row)는 여기서 치명 처리해 조용한 반쪽 산출물을 만들지 않는다.
+// 복구는 같은 --force 를 끝까지 다시 돌리면 된다(멱등).
+function cacheMiss(kind, key) {
+  const e = new Error(
+    `--rerender: 캐시에 없는 입력 (${kind}: ${key.slice(0, 80)})\n` +
+      `   이 slug 는 캐시가 불완전합니다 — NOTION_TOKEN 을 주고 --force 로 다시 받으세요.`,
+  );
+  e.__cacheMiss = {kind, key};
+  throw e;
+}
+// 사전 점검: 이 페이지의 **최상위** 렌더 입력 2개가 캐시에 있는지. fetchChildren 이 재귀로
+// 전체 트리를 한 번에 받아 캐시하므로, 이 둘이 있으면 본문 블록은 통째로 있다.
+function hasRenderCache(contentPageId) {
+  const childrenKey = `GET blocks/${contentPageId}/children?page_size=100 `;
+  return (
+    cacheRead('api', childrenKey) !== undefined &&
+    cacheRead('layout', contentPageId) !== undefined
+  );
+}
+
 async function api(method, p, body) {
+  const isRead = method === 'GET' || /\/query$/.test(p);
+  const key = `${method} ${p} ${body ? JSON.stringify(body) : ''}`;
+  if (RERENDER) {
+    // 쓰기(publishedAt 스탬프)는 재렌더에서 하지 않는다 — Notion 을 건드리지 않는 모드다
+    if (!isRead) return {};
+    const hit = cacheRead('api', key);
+    if (hit === undefined) cacheMiss('api', key);
+    return hit;
+  }
   const res = await fetchWithTimeout(`https://api.notion.com/v1/${p}`, {
     method,
     headers: H,
@@ -130,6 +212,7 @@ async function api(method, p, body) {
   const j = await res.json();
   if (j && j.object === 'error')
     throw new Error(`Notion ${j.code}: ${j.message}`);
+  if (isRead) cacheWrite('api', key, j);
   return j;
 }
 async function queryDb(dbId) {
@@ -169,6 +252,16 @@ async function fetchChildren(blockId) {
 // 반환: { img: {blockId → {w,ar,align,full}}, db: {dbBlockId → [{name,width}]}(뷰 순서) }
 const v3val = r => r && r.value && (r.value.value || r.value);
 async function fetchPageLayout(pageId) {
+  if (RERENDER) {
+    const hit = cacheRead('layout', pageId);
+    if (hit === undefined) cacheMiss('layout', pageId);
+    return hit;
+  }
+  const out = await fetchPageLayoutUncached(pageId);
+  cacheWrite('layout', pageId, out);
+  return out;
+}
+async function fetchPageLayoutUncached(pageId) {
   const img = {};
   const db = {};
   try {
@@ -393,6 +486,19 @@ const unent = s =>
     .trim();
 async function fetchOg(url) {
   if (OG_CACHE.has(url)) return OG_CACHE.get(url);
+  if (RERENDER) {
+    // OG 는 실패해도 카드가 URL 폴백으로 렌더되므로(정상 경로) 미스를 slug 스킵으로 올리지
+    // 않는다. 단 조용히 폴백하면 커밋된 HTML 에 있던 제목이 URL 로 되돌아갈 수 있으므로
+    // 반드시 경고한다 — 이게 뜨면 그 페이지는 --force 로 받아야 한다.
+    const hit = cacheRead('og', url);
+    if (hit === undefined)
+      console.warn(
+        `  ⚠️ --rerender: OG 캐시 없음(${url}) → 카드가 URL 폴백으로 렌더될 수 있음`,
+      );
+    const card = hit === undefined ? null : hit;
+    OG_CACHE.set(url, card);
+    return card;
+  }
   let card = null;
   try {
     const res = await fetchWithTimeout(
@@ -425,6 +531,7 @@ async function fetchOg(url) {
     console.warn(`  ⚠️ bookmark OG 조회 실패(${url}): ${e.message}`);
   }
   OG_CACHE.set(url, card);
+  cacheWrite('og', url, card);
   return card;
 }
 
@@ -554,6 +661,14 @@ function heifToJpeg(buf) {
 
 async function downloadImage(url, destDir, idx, prefix = 'img') {
   fs.mkdirSync(destDir, {recursive: true});
+  // --rerender 는 네트워크를 타지 않는다 — 커밋된 에셋을 그대로 재사용한다.
+  // (reuseExistingAsset 이 markUsed 까지 하므로 pruneUnusedAssets 가 지우지 않는다.)
+  // 없으면 그 slug 는 캐시가 불완전한 것이므로 --force 로 넘긴다.
+  if (RERENDER) {
+    const kept = reuseExistingAsset(destDir, idx, prefix);
+    if (!kept) cacheMiss('asset', `${prefix}-${idx} @ ${destDir}`);
+    return kept;
+  }
   let res;
   try {
     res = await fetchWithTimeout(url, {}, 30000, 2);
@@ -1682,7 +1797,24 @@ async function main() {
     return;
   }
 
-  console.log('📥 Notion DB 쿼리...');
+  // --rerender 는 캐시가 통째로 없을 때(새 클론 등)가 가장 흔한 실패다. 첫 DB 쿼리에서
+  // raw 스택을 뱉지 말고 무엇을 해야 하는지 알려준다.
+  if (
+    RERENDER &&
+    cacheRead('api', `POST databases/${DB_ID}/query {}`) === undefined
+  ) {
+    console.error(
+      '❌ --rerender: 렌더 입력 캐시가 없습니다.\n' +
+        `   캐시는 gitignore 라(${path.relative(ROOT, CACHE_DIR)}/) 새 클론에는 없습니다.\n` +
+        '   NOTION_TOKEN 을 주고 --force 로 1회 받으면 캐시가 채워지고, 이후 템플릿 수정은\n' +
+        '   --rerender 로 Notion 무접속·수십 초에 끝납니다.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    RERENDER ? '💾 캐시에서 렌더 입력 로드...' : '📥 Notion DB 쿼리...',
+  );
   const allPages = await queryAllPages();
   // [WIP] 글은 파이프라인 진입 전에 걸러낸다. current에서도 빠지므로, 발행된 글에
   // 나중에 [WIP]를 붙이면 삭제 판정에 걸려 prod에서 내려간다.
@@ -1757,7 +1889,8 @@ async function main() {
 
   const changed = rows.filter(r => {
     if (ONLY.length) return ONLY.includes(r.meta.slug);
-    if (FORCE) return true;
+    // --rerender 는 "템플릿이 바뀌었다"는 뜻이므로 --force 와 같이 전 페이지를 다시 찍는다.
+    if (FORCE || RERENDER) return true;
     const prev = manifest[r.meta.rowId];
     return (
       !prev ||
@@ -1863,6 +1996,13 @@ async function main() {
     delete manifest[id];
   }
   for (const {meta, times} of changed) {
+    // --rerender 사전 점검: 캐시가 없으면 **디렉토리를 건드리기 전에** 건너뛴다.
+    // prepareArticleDir 가 index.html 을 먼저 지우므로, 렌더에 들어간 뒤 미스가 나면
+    // 그 페이지가 빈 채로 남는다. 여기서 걸러야 커밋본이 보존된다.
+    if (RERENDER && !hasRenderCache(meta.contentPageId)) {
+      cacheMisses.push(meta.slug);
+      continue;
+    }
     console.log(`  🔧 생성: ${meta.slug}  (${meta.title})`);
     // 이 부모의 기존 상세 페이지 manifest 엔트리 제거 후 재생성(스테일 방지)
     for (const k of Object.keys(manifest))
@@ -1906,6 +2046,17 @@ async function main() {
 
   const published = reassembleDist(manifest);
   console.log(`✅ 완료: 발행 ${published.length}건 → web-dist/articles/`);
+  // 조용히 넘어가면 "성공 로그만 보고 반영됐다고 착각"하는 --offline 함정이 그대로 재현된다.
+  // 스킵된 글은 커밋된 HTML 이 그대로 남아 있어(= 템플릿 변경 미반영) 산출물 grep 이 어긋난다.
+  if (cacheMisses.length) {
+    console.log(
+      `\n⚠️  --rerender 로 다시 찍지 못한 글 ${cacheMisses.length}건 (캐시 없음 — 커밋본 유지됨):\n` +
+        cacheMisses.map(s => `      - ${s}`).join('\n') +
+        `\n   템플릿 변경이 이 글들에는 **반영되지 않았습니다**. 다음 중 하나로 마무리하세요:\n` +
+        `      NOTION_TOKEN=... node scripts/build-articles.js --db <id> --only ${cacheMisses.join(',')}\n` +
+        `      NOTION_TOKEN=... node scripts/build-articles.js --db <id> --force   (전체, 캐시도 새로 채움)`,
+    );
+  }
 }
 
 if (require.main === module) {
@@ -1924,5 +2075,12 @@ if (require.main === module) {
     THUMB_NAME,
     isImage,
     isHeif,
+    // --rerender 캐시 레이어 (scripts/__tests__/build-articles-cache.test.js)
+    cacheRead,
+    cacheWrite,
+    cacheFile,
+    hasRenderCache,
+    CACHE_DIR,
+    CACHE_V,
   };
 }


### PR DESCRIPTION
## 왜

템플릿/CSS/인라인JS 를 고치면 그 코드가 42개 페이지 `<head>` 에 인라인이라 전 페이지를 다시 찍어야 하는데,
그 **유일한 경로가 `--force`** 였습니다. `--force` 는 렌더 입력을 Notion 에서 전부 다시 받으므로:

- 20분+ 소요
- 그 20분 동안 외부 fetch transient 실패에 노출 (오늘 실측: OG 실패 4건 + 403 2건)
- 북마크 카드의 라이브 카운터가 덤으로 흔들려 생성물 diff 에 노이즈가 섞임

정작 필요한 건 **"Notion 은 그대로 두고 템플릿만 다시 적용"** 인데 그 모드가 없었습니다.
(`--offline` 은 커밋된 HTML 을 *복사만* 합니다.)

| 모드 | Notion | 템플릿 재적용 | 실측 |
|---|---|---|---|
| `--force` | 전부 재fetch | ✅ | 20분+ |
| `--offline` | 미접속 | ❌ (복사만) | 수초 |
| **`--rerender`** (신규) | **미접속** | **✅** | **1.3초** |

## 무엇을

렌더 입력을 디스크에 캐시하고, `--rerender` 가 그 캐시만 읽어 템플릿을 다시 태웁니다.
캐시 경계를 **네트워크 진입점 4곳**(공식 API·v3 레이아웃·북마크 OG·이미지)에 두므로 **렌더 코드는 건드리지 않았습니다**.

```bash
node scripts/build-articles.js --db <id> --rerender   # NOTION_TOKEN 불필요
```

캐시는 **gitignore**(`.articles-cache/`) — 레포 용량을 안 쓰는 대신 새 클론에서는 `--force` 1회가 선행돼야 합니다(사용자 결정).

## 조용한 미반영을 만들지 않는 것이 설계 제약

`--offline` 로 빌드하고 템플릿이 반영된 줄 착각한 사고(2026-08-07)와 **같은 함정을 새로 만들지 않는** 것이 이 PR 의 핵심 제약입니다:

- 캐시가 통째로 없으면(새 클론) 첫 DB 쿼리에서 raw 스택 대신 **무엇을 하라고 안내하고 exit 1**
- 캐시가 부분적이면 **디렉토리를 건드리기 전에** `hasRenderCache` 로 걸러 그 slug 를 건너뜁니다.
  `prepareArticleDir` 가 렌더 시작 시 `index.html` 을 **먼저 지우므로**, 렌더에 들어간 뒤 미스가 나면 그 페이지가 빈 채로 남습니다 — 사전 점검이라야 커밋본이 삽니다
- 끝에 **스킵된 slug 목록 + 복구 명령**을 찍습니다. 성공 로그만 보고 "반영됐다"고 읽을 수 없게
- OG 캐시 미스는 slug 스킵까지 가지 않지만(카드가 URL 폴백으로 정상 렌더) **경고는 찍습니다** — 조용히 폴백하면 커밋된 HTML 의 제목이 URL 로 되돌아갑니다
- `--offline` + `--rerender` 조합은 거부

## 검증

**인수 테스트** — 템플릿에 마커를 넣고 `--rerender`:
- 캐시 있는 글에만 마커 반영 (42개 중 2개), 스킵된 25건은 커밋본 유지 + 경고에 이름 표시
- 마커 원복 후 재실행 → 워킹트리 clean 복귀

**그 외**
- 캐시 없이 `--rerender` → 안내 + `exit 1`(파이프 없이 종료코드 직접 확인), 워킹트리 변경 0, `index.html` 42개 온존
- 캐시 채운 뒤 `--rerender` → 산출물이 커밋본과 **바이트 동일** (`git status` 0)
- 신규 테스트 **9건**: 왕복 / `undefined` vs `null` 구분(OG "카드 없음"이 미스로 안 섞이게) / 스키마 버전 불일치·깨진 JSON 은 미스 / kind 간 키 충돌 없음 / `hasRenderCache` 4케이스
- jest **209/209** · lint 0 error · tsc 0 error
  (`App-test.tsx` 스위트 실패는 `pod install` 미링크로 이 브랜치와 무관 — stash 후에도 동일)

## 배포 영향

**없습니다.** 발행 산출물이 바이트 동일함을 확인했으므로 웹 배포·OTA 대상이 아닙니다. 빌드 도구 + 스킬 문서 변경입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)